### PR TITLE
release: v1.9.0 — M-C12 prose count drift verifier

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Complete project lifecycle methodology — 16 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code. Includes quality gates, skill discovery hooks, enforcement hooks (v1.5.0: block incomplete skills and incomplete commits), self-hosted mode, meta-review rubric, and regression fixtures.",
   "author": {
     "name": "HiH-DimaN"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.0] — 2026-04-08
+
+Minor release. Adds **M-C12** to the meta-review rubric: structural detection of stale skill-count and agent-count numbers in user-facing documentation prose. Closes the drift class that accumulated silently across v1.4.0 → v1.8.1. The initial M-C12 run caught the last 2 `existing 13` references in Contributing sections that had escaped the v1.8.1 spot-fix.
+
+### Added
+
+- **M-C12 (Critical)** in `skills/review/references/meta-review-checklist.md`: "Skill and agent counts in user-facing prose must match reality." Full binary criterion with scanned/not-scanned file scope, skipped-line rules (tables, headings, historical contexts), pattern definitions (direct count, contextual `existing N`, agent count), and action-on-fail guidance.
+
+- **M-C12 implementation** in `tests/meta_review.py`. Scans `README.md`, `README.ru.md`, `CONTRIBUTING.md`, `hooks/README.md`, `docs/**/*.md`. Deliberately skips `CHANGELOG.md` (historical), `skills/*/SKILL.md` (too many false positives from example counts), and `skills/review/references/*.md` (rubric docs legitimately reference historical counts). Uses three regex patterns with hyphen-guards and heading-skip to suppress false positives.
+
+- **Meta-review Critical tier** grew from 11 to 12 checks.
+
+### Fixed (caught by the initial M-C12 run)
+
+- **`README.md:494`** — `the existing 13` → `the existing 16`. In the Contributing section, explaining that new skills should follow the shape of existing ones. Count was left at 13 since v1.3.x.
+- **`README.ru.md:494`** — same fix, Russian version (`существующих 13` → `существующих 16`).
+
+These two had survived the v1.8.1 cleanup because the author's ad-hoc `grep "13\s+skill"` pattern did not match `existing 13` (word "skill" appeared earlier in the sentence, not after the number). M-C12's Pattern B (`existing N` in skill context) generalizes the check to cover this form.
+
+### Calibration findings during development
+
+Before merging M-C12 into the rubric, its initial runs revealed two classes of false positives that were fixed as part of the same release — **before** the check was merged, so the rubric enters the main branch passing cleanly:
+
+1. **12 false positives on Markdown headings** — e.g., `### Project Creation (3 skills)`, `### Daily Work (6 skills)`, `### Operations (4 skills)`. These are legitimate category subtotals in section headings, not global-count claims in prose. Fix: skip all lines starting with `#`.
+2. **2 false positives on hyphenated qualifiers** — `depth-3 skills` in the Call Graph prose. Regex `\b\d+\s+skills?` matched because `\b` fires between `-` and `3`. Fix: prepend `(?<!\S)` lookbehind so only whitespace-preceded numbers count.
+
+Both fixes are documented inline in `tests/meta_review.py`.
+
+### Changed
+
+- **`plugin.json`** version 1.8.1 → 1.9.0.
+- **Both README badges** bumped.
+
+### Why this is a minor release
+
+M-C12 is a new rubric feature adding a new Critical check. Per the SemVer rules established in `CONTRIBUTING.md`, new rubric checks are minor-version bumps. The 2 prose fixes are cleanup enabled by the new feature, not the feature itself.
+
+### Verified before release
+
+- `python3 tests/meta_review.py --verbose` — PASSED (0 Critical, 0 Important) with M-C12 now active
+- `python3 tests/verify_triggers.py` — 0 drift
+- Initial M-C12 run (pre-calibration) flagged 14 findings; 12 were resolved by the heading/hyphen fixes, 2 were real drift and resolved by the Contributing fixes.
+- Branch protection on `main` rejected direct push (first-class test of the v1.8.0 setup); release went through a proper PR.
+
+### Meta — the rubric is learning faster
+
+The v1.4→v1.9 sequence shows the meta-rubric catching its predecessor's blind spot in each release:
+
+```
+v1.4 Potemkin skills             →  v1.5 spec-noncompliant hooks
+v1.5 Potemkin enforcement        →  v1.6 static hook-schema check (M-C10)
+v1.6 drift in trigger phrases    →  v1.7 trigger drift verifier (M-C11)
+v1.7 no public-repo polish       →  v1.8 CI + CONTRIBUTING + CI badge
+v1.8 drift in prose counts       →  v1.9 prose count verifier (M-C12)
+```
+
+At each step, the lesson comes from how the previous release actually failed, not from top-down design. The rubric now has 12 Critical + 8 Important + 4 Nice-to-have checks covering structural, behavioral, and narrative consistency — a defense surface that is harder to slip past than any single-person review could be.
+
+---
+
 ## [1.8.1] — 2026-04-08
 
 Patch release. Documentation consistency fix. Three stale "13 skills" references in the README body survived the v1.4.0 → v1.5.0 → v1.6.0 → v1.7.0 → v1.8.0 sequence because the badge count was updated but the in-body prose was missed. All badges and tables were already correct at 16; only narrative sentences drifted.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 16](https://img.shields.io/badge/Skills-16-green.svg)](#skills)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#subagents)
-[![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
@@ -491,7 +491,7 @@ Open an issue: [github.com/HiH-DimaN/idea-to-deploy/issues](https://github.com/H
 Contributions are welcome. The project is small enough that process is lightweight:
 
 1. **Report issues / suggest skills** — open a GitHub issue with a concrete scenario and expected behavior.
-2. **Propose a new skill** — skills live under `skills/<name>/SKILL.md` and follow the shape documented in the existing 13. Each needs: frontmatter (name, description, triggers, allowed-tools, recommended model), Instructions, Examples, Troubleshooting.
+2. **Propose a new skill** — skills live under `skills/<name>/SKILL.md` and follow the shape documented in the existing 16. Each needs: frontmatter (name, description, triggers, allowed-tools, recommended model), Instructions, Examples, Troubleshooting.
 3. **Fix a bug or polish a skill** — open a PR against `main`. Run `tests/run-fixtures.sh` locally to sanity-check against fixtures before submitting.
 4. **Improve documentation** — both `README.md` and `README.ru.md` must stay in sync. Updates to one require updates to the other.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 16](https://img.shields.io/badge/Skills-16-green.svg)](#скиллы)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#субагенты)
-[![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
@@ -491,7 +491,7 @@ By design — см. таблицу [Рекомендуемые модели](#р
 Контрибьюции приветствуются. Проект небольшой, поэтому процесс лёгкий:
 
 1. **Сообщить о баге / предложить скилл** — заведите GitHub issue с конкретным сценарием и ожидаемым поведением.
-2. **Предложить новый скилл** — скиллы живут в `skills/<name>/SKILL.md` и следуют форме существующих 13. Нужны: frontmatter (name, description, triggers, allowed-tools, recommended model), Instructions, Examples, Troubleshooting.
+2. **Предложить новый скилл** — скиллы живут в `skills/<name>/SKILL.md` и следуют форме существующих 16. Нужны: frontmatter (name, description, triggers, allowed-tools, recommended model), Instructions, Examples, Troubleshooting.
 3. **Исправить баг или отполировать скилл** — открывайте PR в `main`. Перед отправкой локально прогоните `tests/run-fixtures.sh`.
 4. **Улучшить документацию** — `README.md` и `README.ru.md` должны оставаться синхронными. Правки в одном требуют правок в другом.
 

--- a/skills/review/references/meta-review-checklist.md
+++ b/skills/review/references/meta-review-checklist.md
@@ -129,6 +129,41 @@ If any of 1–3 disagree → fail.
 
 **Why this check exists:** v1.5.0 shipped two hooks — `check-skill-completeness.sh` (PostToolUse with `decision: "block"`, advertised as hard-blocking) and `check-commit-completeness.sh` (PreToolUse with root-level `decision: "deny"`). Both were wrong per Anthropic's spec. Neither was caught by the v1.5.0 meta-review because the rubric checked structural completeness (hook exists, references correct event name), not spec compliance (field paths, exit code semantics per event). v1.6.0 adds M-C10 so the next hook-related mistake cannot repeat the same blind spot.
 
+### M-C12. Skill and agent counts in user-facing prose must match reality
+**Added in v1.9.0 — closes the v1.4.0 → v1.8.1 "stale narrative count" drift class.**
+
+**Criterion (binary, static analysis):** for each user-facing documentation file, scan narrative prose for hardcoded skill-count or agent-count numbers and verify they match `ls skills/ | wc -l` and `ls agents/*.md | wc -l` respectively.
+
+**Scope — scanned files:**
+- `README.md`
+- `README.ru.md`
+- `CONTRIBUTING.md`
+- `hooks/README.md`
+- `docs/**/*.md`
+
+**Scope — deliberately NOT scanned:**
+- `CHANGELOG.md` — historical entries legitimately reference past counts.
+- `skills/*/SKILL.md` — skill bodies mention small numbers in examples that would produce many false positives.
+- `skills/review/references/*.md` — rubric documentation may legitimately reference historical counts for context.
+
+**Skipped lines (even within scanned files):**
+- Markdown table rows (start with `|`) — tables are the authoritative per-row count, not prose.
+- Markdown headings (start with `#`) — headings legitimately list category subtotals like `### Project Creation (3 skills)`.
+- Lines with version markers (`v\d+\.\d+`) or historical phrases (`at that time`, `existed at`, `era`, `legacy`, `initially`, `was enforced`, `изначально`, `тогда существовал`, `на момент`).
+
+**Patterns caught:**
+1. **Direct count:** `\d+ skills?`, `\d+ skill directories`, `\d+ скиллов` — with a hyphen guard `(?<!\S)` to avoid false positives on qualifiers like `depth-3 skills`.
+2. **Contextual count:** `existing N` / `current N` / `существующих N` — only fires when the same line also mentions `skill` / `скилл`. This catches phrases like "the existing 13" that escape pattern 1.
+3. **Direct agent count:** `\d+ agents?`, `\d+ subagents?`, `\d+ агентов`, `\d+ субагентов` — same hyphen guard.
+
+**Failure mode:** every finding is Critical. A prose sentence saying "registers 13 skills" when there are 16 is user-visible wrongness that hurts trust.
+
+**Verification:** implemented inline in `tests/meta_review.py` under the `--- M-C12 ---` block.
+
+**Action on fail:** update the prose to the correct count. Do not work around the check by adding `v\d+\.\d+` version markers to hide drift — that defeats the purpose.
+
+**Why this check exists:** the v1.4.0 → v1.5.0 → v1.6.0 → v1.7.0 → v1.8.0 sequence bumped the skill count from 13 to 16 in badges, tables, the call graph, and the Skill Contracts section — but left 5 narrative sentences saying "13 skills". The user caught the first 3 in v1.8.1 by direct inspection. The remaining 2 (the `existing 13` phrasing in Contributing) escaped because the initial ad-hoc grep pattern only matched `\d+\s+(skill|скилл)`, not `existing \d+`. M-C12 generalizes the check so no future count bump silently drifts narrative prose. Catches the class of bug structurally instead of reactively.
+
 ### M-C11. Every canonical trigger phrase in a `SKILL.md` body routes to the right skill via `hooks/check-skills.sh`
 **Added in v1.7.0 — closes the v1.4.0 drift-class of bug.**
 
@@ -213,7 +248,7 @@ Same as the standard `/review` rubric — tier-by-tier list with ✅/❌/⚠️/
 ### Summary
 | Tier | Pass | Total | Status |
 |---|---|---|---|
-| Critical | 10 | 11 | ❌ BLOCKED |
+| Critical | 11 | 12 | ❌ BLOCKED |
 | Important | 6 | 8 | ⚠️ |
 | Nice-to-have | 3 | 4 | ℹ️ |
 
@@ -225,5 +260,7 @@ Same as the standard `/review` rubric — tier-by-tier list with ✅/❌/⚠️/
 > **v1.6.0 note:** the Critical tier grew from 9 to 10 checks with the addition of M-C10 (hook schema compliance). All 4 hooks in the v1.6.0 methodology repo pass M-C10; the check was validated on the v1.5.1 post-fix state before being merged into the rubric.
 >
 > **v1.7.0 note:** the Critical tier grew from 10 to 11 with the addition of M-C11 (trigger drift). The initial run against v1.6.1 caught 111 drift findings — all fixed as part of the v1.7.0 release before the check was merged into the rubric. v1.7.0 is the first release to pass M-C11 cleanly.
+>
+> **v1.9.0 note:** the Critical tier grew from 11 to 12 with the addition of M-C12 (prose count drift). The initial run against v1.8.1 caught 2 remaining `existing 13` references that had survived the v1.8.1 spot-fix because the user's ad-hoc grep pattern was narrower than M-C12's. Also caught 12 false-positive category-subtotal matches in headings (e.g., `### Project Creation (3 skills)`) and 2 false positives on hyphenated qualifiers (`depth-3 skills`) — both false-positive classes were closed by adding heading-skip and hyphen-guard to the check before merging it into the rubric. v1.9.0 is the first release to pass M-C12 cleanly.
 
 When `check-commit-completeness.sh` is active (recommended in the methodology repo), any Critical failure here will also block the next `git commit` — there is no path to shipping a broken release short of the documented override file.

--- a/tests/meta_review.py
+++ b/tests/meta_review.py
@@ -258,6 +258,127 @@ def run_rubric(repo: Path) -> Report:
     except Exception as e:
         r.imp("M-I7", f"could not load hook module: {e}")
 
+    # --- M-C12: prose skill/agent count consistency (v1.9.0) ---
+    # Scan user-facing documentation prose for hardcoded skill or agent
+    # counts that don't match reality. This catches the class of bug that
+    # accumulated silently across v1.4.0 → v1.8.1: badges and tables were
+    # updated when the count changed, but narrative sentences like
+    # "registers 13 skills" or "the existing 13" drifted unnoticed because
+    # M-C7 only checks the badge against `ls skills/`.
+    #
+    # Scope: README.md, README.ru.md, CONTRIBUTING.md, hooks/README.md,
+    # docs/**/*.md. Deliberately NOT scanned:
+    #   - CHANGELOG.md (historical entries legitimately mention old counts)
+    #   - skills/*/SKILL.md (too many false positives from examples)
+    #   - skills/review/references/*.md (rubric docs legitimately mention
+    #     historical counts for context)
+    #
+    # Skipped lines:
+    #   - Markdown table rows (start with `|`)
+    #   - Lines with version markers (`v1.x.y`) or historical phrases
+    #     ("at that time", "existed", "era", "initially", "before")
+    try:
+        actual_skills_n = len([p for p in (repo / "skills").iterdir() if p.is_dir()])
+        agents_dir = repo / "agents"
+        actual_agents_n = 0
+        if agents_dir.is_dir():
+            actual_agents_n = len(
+                [p for p in agents_dir.iterdir() if p.is_file() and p.suffix == ".md"]
+            )
+
+        doc_paths: list[Path] = [
+            repo / "README.md",
+            repo / "README.ru.md",
+            repo / "CONTRIBUTING.md",
+            repo / "hooks" / "README.md",
+        ]
+        docs_dir = repo / "docs"
+        if docs_dir.is_dir():
+            doc_paths.extend(docs_dir.rglob("*.md"))
+
+        # Pattern A: "N skill(s)", "N скилл(ов)", "N skill directories", etc.
+        # `(?<!\S)` requires the number to be preceded by whitespace or start
+        # of line — prevents false positives on hyphenated qualifiers like
+        # "depth-3 skills" where "3" is part of "depth-3", not a count.
+        skill_direct_re = re.compile(
+            r"(?<!\S)(\d+)\s+(skills?|skill\s+director\w+|скилл\w*|скилл\w*\s+директор\w+|папк\w*\s+скилл\w+)\b",
+            re.IGNORECASE,
+        )
+        # Pattern B: "existing N" / "существующих N" — only counts when the
+        # same line also mentions "skill"/"скилл" (context required).
+        skill_ctx_re = re.compile(
+            r"\b(?:existing|current|last)\s+(\d+)\b|\bсуществующ\w+\s+(\d+)\b",
+            re.IGNORECASE,
+        )
+        # Pattern C: "N agent(s)", "N субагент(ов)", etc. Same hyphen guard.
+        agent_direct_re = re.compile(
+            r"(?<!\S)(\d+)\s+(agents?|subagents?|агент\w*|субагент\w*)\b",
+            re.IGNORECASE,
+        )
+
+        table_line_re = re.compile(r"^\s*\|")
+        heading_line_re = re.compile(r"^\s*#")
+        historical_re = re.compile(
+            r"(v\d+\.\d+|at\s+that\s+time|existed\s+at|era\b|legacy\b|initially\b|"
+            r"was\s+enforced|изначально|тогда\s+существов|на\s+момент)",
+            re.IGNORECASE,
+        )
+        line_mentions_skill_re = re.compile(r"skill|скилл", re.IGNORECASE)
+        line_mentions_agent_re = re.compile(r"agent|агент|субагент", re.IGNORECASE)
+
+        for doc in doc_paths:
+            if not doc.exists():
+                continue
+            rel = doc.relative_to(repo)
+            text = doc.read_text(encoding="utf-8", errors="replace")
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if table_line_re.match(line):
+                    continue
+                if heading_line_re.match(line):
+                    # Markdown headings legitimately list category subtotals
+                    # like "### Project Creation (3 skills)". M-C12 is for
+                    # global-count drift in narrative prose, not for
+                    # category counts in headings.
+                    continue
+                if historical_re.search(line):
+                    continue
+
+                line_has_skill_word = bool(line_mentions_skill_re.search(line))
+                line_has_agent_word = bool(line_mentions_agent_re.search(line))
+
+                # Pattern A — direct skill count
+                for m in skill_direct_re.finditer(line):
+                    n = int(m.group(1))
+                    if n != actual_skills_n:
+                        r.crit(
+                            "M-C12",
+                            f"{rel}:{lineno}: '{m.group(0)}' but actual skill count is {actual_skills_n}",
+                        )
+
+                # Pattern B — contextual "existing N" (requires skill word on the same line)
+                if line_has_skill_word:
+                    for m in skill_ctx_re.finditer(line):
+                        n_str = m.group(1) or m.group(2)
+                        if not n_str:
+                            continue
+                        n = int(n_str)
+                        if n != actual_skills_n:
+                            r.crit(
+                                "M-C12",
+                                f"{rel}:{lineno}: '{m.group(0)}' in skill context but actual is {actual_skills_n}",
+                            )
+
+                # Pattern C — direct agent count
+                for m in agent_direct_re.finditer(line):
+                    n = int(m.group(1))
+                    if n != actual_agents_n:
+                        r.crit(
+                            "M-C12",
+                            f"{rel}:{lineno}: '{m.group(0)}' but actual agent count is {actual_agents_n}",
+                        )
+    except Exception as e:
+        r.imp("M-C12", f"could not run prose-count check: {e}")
+
     # --- M-C11: trigger drift verifier (v1.7.0) ---
     # Delegate to tests/verify_triggers.py via subprocess. Each canonical
     # phrase in every SKILL.md `## Trigger phrases` section must match a


### PR DESCRIPTION
Closes the v1.4.0 → v1.8.1 stale-narrative-count drift class. Adds M-C12 (Critical) to the meta-rubric: structural detection of stale skill-count and agent-count numbers in user-facing prose.

Added:
- M-C12 in meta-review-checklist.md — binary criterion with scanned scope (README.md, README.ru.md, CONTRIBUTING.md, hooks/README.md, docs/**/*.md), skipped-line rules (tables, headings, historical contexts), pattern definitions (direct count, contextual existing N, agent count), action-on-fail guidance.
- M-C12 implementation in tests/meta_review.py. Uses three regex patterns with (?<!\S) hyphen-guards to avoid false positives on "depth-3 skills" and heading-skip to avoid "### Project Creation (3 skills)" category subtotals.
- Meta-review Critical tier: 11 -> 12.

Fixed (caught by initial M-C12 run):
- README.md:494 — "the existing 13" -> "the existing 16" in Contributing section. Survived v1.8.1 spot-fix because ad-hoc grep pattern was narrower than M-C12's contextual pattern.
- README.ru.md:494 — same, Russian version.

Calibration findings (false positives closed before merge):
- 12 heading false positives (category subtotals like "### Daily Work (6 skills)") fixed by skipping lines starting with #.
- 2 hyphen false positives ("depth-3 skills") fixed by adding (?<!\S) lookbehind to the number pattern. Both fixes documented inline in meta_review.py.

Changed:
- plugin.json 1.8.1 -> 1.9.0
- README badges bumped

Verified before commit:
- python3 tests/meta_review.py --verbose: PASSED (0 Crit, 0 Imp) with M-C12 now active
- python3 tests/verify_triggers.py: 0 drift
- Branch protection working: release routed through PR feature branch.

Meta: the v1.4→v1.9 sequence shows the rubric catching each predecessor's blind spot:
  v1.4 Potemkin skills → v1.5 spec-noncompliant hooks
  v1.5 Potemkin enforcement → v1.6 hook-schema check (M-C10)
  v1.6 trigger phrase drift → v1.7 trigger verifier (M-C11)
  v1.7 no public-repo polish → v1.8 CI + CONTRIBUTING + badge
  v1.8 prose count drift → v1.9 prose verifier (M-C12)
Each lesson comes from actual failure, not top-down design.