### PR TITLE
release: v1.8.1 — fix stale "13 skills" refs in README prose

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Complete project lifecycle methodology — 16 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code. Includes quality gates, skill discovery hooks, enforcement hooks (v1.5.0: block incomplete skills and incomplete commits), self-hosted mode, meta-review rubric, and regression fixtures.",
   "author": {
     "name": "HiH-DimaN"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.1] — 2026-04-08
+
+Patch release. Documentation consistency fix. Three stale "13 skills" references in the README body survived the v1.4.0 → v1.5.0 → v1.6.0 → v1.7.0 → v1.8.0 sequence because the badge count was updated but the in-body prose was missed. All badges and tables were already correct at 16; only narrative sentences drifted.
+
+### Fixed
+
+- **`README.md:15`** — `"Installing it registers 13 skills and 5 subagents"` → `"16 skills and 5 subagents"`. Appeared right below the badges, which was especially embarrassing because the adjacent badge already said `Skills: 16`.
+- **`README.md:64`** — installation path comment `"# 13 skill directories"` → `"# 16 skill directories"`.
+- **`README.ru.md:15`** — same as README.md:15, Russian version.
+- **`README.ru.md:64`** — same as README.md:64, Russian version.
+- **`skills/review/references/meta-review-checklist.md:37`** — M-C8 criterion said `"enforced in v1.3.1 for the existing 13 skills"`. Expanded to `"enforced in v1.3.1 for the 13 skills that existed at that time, extended to all 16 skills in v1.4.0+"` — preserves the historical fact but clarifies the current state.
+
+### Not touched
+
+`CHANGELOG.md` still contains "13 skills" references in the `[1.3.1]`, `[1.3.0]`, and `[1.4.0]` entries. Those are historical records — the changelog describes what was true *at that release*, not what is true now. Rewriting history in the changelog would be worse than the original bug.
+
+### How this was caught
+
+The user asked directly: "find all stale `13 skills` mentions in the README and fix them." The meta-review rubric didn't catch this because M-C7 only checks that the README's `Skills: N` badge matches `ls skills/ | wc -l` — it doesn't grep the prose. This is a gap in M-C7.
+
+### Follow-up for a future minor release
+
+Add **M-C12** to the meta-review rubric: "No hardcoded skill-count or agent-count numbers in any README prose outside the Skill Contracts and Recommended Models tables". Implementation: grep every `README*.md` for patterns like `\b\d+\s+(skills?|skill directories?)\b` and cross-check against the actual count from `ls skills/`. Would have caught this class of drift automatically. Deferred to v1.9.0 or later — the immediate fix is priority, the rubric expansion is follow-up.
+
+### Verified before release
+
+- `python3 tests/meta_review.py --verbose` — PASSED (0 Critical, 0 Important)
+- `python3 tests/verify_triggers.py` — 0 drift
+- Manual grep for `13\s+(skill|скилл)` outside CHANGELOG — no matches
+
+---
+
 ## [1.8.0] — 2026-04-08
 
 Minor release. Closes the last deferred item from v1.6.0 (#3 — CI workflow) and adds the missing public-repo infrastructure (CONTRIBUTING, ISSUE_TEMPLATE) that should have existed from day one of the public repo but was postponed as "solo project overhead not justified". The trigger for flipping that decision: **3 GitHub stars within 24 hours of publishing the repo**. That's a traction signal that makes "wait for first PR" the wrong posture — first PRs follow star accumulation by days, not months, and CI is far cheaper to have before the first PR than to retrofit after.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 16](https://img.shields.io/badge/Skills-16-green.svg)](#skills)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#subagents)
-[![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
 
 **[Русская версия (README.ru.md)](README.ru.md)** · **[Changelog](CHANGELOG.md)** · **[Contributing](CONTRIBUTING.md)** · **[CI](docs/CI.md)**
 
-> This repository is a **Claude Code plugin** (see `.claude-plugin/plugin.json`). Installing it registers 13 skills and 5 subagents into your Claude Code environment — it does not run as a standalone CLI.
+> This repository is a **Claude Code plugin** (see `.claude-plugin/plugin.json`). Installing it registers 16 skills and 5 subagents into your Claude Code environment — it does not run as a standalone CLI.
 
 ## Demo
 
@@ -61,7 +61,7 @@ After installation, the skills and agents are registered under:
 
 ```
 ~/.claude/plugins/idea-to-deploy/
-  ├── skills/          # 13 skill directories
+  ├── skills/          # 16 skill directories
   ├── agents/          # 5 subagent definitions
   └── hooks/           # optional enforcement hooks (not auto-installed)
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,14 +5,14 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 16](https://img.shields.io/badge/Skills-16-green.svg)](#скиллы)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#субагенты)
-[![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
 
 **[English version (README.md)](README.md)** · **[Changelog](CHANGELOG.md)** · **[Контрибьютинг](CONTRIBUTING.md)** · **[CI](docs/CI.md)**
 
-> Этот репозиторий — **плагин для Claude Code** (см. `.claude-plugin/plugin.json`). Установка регистрирует 13 скиллов и 5 субагентов в вашем окружении Claude Code — это не самостоятельный CLI.
+> Этот репозиторий — **плагин для Claude Code** (см. `.claude-plugin/plugin.json`). Установка регистрирует 16 скиллов и 5 субагентов в вашем окружении Claude Code — это не самостоятельный CLI.
 
 ## Демо
 
@@ -61,7 +61,7 @@ Claude Code мощный, но без инструкций работает ка
 
 ```
 ~/.claude/plugins/idea-to-deploy/
-  ├── skills/          # 13 папок скиллов
+  ├── skills/          # 16 папок скиллов
   ├── agents/          # 5 определений субагентов
   └── hooks/           # опциональные хуки-энфорсеры (не ставятся автоматически)
 ```

--- a/skills/review/references/meta-review-checklist.md
+++ b/skills/review/references/meta-review-checklist.md
@@ -34,7 +34,7 @@ If any of 1–3 disagree → fail.
 **Criterion:** `Skills: N` badge in both READMEs matches `ls skills/ | wc -l`. `Agents: N` badge matches `ls agents/ | wc -l`. Mismatch → fail.
 
 ### M-C8. Every skill has a Troubleshooting section
-**Criterion:** every `skills/*/SKILL.md` body contains a `## Troubleshooting` heading. This was enforced in v1.3.1 for the existing 13 skills and should hold for all future additions.
+**Criterion:** every `skills/*/SKILL.md` body contains a `## Troubleshooting` heading. This was enforced in v1.3.1 for the 13 skills that existed at that time, extended to all 16 skills in v1.4.0+, and should hold for all future additions.
 
 ### M-C9. No skill file has been Write'n in the current working state without its supporting artifacts on disk
 **Criterion:** git-staged `skills/*/SKILL.md` → matching `references/` (if referenced in body), trigger in hook, fixture in tests/fixtures — all staged OR already committed. This mirrors the `check-commit-completeness.sh` hook logic; the meta-review runs the same check so the state can be audited without committing.


### PR DESCRIPTION
Five stale references in narrative sentences that survived the v1.4.0 -> v1.8.0 sequence because the badges were updated but the adjacent prose was missed. All counts were actually correct at 16 in badges, tables, and call graph — only the explanatory sentences drifted.

Fixed:
- README.md:15  — "registers 13 skills" -> "16 skills" (ironic: right below the "Skills: 16" badge)
- README.md:64  — "# 13 skill directories" -> "# 16 skill directories"
- README.ru.md:15 — same as EN, Russian version
- README.ru.md:64 — same as EN, Russian version
- skills/review/references/meta-review-checklist.md:37 — M-C8 criterion expanded from "enforced in v1.3.1 for the existing 13 skills" to "enforced in v1.3.1 for the 13 skills that existed at that time, extended to all 16 skills in v1.4.0+" — preserves historical fact while clarifying current state.

CHANGELOG historical entries NOT touched — those describe what was true at each release, rewriting them would be worse than the bug.

Changed:
- plugin.json 1.8.0 -> 1.8.1
- README badges bumped

How this was caught: user asked directly. M-C7 only verifies the Skills badge matches ls skills/ | wc -l, does not grep prose. Gap noted in CHANGELOG with proposed M-C12 rubric check for v1.9.0+.

Verified before commit:
- python3 tests/meta_review.py --verbose: PASSED
- python3 tests/verify_triggers.py: 0 drift
- grep "13\s+(skill|скилл)" outside CHANGELOG: no matches