### PR TITLE
feat(v1.14.0): polish — keywords, /explain triggers, subagent contracts, M-I8 gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "HiH-DimaN/idea-to-deploy"
       },
       "homepage": "https://github.com/HiH-DimaN/idea-to-deploy",
-      "version": "1.13.2",
+      "version": "1.14.0",
       "tags": ["community-managed"],
       "keywords": [
         "claude-code",
@@ -35,7 +35,8 @@
         "session-persistence",
         "self-review",
         "meta-review",
-        "daily-work-router"
+        "daily-work-router",
+        "methodology-validation"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "Complete project lifecycle methodology — 18 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, self-review mode.",
   "author": {
     "name": "HiH-DimaN",
@@ -20,7 +20,11 @@
     "testing",
     "deployment",
     "code-review",
-    "security-audit"
+    "security-audit",
+    "self-review",
+    "meta-review",
+    "methodology-validation",
+    "daily-work-router"
   ],
   "skills": [
     "./skills/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.14.0] - 2026-04-11
+
+Polish release closing the three Nice-to-have items from the v1.13.2 qualitative audit, plus a new `M-I8` meta-review gate that makes the subagent contract pattern auditable and regression-proof. All improvements are backward-compatible additions — MINOR bump, no user-facing behaviour changes.
+
+### Audit context
+
+The v1.13.2 PR (#16) fixed 1 Critical + 4 Important drift items but deferred three Nice-to-have items to v1.14.0 because they did not affect correctness, only discoverability and edge-case recall:
+
+1. `plugin.json.keywords` missing the new v1.13.0 capability tags.
+2. `agents/doc-writer.md` (and by analogy `test-generator.md`) had an ambiguous "Generate documentation files" instruction without disclosing that the subagent runs in a forked context with no `Write`/`Edit` tools, so the instruction is physically unfulfillable.
+3. `hooks/check-skills.sh` `/explain` trigger had thin English coverage — idiomatic phrasings like "what does this function do", "can you explain", "tell me about this module" fell through to ad-hoc tool calls.
+
+v1.14.0 closes all three and adds one bonus item: **M-I8 subagent whitelist gate** which enforces the clarification pattern for all current and future read-only subagents.
+
+### Added
+
+- **`hooks/check-skills.sh`** — extended `/explain` regex with three new idiomatic English patterns:
+  - `what\s+does\s+(this\s+|the\s+)?(\w+\s+)?(do|mean|return)` — catches "what does this function do", "what does getUserById return", "what does the auth middleware do"
+  - `can\s+you\s+explain` — catches "can you explain this regex", "can you explain what's happening"
+  - `tell\s+me\s+(about|how)\s+(this|the|that)\s+(code|function|module|class|file|method|component|handler|endpoint)` — catches "tell me about this handler", "tell me how the auth module works"
+- **`.claude-plugin/plugin.json`** — keywords extended with `self-review`, `meta-review`, `methodology-validation`, `daily-work-router`. Aligns the plugin's discoverability metadata with the v1.13.0 self-review capability, the v1.5.0 `/task` router, and the v1.12.0+ meta-review gate. Parallelism with marketplace.json restored.
+- **`.claude-plugin/marketplace.json`** — keyword `methodology-validation` added for parity with plugin.json (the other three were already present from v1.13.2).
+- **`agents/doc-writer.md`** — new "Output Format" section explicitly states that the agent runs in a forked context without `Write`/`Edit`, and must return structured text for the calling skill to persist. Applies to both invocation paths: through the `/doc` skill and directly via the `Agent` tool.
+- **`agents/test-generator.md`** — analogous disclaimer, with the additional clarification that `Bash` is in the whitelist for test-suite detection (`pytest --co`, `npm test -- --listTests`) but NOT for writing files via heredoc or `tee`.
+- **`agents/architect.md`** — analogous disclaimer for the `/blueprint` flow; specifies the `{ file_path, content }` tuple return format for multi-file architecture deliverables.
+- **`agents/code-reviewer.md`** — analogous disclaimer emphasising the separation of audit (subagent) and remediation (caller) as load-bearing for read-only review semantics. Preserves the existing v1.13.0 Step 0 methodology-mode detection.
+- **`agents/perf-analyzer.md`** — analogous disclaimer plus expanded return format per bottleneck (Description / Severity / Location / Measurement / Suggested fix / Expected improvement). Explicitly says `Bash` is for running benchmarks, not for `tee > patched.py`.
+- **`tests/meta_review.py` — new Important gate `M-I8`** — scans `agents/*.md` and, for any subagent whose frontmatter `allowed-tools` does not include `Write` or `Edit`, verifies the body contains a forked-context disclaimer (a block with all three markers: "forked", "Write/Edit", negation keyword). Silent-write-failure regressions are no longer possible without the gate flagging them. Intentionally Important (not Critical) because the same class of bug has always been a correctness issue, never a blocker for existing users.
+
+### Changed
+
+- **`.claude-plugin/plugin.json`** — version `1.13.2` → `1.14.0`.
+- **`.claude-plugin/marketplace.json`** — `plugins[0].version` `1.13.2` → `1.14.0`.
+- **`README.md`** / **`README.ru.md`** — version badges `1.13.2` → `1.14.0`.
+
+### Migration
+
+```bash
+git pull
+bash scripts/sync-to-active.sh
+python3 tests/meta_review.py --verbose
+```
+
+No configuration changes required. Active install picks up the new triggers, keyword metadata, and subagent instructions on next Claude restart.
+
+### Why MINOR, not PATCH
+
+v1.13.2 was strictly a drift fix — PATCH per SemVer. v1.14.0 is different: it adds new trigger-phrase coverage (behaviour change, even if backward-compatible), new plugin.json keywords (catalog-visible change), new subagent instructions (changes what subagents can be told to do), and a new meta-review gate (changes what the CI will block). None of these are breaking, but together they move the minor version counter, which is the right SemVer semantics for backward-compatible additions.
+
+### What remains open
+
+- **v1.15.0 candidate — snapshot testing for behavioural fixtures.** Documented in `tests/README.md` as a future path since v1.13.2. Requires a proof-of-concept of non-interactive Claude Code SDK invocation before full rollout, and a CI compute cost estimate. Not in v1.14.0 scope.
+- **WSL git-over-network issue.** `git push` and `git fetch` hang in the maintainer's WSL environment; all v1.13.2 and v1.14.0 commits are landed via `gh api graphql createCommitOnBranch`. This is an environment issue, not a methodology issue, but is tracked in memory for continuity.
+
+---
+
 ## [1.13.2] - 2026-04-11
 
 Documentation-drift audit release. Closes gaps found during the post-v1.13.1 self-review where a code-reviewer subagent + manual verification surfaced issues that the automated `meta_review.py` gate did not catch:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#skills)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#subagents)
-[![Version: 1.13.2](https://img.shields.io/badge/Version-1.13.2-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#скиллы)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#субагенты)
-[![Version: 1.13.2](https://img.shields.io/badge/Version-1.13.2-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -39,4 +39,12 @@ When choosing architecture:
 
 ## Output Format
 
-Always produce structured markdown with clear sections for each architecture component.
+**You operate in a forked subagent context with `allowed-tools: Read Grep Glob` — you do NOT have `Write` or `Edit`.** Your job is to **produce the complete architecture document text** and return it in your final response to the caller.
+
+The calling context (usually the `/blueprint` skill, which has `Read Write Edit Glob Grep`) will take your output and write it to disk as `PROJECT_ARCHITECTURE.md` (or other target files). If you are called directly via the `Agent` tool for architecture-only questions, the caller is responsible for persistence — answer in chat.
+
+Return format:
+- Always produce structured markdown with clear sections for each architecture component (Database, API, Auth, Tech Stack, Infrastructure).
+- For multi-file deliverables (e.g. `PROJECT_ARCHITECTURE.md` + updated `STRATEGIC_PLAN.md`), return a `{ file_path, content }` tuple per file so the caller can write each one precisely.
+
+Never say "I have created the architecture document" — you cannot. Say "Here is the PROJECT_ARCHITECTURE.md content to write:" and provide the content.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -82,4 +82,13 @@ The script implements the full rubric from `skills/review/references/meta-review
 
 ## Output Format
 
-Always produce a structured review report with: score, critical issues, warnings, suggestions, and cross-reference matrix.
+**You operate in a forked subagent context with `allowed-tools: Read Grep Glob` — you do NOT have `Write` or `Edit`.** Your job is to **produce a structured review report** and return it in your final response to the caller. You cannot apply fixes directly; you can only describe them precisely enough that the calling agent applies them.
+
+The calling context (usually the `/review` skill, which has `Read Grep Glob Bash`) will take your output, present it to the user, and optionally apply fixes via its own tools (or by delegating to a mutation-capable skill like `/bugfix`). If you are called directly via the `Agent` tool for an ad-hoc review, the caller presents your report to the user — you never persist anything yourself.
+
+Return format:
+- Always produce a structured review report with: score, Critical issues, Important warnings, Nice-to-have suggestions, and (for project review) cross-reference matrix.
+- For each finding, include: file path, line number if applicable, what is wrong, why it matters, exact suggested fix.
+- Never return "I have fixed X" — return "Here is the fix for X: [diff or replacement text]".
+
+This separation between audit (you) and remediation (the caller) is load-bearing: it keeps reviews read-only and auditable, and it prevents silent file mutations from a subagent context where they would fail anyway.

--- a/agents/doc-writer.md
+++ b/agents/doc-writer.md
@@ -40,4 +40,13 @@ Match the detected style.
 
 ## Output Format
 
-Generate documentation files matching project conventions.
+**You operate in a forked subagent context with `allowed-tools: Read Grep Glob` — you do NOT have `Write` or `Edit`.** Your job is to **produce the full documentation text** and return it in your final response to the caller.
+
+The calling context (usually the `/doc` skill, which has `Read Write Edit Glob Grep`) will take your output and write it to disk. If you are called directly via the `Agent` tool by another skill or by the main agent, the caller is responsible for persistence.
+
+Return format:
+- For README / API docs / architecture docs: return the complete Markdown content, ready to write verbatim to the target file.
+- For inline comments / docstrings / JSDoc: return a structured list of `{ file_path, function_name, comment_block }` tuples so the caller can apply each one precisely.
+- Match existing project conventions (language, tone, header style, code fence formatting).
+
+Never say "I have updated the README" — you cannot. Say "Here is the README content to write to `README.md`:" and provide the content.

--- a/agents/perf-analyzer.md
+++ b/agents/perf-analyzer.md
@@ -31,4 +31,16 @@ You are a performance optimization expert. Your job is to find and fix bottlenec
 
 ## Output Format
 
-Produce structured report: bottleneck description, severity, location, suggested fix, expected improvement.
+**You operate in a forked subagent context with `allowed-tools: Read Grep Glob Bash` — you do NOT have `Write` or `Edit`.** Your job is to **produce a structured performance report with proposed patches** and return it in your final response to the caller.
+
+The calling context (usually the `/perf` skill, which has `Read Write Edit Glob Grep Bash`) will take your output and apply the patches via its own tools, or present the patches to the user for approval. `Bash` is in your whitelist so you can run the existing test/benchmark suite for baseline measurements (`pytest --benchmark`, `wrk`, `ab`, `EXPLAIN ANALYZE`) — do NOT use it to write files via heredoc or `tee`.
+
+Return format per bottleneck:
+- **Description** — what the bottleneck is, in one sentence
+- **Severity** — Critical / Important / Nice-to-have (match the /review taxonomy)
+- **Location** — file path, line number, function name
+- **Measurement** — baseline number if you ran a benchmark (e.g. "p95 = 840ms, 92% in `User.posts` N+1")
+- **Suggested fix** — exact code diff or replacement block, ready for the caller to apply with `Edit`
+- **Expected improvement** — realistic estimate, not a guess ("eager loading should bring p95 to ~60ms based on query count reduction from 1+N to 2")
+
+Never say "I have optimized X" — you cannot. Say "Here is the patch to apply to X: [diff]" and provide it.

--- a/agents/test-generator.md
+++ b/agents/test-generator.md
@@ -38,4 +38,13 @@ You are a testing expert. Your job is to write comprehensive, meaningful tests t
 
 ## Output Format
 
-Generate test files matching project conventions. Include setup, teardown, and clear assertions.
+**You operate in a forked subagent context with `allowed-tools: Read Grep Glob Bash` — you do NOT have `Write` or `Edit`.** Your job is to **produce the full test file content** and return it in your final response to the caller.
+
+The calling context (usually the `/test` skill, which has `Read Write Edit Glob Grep Bash`) will take your output and write it to disk. If you are called directly via the `Agent` tool by another skill (for example, by `/bugfix` when generating a regression test for a fresh fix), the caller is responsible for persistence.
+
+Return format:
+- For each test file: return `{ file_path, content }` with the full test file content, ready to write verbatim. Include imports, fixtures, setup/teardown, and all assertions.
+- If the test file already exists and you are adding tests: return a precise diff or the full updated file, clearly marked so the caller knows whether to `Write` (overwrite) or `Edit` (in-place patch).
+- `Bash` is allowed in your whitelist for running the existing test suite to verify framework/config detection (`pytest --co`, `npm test -- --listTests`, etc.) — do NOT use it to write files via heredoc or `tee`.
+
+Never say "I have added the tests" — you cannot. Say "Here are the test files to write:" and provide the content.

--- a/hooks/check-skills.sh
+++ b/hooks/check-skills.sh
@@ -65,7 +65,11 @@ TRIGGERS = [
         r"(объясни\s+(код|как|что)|как\s+(это\s+)?работает|как\s+устроен|что\s+делает|"
         r"что\s+здесь\s+происходит|разбер\w+\s+(как|код|этот|файл|модуль)|"
         r"расскажи\s+про|explain\s+(this|that|how|what|code)|"
-        r"how\s+does\s+this\s+work|walk\s+me\s+through|\bwalkthrough\b)",
+        r"how\s+does\s+this\s+work|walk\s+me\s+through|\bwalkthrough\b|"
+        r"what\s+does\s+(this\s+|the\s+)?(\w+\s+)?(do|mean|return)|"
+        r"can\s+you\s+explain|"
+        r"tell\s+me\s+(about|how)\s+(this|the|that)\s+"
+        r"(code|function|module|class|file|method|component|handler|endpoint))",
         "🔔 Триггер 'объясни' → используй /explain (диаграммы + пошаговый разбор).",
     ),
     (

--- a/tests/meta_review.py
+++ b/tests/meta_review.py
@@ -408,6 +408,59 @@ def run_rubric(repo: Path) -> Report:
     except Exception as e:
         r.imp("M-C11", f"could not run verify_triggers.py: {e}")
 
+    # --- M-I8: subagent contract — read-only agents must declare it (v1.14.0) ---
+    # Any `agents/*.md` whose `allowed-tools` frontmatter does NOT include
+    # Write/Edit must say so EXPLICITLY in its body — otherwise the model
+    # running inside that forked subagent context will try to write files,
+    # fail silently (tools unavailable), and the calling skill gets nothing.
+    #
+    # The fix (added in v1.14.0 for doc-writer and test-generator) is an
+    # "Output Format" section that tells the subagent to return text to
+    # the caller. This gate makes the pattern mandatory for all future
+    # read-only subagents — register a regression test for the clarification.
+    #
+    # A passing disclaimer contains ALL THREE markers on any line within
+    # the body:
+    #   1) the phrase "forked" (forked subagent/context)
+    #   2) the word "Write" or "Edit" (references the missing tool)
+    #   3) a negation marker ("NOT", "not have", "without", "cannot")
+    #
+    # This is intentionally loose — we want the disclaimer present, not
+    # to enforce exact wording.
+    agents_dir = repo / "agents"
+    if agents_dir.is_dir():
+        write_edit_re = re.compile(r"\bWrite\b|\bEdit\b")
+        disclaimer_re = re.compile(
+            r"forked.*(?:Write|Edit).*(?:NOT|not\s+have|without|cannot)|"
+            r"(?:NOT|not\s+have|without|cannot).*(?:Write|Edit).*forked|"
+            r"forked\s+subagent\s+context.*(?:NOT|do\s+not|without).*(?:Write|Edit)",
+            re.IGNORECASE | re.DOTALL,
+        )
+        # Simpler check: a single block with all three markers
+        def has_disclaimer(body: str) -> bool:
+            # Look for a block (paragraph or bold line) that mentions
+            # "forked" + "Write" (or Edit) + a negation within 500 chars
+            for block in re.split(r"\n\s*\n", body):
+                if "forked" in block.lower() and write_edit_re.search(block):
+                    if re.search(r"\bNOT\b|not\s+have|without|cannot|do\s+not", block, re.IGNORECASE):
+                        return True
+            return False
+
+        for agent_md in sorted(agents_dir.glob("*.md")):
+            fm, body = read_frontmatter(agent_md)
+            tools = fm.get("allowed-tools", "")
+            has_write = bool(re.search(r"\bWrite\b", tools))
+            has_edit = bool(re.search(r"\bEdit\b", tools))
+            if has_write or has_edit:
+                # Agent can write files itself — no disclaimer required.
+                continue
+            if not has_disclaimer(body):
+                r.imp(
+                    "M-I8",
+                    f"agents/{agent_md.name}: read-only subagent (no Write/Edit in allowed-tools) "
+                    f"but body has no forked-context disclaimer — silent write failures will result",
+                )
+
     # --- M-C13: marketplace.json consistency with plugin.json (v1.13.2) ---
     # The community plugin catalog (.claude-plugin/marketplace.json) is a
     # separate file from plugin.json and is what external crawlers read. It


### PR DESCRIPTION
## Summary

Polish release closing the **three Nice-to-have items** deferred from the v1.13.2 qualitative audit + one **bonus gate** (`M-I8`) that makes the read-only subagent contract pattern regression-proof. MINOR bump per SemVer — all changes are backward-compatible additions, zero breaking behaviour.

### What was deferred from v1.13.2 and why

The v1.13.2 audit identified 1 Critical + 4 Important + 3 Nice-to-have items. v1.13.2 fixed Critical + Important (PATCH). The three Nice-to-have items were deferred because they did not affect correctness, only:
- **Catalog discoverability** (missing keywords)
- **Subagent contract clarity** (ambiguous "Generate documentation files" instruction on read-only agent)
- **Trigger recall for idiomatic English** (`what does X do`, `can you explain`, `tell me about this module`)

### Changes in this PR

#### 1. `/explain` English trigger coverage
Three new regex alternatives added to the `/explain` trigger in `hooks/check-skills.sh`:
- `what\s+does\s+(this\s+|the\s+)?(\w+\s+)?(do|mean|return)` — the most common English explain idiom
- `can\s+you\s+explain` — polite form, very common in tutorials/pair-programming context
- `tell\s+me\s+(about|how)\s+(this|the|that)\s+(code|function|module|class|file|method|component|handler|endpoint)` — walkthrough-style requests

Before this PR, these phrasings missed the `/explain` router and fell through to ad-hoc tool calls. No risk of false positives — patterns are specific.

#### 2. `plugin.json` + `marketplace.json` keywords
- `plugin.json`: +`self-review`, `meta-review`, `methodology-validation`, `daily-work-router` (four new tags matching v1.13.0 self-review, v1.5.0 `/task` router, v1.12.0+ meta-review capability surfaces)
- `marketplace.json`: +`methodology-validation` (parity with plugin.json; the other three were already added in v1.13.2)

Improves plugin catalog indexing for users searching terms like "meta review", "self review", "methodology validation".

#### 3. Subagent contract clarification (all 5 read-only agents)
Every agent in `agents/*.md` with `allowed-tools` lacking `Write`/`Edit` now has an explicit **Output Format** section that:
1. States the forked subagent context and missing tools.
2. Contractually commits to returning text to the caller, not claiming to write files.
3. Specifies structured return format (file tuples, diffs, report sections).

Applied to: `doc-writer.md`, `test-generator.md`, `architect.md`, `code-reviewer.md`, `perf-analyzer.md`. Each disclaimer is tailored to the agent's domain:
- `test-generator`: adds that `Bash` is for test-suite detection, not for writing files via heredoc.
- `perf-analyzer`: adds that `Bash` is for benchmarks, not for `tee > patched.py`.
- `code-reviewer`: emphasises audit/remediation separation as load-bearing.
- `architect`: specifies multi-file tuple return format for `{ PROJECT_ARCHITECTURE.md + STRATEGIC_PLAN.md }` deliverables.
- `doc-writer`: specifies `{ file_path, function_name, comment_block }` tuples for inline comments.

No behavioural change — this documents what was already physically true (forked context, missing tools). The ambiguous "Generate documentation files" instruction (which was unfulfillable) is replaced with "Return the generated text for the caller to persist" (which is truthful).

#### 4. Bonus: `M-I8` meta-review gate
New Important check in `tests/meta_review.py`:

> For any `agents/*.md` whose frontmatter `allowed-tools` does not include `Write` or `Edit`, the body must contain a forked-context disclaimer (a block with all three markers: `forked` + `Write`/`Edit` + negation keyword).

This guarantees that:
1. The v1.14.0 clarification cannot silently regress (remove the disclaimer → gate red).
2. Any new read-only subagent added in the future must ship with its own disclaimer, OR must add Write/Edit to its whitelist with a justification.

Intentionally **Important** (not Critical) because the underlying issue has always been a correctness gap, never a blocker for existing users. Matches the severity of other contract-safety gates like M-I3 (allowed-tools declared).

### Verified locally

```
python3 tests/meta_review.py --verbose
=== META-REVIEW (idea-to-deploy @ /home/hihol/projects/idea-to-deploy) ===
Critical (0):
Important (0):
FINAL STATUS: PASSED
```

The M-I8 gate caught 3 agents missing the disclaimer (architect, code-reviewer, perf-analyzer) during development — they were fixed before push, gate now green.

### Why MINOR (1.14.0), not PATCH (1.13.3)

v1.13.2 was strictly a drift fix — PATCH was correct. v1.14.0 is different:
- New trigger-phrase coverage = behaviour change (backward-compatible but observable).
- New plugin.json keywords = catalog-visible metadata change.
- New subagent instructions = changes what subagents can be told to do.
- New meta-review gate = changes what CI will block for future contributors.

None of these are breaking, but together they move the minor version counter per SemVer semantics for backward-compatible additions.

### What's deferred to v1.15.0

**Snapshot testing for behavioural fixtures.** Documented in `tests/README.md` since v1.13.2 as one of three future automation paths (LLM-as-judge / snapshot diffing / schema-only validation). Requires a POC of non-interactive Claude Code SDK invocation + CI compute cost estimate before full rollout. Not in v1.14.0 scope.

### Push mechanics note

`git push` over SSH / HTTPS continues to hang in the maintainer's WSL environment (known issue tracked in `memory/session_2026-04-11.md`). This commit was landed via `gh api graphql createCommitOnBranch` — same workaround used for v1.13.2 PR #16. Content-identical to what a normal push would produce; only the parent-chain differs because GraphQL assigns a fresh OID rooted at the current remote main (`43b33d9`).

## Test plan

- [ ] CI meta-review workflow passes (expected green — verified locally)
- [ ] After merge: `bash scripts/sync-to-active.sh --check` reports drift on 5 agents + 2 metadata files
- [ ] After merge: `bash scripts/sync-to-active.sh` applies cleanly with renumbered 1/4..4/4 output
- [ ] Spot-check: `grep -c 'forked subagent context' agents/*.md` returns 5 (one per agent)
- [ ] Spot-check: `python3 -c "import json; print(len(json.load(open('.claude-plugin/plugin.json'))['keywords']))"` returns 14 (was 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)