### PR TITLE
fix(v1.13.1): sync-to-active.sh — handle agents/ directory (9th gap)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Complete project lifecycle methodology — 18 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, self-review mode.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.13.1] - 2026-04-11
+
+Patch release that finishes what v1.13.0 started. Closes the 9th gap, discovered immediately after merging v1.13.0: the `sync-to-active.sh` script added in v1.12.0 handles `skills/` and `hooks/` but has no `agents/` handling. That means the v1.13.0 fix to `agents/code-reviewer.md` (methodology-mode Step 0 for the forked subagent) landed in the repo but never propagated to `~/.claude/agents/code-reviewer.md`. The `/review --self` mode was effectively inactive: subagent kept using the stale project-level instructions, would still have produced the "Missing PRD.md" nonsense reports.
+
+Detected by `diff -rq agents/ ~/.claude/agents/` after v1.13.0 sync — all 5 agents differed (not just code-reviewer; they had never been sync'd since the script was written).
+
+### Fixed
+
+- **`scripts/sync-to-active.sh`** — added Step 2.5 (agents/) mirroring Step 2 (hooks/) logic. Copies `agents/*.md` to `~/.claude/agents/` with the same `cmp -s` content-based drift detection as the hooks step. No-op when content matches, idempotent on re-runs. Handles both `--check` (dry-run) and normal mode.
+
+### Changed
+
+- **`.claude-plugin/plugin.json`** — version 1.13.0 → 1.13.1.
+- **`README.md`** / **`README.ru.md`** — version badges 1.13.0 → 1.13.1.
+
+### Migration
+
+```bash
+git pull
+bash scripts/sync-to-active.sh
+```
+
+This now copies all 5 subagent files into `~/.claude/agents/`. Verify with:
+
+```bash
+diff -rq agents/ ~/.claude/agents/   # should be silent (no output)
+```
+
+No claude restart needed — subagent definitions are re-read on every invocation.
+
+### Why a patch-level bump
+
+This change adds no new user-facing capability; it restores the effective activation of v1.13.0 which would otherwise remain dormant. Per SemVer this is a bug fix (PATCH), not a feature (MINOR). The methodology version counter stays at 1.13, which is the correct semantic version for "review skill supports self-mode".
+
+---
+
 ## [1.13.0] - 2026-04-11
 
 Methodology self-review release. Closes the 8th gap surfaced during v1.12.0 review: `/review` skill had Step 0 methodology-mode detection since v1.5.0 (`--self` flag, `.claude-plugin/plugin.json` sniffing), but the `code-reviewer` subagent to which `/review` forks via `agent: code-reviewer` had its own instructions in `agents/code-reviewer.md` that did NOT mention methodology mode. Running `/review` inside the idea-to-deploy repo produced nonsense BLOCKED reports because the subagent searched for `PRD.md`, `STRATEGIC_PLAN.md`, `IMPLEMENTATION_PLAN.md` (project-level documents that don't exist in a methodology repo).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#skills)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#subagents)
-[![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#скиллы)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#субагенты)
-[![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/scripts/sync-to-active.sh
+++ b/scripts/sync-to-active.sh
@@ -147,6 +147,55 @@ done
 ok "hooks: +$h_added added, ~$h_updated updated, =$h_unchanged unchanged"
 
 # -----------------------------------------------------------------------------
+# Step 2.5: Sync agents/*.md (subagents)
+# -----------------------------------------------------------------------------
+# Gap #9 (v1.13.1): sync-to-active.sh originally copied skills/ and hooks/
+# but NOT agents/, so updates to subagent instructions (e.g. the v1.13.0
+# methodology-mode Step 0 in agents/code-reviewer.md) never propagated to
+# ~/.claude/agents/. That made the v1.13.0 /review fix effectively inactive
+# until a manual copy. This step fixes it symmetrically with Step 2.
+say "Step 2.5/3: agents/"
+mkdir -p "$ACTIVE/agents"
+
+a_added=0
+a_updated=0
+a_unchanged=0
+
+if [ -d "$REPO_ROOT/agents" ]; then
+  for src_agent in "$REPO_ROOT"/agents/*.md; do
+    [ -e "$src_agent" ] || continue
+    name="$(basename "$src_agent")"
+    dst="$ACTIVE/agents/$name"
+
+    if [ ! -f "$dst" ]; then
+      if [ "$DRY_RUN" = "1" ]; then
+        printf "  + would add   %s\n" "$name"
+      else
+        cp "$src_agent" "$dst"
+        printf "  + added       %s\n" "$name"
+      fi
+      a_added=$((a_added + 1))
+      continue
+    fi
+
+    if cmp -s "$src_agent" "$dst"; then
+      a_unchanged=$((a_unchanged + 1))
+      continue
+    fi
+
+    if [ "$DRY_RUN" = "1" ]; then
+      printf "  ~ would sync  %s (content drift)\n" "$name"
+    else
+      cp "$src_agent" "$dst"
+      printf "  ~ updated     %s\n" "$name"
+    fi
+    a_updated=$((a_updated + 1))
+  done
+fi
+
+ok "agents: +$a_added added, ~$a_updated updated, =$a_unchanged unchanged"
+
+# -----------------------------------------------------------------------------
 # Step 3: Patch settings.json "hooks" section
 # -----------------------------------------------------------------------------
 say "Step 3/3: settings.json hooks registration"


### PR DESCRIPTION
## Summary

Closes the 9th gap, discovered immediately after merging v1.13.0: `scripts/sync-to-active.sh` (added in v1.12.0) syncs `skills/` and `hooks/` but has **no** `agents/` handling. That made the v1.13.0 fix to `agents/code-reviewer.md` (methodology-mode Step 0 for the forked subagent) effectively inactive in the local install — the file landed in the repo but never propagated to `~/.claude/agents/`.

## Detection

Immediately after running `sync-to-active.sh` on v1.13.0, I checked `diff -rq agents/ ~/.claude/agents/` and all 5 agents differed. Not just `code-reviewer.md` — **all 5** had never been synced since the script was written, because the script simply didn't know about `agents/`. Example diff head for `code-reviewer.md`:

```
< description: "Specialized agent ... [long description with v1.13.0 Step 0]"
< model: sonnet
< effort: high
---
> description: "Specialized agent ... [old short description]"
> model: claude-sonnet-4-20250514
```

Active install was running stale instructions from whenever the agents were last manually copied. `/review --self` would still have produced the "Missing PRD.md" nonsense reports until someone noticed.

## Fix

`scripts/sync-to-active.sh` — new **Step 2.5 (agents/)** between Step 2 (hooks) and Step 3 (settings.json). Mirrors Step 2 logic exactly:

- Creates `~/.claude/agents/` if missing
- Iterates `agents/*.md`
- Uses `cmp -s` for content-based drift detection (same approach as hooks)
- Reports `+added / ~updated / =unchanged` counts
- Handles `--check` dry-run mode
- No-op on unchanged files, idempotent on re-runs

Verified locally: first run reported `agents: ~5 updated`, second run reported `agents: =5 unchanged`. `diff -rq agents/ ~/.claude/agents/` silent after sync.

## Why a patch-level bump (1.13.0 → 1.13.1)

This change adds **no new user-facing capability** — it restores the effective activation of v1.13.0 which would otherwise remain dormant. Per SemVer this is a bug fix (PATCH), not a feature (MINOR). The methodology version counter stays at 1.13 ("review skill supports self-mode"), the plugin marketplace version becomes 1.13.1.

## Test plan

- [x] `python3 tests/meta_review.py --verbose` → `FINAL STATUS: PASSED` (0 critical, 0 important)
- [x] `bash scripts/sync-to-active.sh` first run → `agents: ~5 updated`
- [x] `bash scripts/sync-to-active.sh --check` → `agents: =5 unchanged` (idempotent)
- [x] `diff -rq agents/ ~/.claude/agents/` → silent after sync
- [x] `bash -n scripts/sync-to-active.sh` → clean
- [ ] Manual: after merge, `git pull && bash scripts/sync-to-active.sh` brings any install in line automatically — no need to touch `~/.claude/agents/` manually ever again

## Migration

```bash
git pull
bash scripts/sync-to-active.sh
```

No claude restart needed — subagent definitions are re-read on every invocation, so the updated `code-reviewer.md` (with v1.13.0 methodology Step 0) takes effect immediately after the copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)