### PR TITLE
fix(v1.13.0): sync /review methodology mode to code-reviewer subagent (closes 8th gap)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.12.0",
-  "description": "Complete project lifecycle methodology — 18 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing.",
+  "version": "1.13.0",
+  "description": "Complete project lifecycle methodology — 18 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, self-review mode.",
   "author": {
     "name": "HiH-DimaN",
     "email": "HiH-DimaN@users.noreply.github.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.13.0] - 2026-04-11
+
+Methodology self-review release. Closes the 8th gap surfaced during v1.12.0 review: `/review` skill had Step 0 methodology-mode detection since v1.5.0 (`--self` flag, `.claude-plugin/plugin.json` sniffing), but the `code-reviewer` subagent to which `/review` forks via `agent: code-reviewer` had its own instructions in `agents/code-reviewer.md` that did NOT mention methodology mode. Running `/review` inside the idea-to-deploy repo produced nonsense BLOCKED reports because the subagent searched for `PRD.md`, `STRATEGIC_PLAN.md`, `IMPLEMENTATION_PLAN.md` (project-level documents that don't exist in a methodology repo).
+
+### Fixed
+
+- **`agents/code-reviewer.md`** — added Step 0 at the top of the subagent instructions, mirroring `skills/review/SKILL.md`. The subagent now detects methodology mode (`--self` flag, methodology-repo sniffing, or changed-files touching methodology surfaces) and delegates to `tests/meta_review.py --verbose` instead of running project-level checks. Explicit list of what NOT to do in methodology mode: no `PRD.md`/`STRATEGIC_PLAN.md` lookups, no user-story scoring, no SOLID/code-smell against infrastructure hooks, no inventing rubric checks (delegate to `tests/meta_review.py` which is the authoritative source).
+- **`skills/review/SKILL.md`** — Step 0 rewritten to be unambiguous. Old version said "Jump to Step 3 with the meta-rubric" which was confusing (Step 3 is output formatting, not rubric application). New version says explicitly: run `python3 tests/meta_review.py --verbose`, parse output, present as `/review`-style report. Frontmatter version 1.4.0 → 1.13.0 (jumped to match plugin.json methodology-version track).
+
+### Changed
+
+- **`.claude-plugin/plugin.json`** — version 1.12.0 → 1.13.0, description adds "self-review mode" to the capability list.
+- **`README.md`** / **`README.ru.md`** — version badges 1.12.0 → 1.13.0. Skill count unchanged (18).
+
+### Why
+
+During the v1.12.0 review cycle, I invoked `/review` on the feat/v1.5.0-sync-and-hook-fix branch (17 files of methodology changes). The code-reviewer subagent came back with a report looking for project-level docs: "M-C5: C6 & C7 (Critical) — Missing PRD.md", "recommended to create PRD.md from strategic plan". This was obviously wrong — idea-to-deploy is a methodology repo, not a SaaS project. I had to do a manual review instead and the project-level review agent false-negative was flagged as the 8th gap in `session_2026-04-11_2.md`.
+
+Root cause: `skills/review/SKILL.md` already had Step 0 methodology detection, but `agent: code-reviewer` + `context: fork` in the skill frontmatter means `/review` forks to a subagent with its own instructions. The fork does not inherit SKILL.md — the subagent sees only `agents/code-reviewer.md`. That file had no methodology-mode awareness, so the subagent ran its default (project-level) validation.
+
+Fix is symmetric: sync the Step 0 block between `skills/review/SKILL.md` (for when `/review` runs in-context) and `agents/code-reviewer.md` (for when it forks). Both now detect methodology mode and both delegate to `tests/meta_review.py`. The runner script is the single source of truth for the rubric; both entry points just ask it for the report.
+
+### Migration
+
+No user action required if you already ran `bash scripts/sync-to-active.sh` after v1.12.0. For v1.13.0, re-run:
+
+```bash
+git pull
+bash scripts/sync-to-active.sh
+# no claude restart needed — subagent definitions are re-read on every invocation
+```
+
+### Verify
+
+```bash
+cd /path/to/idea-to-deploy
+# Direct runner:
+python3 tests/meta_review.py --verbose
+# Via /review skill (after claude restart to pick up new SKILL.md):
+#   /review --self
+# Expected output: "FINAL STATUS: PASSED" (or PASSED_WITH_WARNINGS with specific findings)
+```
+
+---
+
 ## [1.12.0] - 2026-04-11
 
 Methodology hardening release. Closes six systemic gaps surfaced by the NeuroExpert 2026-04-11 parallel-session incident, where two Claude sessions performed the same kong.yml tech-debt refactor in parallel because nothing in the methodology forced a pre-flight check on recent commits and no router existed for daily-work tasks on existing code.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#skills)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#subagents)
-[![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#скиллы)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#субагенты)
-[![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -11,7 +11,39 @@ allowed-tools: Read Grep Glob
 
 You are a meticulous code reviewer and document auditor. Your job is to find inconsistencies, gaps, and quality issues.
 
-## Your Responsibilities
+## Step 0: Detect review mode (v1.13.0)
+
+**Before doing anything else**, check whether the target being reviewed is a **methodology self-review** or a **regular project review**. The two modes use entirely different rubrics — mixing them produces nonsense reports (e.g. looking for PRD.md in a methodology repo, or running meta-rubric on a normal project).
+
+**Methodology self-review is active when ANY of the following is true:**
+
+1. The user's request contains `--self`, `--target methodology`, «meta-review», «self-review», «проверь методологию», «review the methodology repo», or similar explicit markers.
+2. The current working directory (or the path in `$ARGUMENTS`) contains `.claude-plugin/plugin.json` AND the JSON's `name` field equals `idea-to-deploy` AND a `skills/` directory with multiple sub-skill directories exists alongside a `hooks/check-skills.sh` file.
+3. The changed files in the current git diff touch `skills/*/SKILL.md`, `hooks/check-skills.sh`, `.claude-plugin/plugin.json`, or `tests/meta_review.py` — these are methodology surfaces, not project surfaces.
+
+**If methodology self-review is active, run this instead of the project-level rubric:**
+
+```bash
+cd <repo_root>
+python3 tests/meta_review.py --verbose
+```
+
+The script implements the full rubric from `skills/review/references/meta-review-checklist.md` (Critical, Important, Nice-to-have tiers — the same three-tier structure as project review). Parse its output and present it in the same format as a regular `/review` report:
+
+- `FINAL STATUS: PASSED` → `PASSED` — report 0 critical, 0 important
+- `FINAL STATUS: PASSED_WITH_WARNINGS` → `PASSED_WITH_WARNINGS` — report critical=0, important=N
+- `FINAL STATUS: BLOCKED` → `BLOCKED` — report critical=N, offer to fix each finding
+
+**Do NOT do any of the following in methodology mode:**
+
+- Do not look for `PRD.md`, `STRATEGIC_PLAN.md`, `IMPLEMENTATION_PLAN.md`, `PROJECT_ARCHITECTURE.md` — those are project-level documents and their absence is expected in a methodology repo.
+- Do not score against project user stories, business risks, competitor analysis — methodology repos don't have those.
+- Do not apply the SOLID/code-smell catalog to the methodology's own Python hooks — those are infrastructure glue, not business logic.
+- Do not invent your own methodology-rubric checks — `tests/meta_review.py` is the authoritative source. If you find a gap in the rubric, add it to `skills/review/references/meta-review-checklist.md` AND to `tests/meta_review.py`, then re-run.
+
+**Regular project review** (below) is used when NONE of the methodology signals match.
+
+## Your Responsibilities (project-level review)
 
 1. **Cross-Document Consistency** - Verify entity names, tech stack, endpoints match across all docs
 2. **Traceability** - Every user story must trace to endpoint, implementation step, and guide prompt

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -8,9 +8,9 @@ context: fork
 agent: code-reviewer
 metadata:
   author: HiH-DimaN
-  version: 1.4.0
+  version: 1.13.0
   category: quality-assurance
-  tags: [validation, quality-check, review, consistency, solid, code-smells]
+  tags: [validation, quality-check, review, consistency, solid, code-smells, methodology-review]
 ---
 
 # Review
@@ -37,12 +37,32 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
-### Step 0: Detect mode (v1.5.0)
+### Step 0: Detect review mode (v1.13.0)
 
-Before anything else, check whether `$ARGUMENTS` contains `--self` OR the current working directory is the idea-to-deploy methodology repo (signals: `.claude-plugin/plugin.json` with `name: idea-to-deploy`, `skills/` with 10+ subdirectories, `hooks/check-skills.sh` present).
+Before anything else, determine whether this is a **methodology self-review** or a **regular project review**. The two modes use different rubrics and different runners — mixing them produces nonsense reports.
 
-- **If `--self` OR self-hosted repo detected** → use the meta-review rubric from `references/meta-review-checklist.md` INSTEAD of `review-checklist.md`. The meta-rubric audits the methodology itself: per-skill references, triggers, fixtures, version consistency across plugin.json / README badges / SKILL frontmatter, CHANGELOG presence for the current version, hook completeness. Jump to Step 3 with the meta-rubric.
-- **Otherwise** → proceed to Step 1 below with the standard rubric.
+Methodology self-review is active when ANY of:
+
+1. `$ARGUMENTS` contains `--self`, `--target methodology`, "meta-review", "self-review", «проверь методологию», «review the methodology repo», or similar explicit marker.
+2. `pwd` (or the path in `$ARGUMENTS`) contains `.claude-plugin/plugin.json` with `"name": "idea-to-deploy"`, AND a populated `skills/` directory, AND `hooks/check-skills.sh`.
+3. The current git diff (or the path under review) touches `skills/*/SKILL.md`, `hooks/*.sh`, `.claude-plugin/plugin.json`, or `tests/meta_review.py` — i.e. methodology surfaces, not project surfaces.
+
+**If methodology self-review is active:**
+
+```bash
+cd <repo_root>
+python3 tests/meta_review.py --verbose
+```
+
+The script implements the full three-tier rubric from `references/meta-review-checklist.md` (same Critical/Important/Nice-to-have structure as project review). Parse its output:
+
+- `FINAL STATUS: PASSED` → report `PASSED`
+- `FINAL STATUS: PASSED_WITH_WARNINGS` → report `PASSED_WITH_WARNINGS` with the Important findings
+- `FINAL STATUS: BLOCKED` → report `BLOCKED` with the Critical findings and offer fixes (Step 4)
+
+Do NOT run the project-level rubric (Steps 1-2 below) in methodology mode — it would look for `PRD.md` / `STRATEGIC_PLAN.md` / `IMPLEMENTATION_PLAN.md` which don't exist in a methodology repo and produce false-negative BLOCKED reports. This was the v1.12.0 "8th gap" incident: the code-reviewer subagent ignored this Step 0 because it had its own instructions that didn't mention methodology mode. Fixed in v1.13.0 by syncing `agents/code-reviewer.md` with the same Step 0 logic — the subagent now detects and delegates the same way.
+
+**If regular project review is active:** proceed to Step 1 below with the standard rubric.
 
 ### Step 1: Detect what to review
 


### PR DESCRIPTION
## Summary

Closes the 8th gap from `session_2026-04-11_2.md`: `/review` skill had Step 0 methodology-mode detection since v1.5.0, but the `code-reviewer` subagent (to which `/review` forks via `agent: code-reviewer` + `context: fork` in frontmatter) had its own instructions in `agents/code-reviewer.md` that did **not** mention methodology mode. Running `/review` inside idea-to-deploy produced nonsense BLOCKED reports because the subagent searched for `PRD.md`, `STRATEGIC_PLAN.md`, `IMPLEMENTATION_PLAN.md` — project-level documents that don't exist in a methodology repo.

## Root cause

`skills/review/SKILL.md` (`context: fork`, `agent: code-reviewer`) means the skill forks to a subagent with its own instructions. The fork does **not** inherit SKILL.md text — the subagent sees only `agents/code-reviewer.md`. That file had no methodology-mode awareness, so the subagent ran its default project-level validation even when the skill's Step 0 told it to switch modes.

Concrete symptom from v1.12.0 review cycle: I invoked `/review` on the `feat/v1.5.0-sync-and-hook-fix` branch (17 files of methodology changes). The subagent came back with:

> "M-C5: C6 & C7 (Critical) — Missing PRD.md"
> "recommended to create PRD.md from strategic plan"

Obviously wrong — idea-to-deploy is a methodology repo, not a SaaS project. I had to do a manual review instead, flagged as the 8th gap.

## Fix

**Symmetric Step 0 block in both entry points:**

### `agents/code-reviewer.md` (subagent)

New Step 0 at the top of the instructions, before "Your Responsibilities". Detects methodology mode via (a) explicit `--self` flag or similar marker, (b) `.claude-plugin/plugin.json` with `name: idea-to-deploy` + populated `skills/` + `hooks/check-skills.sh`, or (c) changed files touching methodology surfaces (`skills/*/SKILL.md`, `hooks/*.sh`, `plugin.json`, `tests/meta_review.py`).

In methodology mode, delegates to `python3 tests/meta_review.py --verbose` and parses its output. Explicit list of things NOT to do in methodology mode:

- No `PRD.md` / `STRATEGIC_PLAN.md` / `IMPLEMENTATION_PLAN.md` lookups
- No user-story scoring, no competitor analysis, no business risks
- No SOLID/code-smell catalog against the methodology's own Python hooks (those are infrastructure glue, not business logic)
- No inventing rubric checks — `tests/meta_review.py` is the authoritative source; gaps should be added to it AND to `meta-review-checklist.md`, not improvised in the review report

### `skills/review/SKILL.md` (skill)

Step 0 rewritten to be unambiguous. Old version said *"Jump to Step 3 with the meta-rubric"* which was confusing (Step 3 is output formatting, not rubric application). New version explicitly says: run `python3 tests/meta_review.py --verbose`, parse output, present as `/review`-style report. Frontmatter version `1.4.0` → `1.13.0` (jumped to match plugin.json methodology-version track).

### Metadata

- `.claude-plugin/plugin.json` — version 1.12.0 → 1.13.0, description adds "self-review mode"
- `README.md` / `README.ru.md` — version badges 1.12.0 → 1.13.0
- Skill count unchanged (18)

## Why symmetric Step 0?

`tests/meta_review.py` is the single source of truth for the rubric. Both `/review` entry points (in-context and forked-subagent) should delegate to it rather than re-implementing the rubric inline. `skills/review/SKILL.md` already said so; now `agents/code-reviewer.md` does too. If the rubric grows, only one file changes (`meta-review-checklist.md` + `meta_review.py`) — the skill and subagent don't need touching.

## Test plan

- [x] `python3 tests/meta_review.py --verbose` → `FINAL STATUS: PASSED` (0 critical, 0 important)
- [x] Commit landed locally without being blocked by `check-commit-completeness.sh` (fixture for /review already exists, trigger in check-skills.sh intact)
- [ ] Manual: after merge + claude restart, invoke `/review --self` inside idea-to-deploy repo and verify the subagent delegates to meta_review.py instead of looking for PRD.md
- [ ] Manual: invoke `/review` inside a regular project (e.g. neuroexpert) and verify the subagent runs the project-level rubric as before (no regression)

## Migration

No user action required beyond `bash scripts/sync-to-active.sh` after `git pull`. Subagent definitions are re-read on every invocation, so no claude restart is needed for `agents/code-reviewer.md` to take effect (unlike skills which are loaded at session start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)