### PR TITLE
fix: shorten skill descriptions to fit Claude Code Skill tool budget

### DIFF
--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blueprint
-description: 'Generate complete project documentation set (6 files in Full mode, 4 in Lite) — strategic plan, architecture, implementation plan, PRD, README, Claude Code guide. Planning only, no code. TRIGGER when user says "спланируй проект", "подготовь blueprint", "спроектируй", "только планирование без кода". Code generation belongs to /kickstart, not here. See `## Trigger phrases` in body for full list.'
+description: 'Generate project documentation set (strategic plan, architecture, implementation plan, PRD, README, guide). Planning only, no code.'
 argument-hint: project idea or description
 license: MIT
 allowed-tools: Read Write Edit Glob Grep

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: 'Systematically debug an issue — find root cause and fix it. Traces errors through stack traces, logs, git history. TRIGGER when user says "почини баг", "не работает", "ошибка", "крашит", "падает", or pastes any error/stack trace. ALWAYS use this instead of ad-hoc Bash/Read/Grep — even small bugs deserve root-cause analysis. See `## Trigger phrases` in body for full list.'
+description: 'Systematically debug an issue — find root cause and fix it. Traces errors through stack traces, logs, git history.'
 argument-hint: error message, symptom, or issue description
 license: MIT
 allowed-tools: Read Edit Glob Grep Bash

--- a/skills/deps-audit/SKILL.md
+++ b/skills/deps-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deps-audit
-description: 'Audit third-party dependencies for known CVEs, license issues, and abandoned packages. Read-only report with Critical/Important/Recommended/Informational tiers. TRIGGER when user says "проверь зависимости", "dependency audit", "найди уязвимые пакеты", "lockfile audit", "проверь лицензии", "check dependencies", "supply chain audit". See `## Trigger phrases` in body for full list.'
+description: 'Audit third-party dependencies for known CVEs, license issues, and abandoned packages. Read-only report with severity tiers.'
 argument-hint: manifest file, directory, or "all" for full project
 license: MIT
 allowed-tools: Read Glob Grep Bash(npm:*) Bash(pip:*) Bash(cargo:*) Bash(go:*)

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc
-description: 'Generate documentation — README, API docs, inline comments. Detects project style and follows existing conventions. TRIGGER when user says "напиши документацию", "создай README", "задокументируй API", "добавь комментарии", or when creating/updating public APIs. Docs are part of "done". See `## Trigger phrases` in body for full list.'
+description: 'Generate documentation — README, API docs, inline comments. Detects project style and follows existing conventions.'
 argument-hint: file, module, or "readme" or "api"
 license: MIT
 allowed-tools: Read Write Edit Glob Grep

--- a/skills/explain/SKILL.md
+++ b/skills/explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explain
-description: 'Explain how code works — architecture, data flow, key decisions. Uses ASCII diagrams and step-by-step walkthroughs. TRIGGER when user says "объясни код", "как это работает", "что делает эта функция", "explain this", or asks any question about how existing code works. For multi-file exploration, use this rather than reading files manually. See `## Trigger phrases` in body for full list.'
+description: 'Explain how code works — architecture, data flow, key decisions. Uses ASCII diagrams and step-by-step walkthroughs.'
 argument-hint: file, function, module, or concept
 license: MIT
 allowed-tools: Read Glob Grep

--- a/skills/guide/SKILL.md
+++ b/skills/guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: guide
-description: 'Generate a CLAUDE_CODE_GUIDE.md — step-by-step copy-paste prompts for building the project from scratch via Claude Code. TRIGGER when user says "создай гайд", "сгенерируй промпты для проекта", "cookbook промптов". Assumes architecture/PRD already exist. See `## Trigger phrases` in body for full list.'
+description: 'Generate CLAUDE_CODE_GUIDE.md — step-by-step copy-paste prompts for building the project via Claude Code.'
 argument-hint: project name or description
 license: MIT
 allowed-tools: Read Write Edit Glob Grep

--- a/skills/harden/SKILL.md
+++ b/skills/harden/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harden
-description: 'Production-readiness hardening checklist — health checks, graceful shutdown, rate limiting, structured logging, monitoring (Prometheus/Grafana), backup strategy, secrets, load test scaffolding, SRE runbook. Binary rubric. TRIGGER when user says "подготовь к продакшену", "production readiness", "harden", "hardening", "готов ли прод", "SRE checklist", "load test setup". See `## Trigger phrases` in body for full list.'
+description: 'Production-readiness hardening — health checks, graceful shutdown, rate limiting, logging, monitoring, backups, secrets, SRE runbook.'
 argument-hint: service name, directory, or "all" for full project
 license: MIT
 allowed-tools: Read Write Edit Glob Grep Bash(docker:*) Bash(curl:*) Bash(k6:*)

--- a/skills/infra/SKILL.md
+++ b/skills/infra/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: infra
-description: 'Generate infrastructure-as-code — Terraform modules, Kubernetes manifests, Helm charts, secrets management wiring (Vault/AWS Secrets Manager/Doppler). Supports DigitalOcean, AWS, Hetzner, bare-metal K8s. TRIGGER when user says "настрой инфраструктуру", "terraform", "helm chart", "k8s manifests", "generate IaC", "infra as code", "настрой vault", "provision servers". See `## Trigger phrases` in body for full list.'
+description: 'Generate infrastructure-as-code — Terraform, Kubernetes, Helm, secrets management. Supports DigitalOcean, AWS, Hetzner.'
 argument-hint: stack type (fastapi-pg-redis, node-pg, static-frontend) + target (do/aws/hetzner/k8s)
 license: MIT
 allowed-tools: Read Write Edit Glob Grep Bash(terraform:*) Bash(helm:*) Bash(kubectl:*)

--- a/skills/kickstart/SKILL.md
+++ b/skills/kickstart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kickstart
-description: 'Generate a complete project from idea — architecture, plans, docs, code, tests, deploy. Full lifecycle, one shot. TRIGGER when user says "создай проект", "новый проект", "запили проект целиком", "от идеи до деплоя". Usually invoked via /project router. See `## Trigger phrases` in body for full list.'
+description: 'Generate a complete project from idea — architecture, plans, docs, code, tests, deploy. Full lifecycle in one shot.'
 argument-hint: project idea or description
 disable-model-invocation: true
 allowed-tools: "Read Write Edit Glob Grep Bash(git:*) Bash(mkdir:*) Bash(npm:*) Bash(pnpm:*) Bash(docker:*) Bash(pytest:*) Bash(go:*) Bash(cargo:*)"

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrate
-description: 'Safely apply a database migration — backup, apply, verify, rollback path. TRIGGER when user says "накати миграцию", "migrate", "apply migration", "ALTER TABLE", "обнови схему БД", "rollback migration", or before any DDL on production. Refuses on prod without explicit confirmation. See `## Trigger phrases` in body for full list.'
+description: 'Safely apply a database migration — backup, apply, verify, rollback path. Refuses on prod without explicit confirmation.'
 argument-hint: migration file path, "next", or SQL statement
 license: MIT
 allowed-tools: Read Glob Grep Bash(psql:*) Bash(sqlite3:*) Bash(mysql:*) Bash(pg_dump:*) Bash(docker:*)

--- a/skills/perf/SKILL.md
+++ b/skills/perf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perf
-description: 'Performance analysis — find bottlenecks and optimize. Covers algorithms, DB queries, memory, I/O, caching. TRIGGER when user says "тормозит", "медленно работает", "оптимизируй", "производительность", or reports slow page loads / high latency / memory issues. Measure first, optimize second. See `## Trigger phrases` in body for full list.'
+description: 'Performance analysis — find bottlenecks and optimize. Covers algorithms, DB queries, memory, I/O, caching. Measure first, optimize second.'
 argument-hint: file, function, or area to analyze
 license: MIT
 allowed-tools: Read Edit Glob Grep Bash

--- a/skills/project/SKILL.md
+++ b/skills/project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project
-description: 'Smart project creation router — single entry point for all "new project from scratch" scenarios. Asks one question and routes to /kickstart, /blueprint, or /guide. TRIGGER when user says "хочу проект", "новый проект", "создай проект". ALWAYS prefer this router over jumping into code or invoking /kickstart directly. See `## Trigger phrases` in body for the full list.'
+description: 'Smart project creation router — routes to /kickstart, /blueprint, or /guide based on user scenario.'
 argument-hint: project idea or description
 license: MIT
 allowed-tools: Read

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: 'Refactor code for readability and maintainability while preserving behavior. Uses Fowler-style catalog (Extract Function, Replace Conditional with Polymorphism, etc.). TRIGGER when user says "отрефактори", "упрости код", "перепиши понятнее", "refactor this", or when code has deep nesting/duplication/long functions. No feature changes. See `## Trigger phrases` in body for full list.'
+description: 'Refactor code for readability and maintainability while preserving behavior. Fowler-style catalog. No feature changes.'
 argument-hint: file, function, or area to refactor
 license: MIT
 allowed-tools: Read Edit Glob Grep Bash

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: 'Validate quality of project documentation and code via deterministic binary rubric. Checks consistency between PRD, architecture, plan, and code. TRIGGER when user says "проверь документацию", "проверь код", "ревью", "review project", or before any commit touching more than 2 files. Returns BLOCKED / PASSED_WITH_WARNINGS / PASSED. See `## Trigger phrases` in body for full list.'
+description: 'Validate project documentation and code via binary rubric. Checks consistency between PRD, architecture, plan, and code.'
 argument-hint: project path or specific document to review
 license: MIT
 allowed-tools: Read Glob Grep

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: 'Audit code for common security vulnerabilities — auth, secrets, injection, CORS/CSP, dependency CVEs, file uploads, error leaks. Read-only checklist + report. TRIGGER when user says "проверь безопасность", "security audit", "найди уязвимости", "проверь auth", "проверь токены", "secrets check", or before launching to production. See `## Trigger phrases` in body for full list.'
+description: 'Audit code for security vulnerabilities — auth, secrets, injection, CORS/CSP, CVEs, file uploads, error leaks. Read-only report.'
 argument-hint: file, directory, or "all" for full project
 license: MIT
 allowed-tools: Read Glob Grep

--- a/skills/session-save/SKILL.md
+++ b/skills/session-save/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-save
-description: 'Save session context to project memory — what was done, key decisions, blockers, next steps. Ensures continuity between Claude Code sessions. TRIGGER when user says "сохрани контекст", "сохрани сессию", "итоги сессии", "save session", "end of session", or signals session end ("на сегодня всё", "заканчиваем"). See `## Trigger phrases` in body for full list.'
+description: 'Save session context to project memory — what was done, decisions, blockers, next steps. Ensures continuity between sessions.'
 argument-hint: (no arguments needed — gathers context automatically)
 license: MIT
 allowed-tools: Read Write Bash Glob Grep

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: 'Generate comprehensive tests — unit, integration, edge cases. Detects project test framework (pytest/vitest/jest/go test) and follows existing conventions. TRIGGER when user says "напиши тесты", "покрой тестами", "добавь тесты", or after writing new code / fixing a bug. Generating a regression test for a fix is part of finishing the fix. See `## Trigger phrases` in body for full list.'
+description: 'Generate comprehensive tests — unit, integration, edge cases. Detects project test framework and follows existing conventions.'
 argument-hint: file, function, or module to test
 license: MIT
 allowed-tools: Read Write Edit Glob Grep Bash


### PR DESCRIPTION
All 17 skill descriptions shortened from 360-470 chars to 116-155 chars. This ensures all skills are registered in the Skill tool within the default 16K character budget. Previously 6 skills (deps-audit, harden, infra, migrate, security-audit, session-save) were silently dropped.

Descriptions are metadata for skill discovery only — full skill logic in SKILL.md body is unchanged. Trigger phrases are handled by hooks.