### PR TITLE
fix(v1.14.1): M-I9 caller-skill tool superset gate + report_only frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "HiH-DimaN/idea-to-deploy"
       },
       "homepage": "https://github.com/HiH-DimaN/idea-to-deploy",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "tags": ["community-managed"],
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Complete project lifecycle methodology — 18 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, self-review mode.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.14.1] - 2026-04-11
+
+PATCH release. Closes the last cheap structural win deferred from v1.14.0 deliberation: **M-I9 caller-skill tool superset gate**. Adds a new formal frontmatter field `report_only: true` to make read-only skill contracts auditable. Pure defense-in-depth addition — zero user-facing behaviour change, zero cost, catches one previously-invisible class of regression.
+
+### Audit context
+
+During v1.14.0 deliberation we walked through five possible Defense-in-depth layers for subagent contracts and found that four of them (runtime self-check, schema validation, integration test duplication, latency-inducing pre-flight gates) had measurable UX cost for marginal value. Only **M-I9** (caller-skill tool superset check) passed the cost/benefit bar: ~30 lines of Python, zero user cost, catches a real class of bug where a skill delegates to a read-only subagent but lacks `Write`/`Edit` itself and cannot persist the output.
+
+Rather than ship M-I9 in the same v1.14.0 PR (which was already doing four things), we split it into v1.14.1 as a focused single-purpose patch.
+
+### Added
+
+- **`tests/meta_review.py` — new gate `M-I9`** — for every skill with a `agent: X` frontmatter field, validates the three legitimate patterns:
+  - **Pattern A** — subagent is read-only, skill has `Write`/`Edit` (example: `/blueprint → architect`, `/perf → perf-analyzer`). Most common.
+  - **Pattern B** — skill AND subagent both read-only, skill declared `report_only: true` (example: `/review → code-reviewer`). Pure audit chain, no mutations anywhere.
+  - **Pattern C** — subagent has `Write`/`Edit` itself (forward compatibility; no current agents match this, but the gate permits it).
+  - **M-I9a** (Critical) — `agent: X` refers to a non-existent agent. Catches typos and rename misses.
+  - **M-I9b** (Critical) — both skill and subagent read-only without `report_only: true`. Catches skills that forgot to add `Write`/`Edit` when they silently need to persist output, and prevents silent-write-failure regressions in future skills.
+- **`skills/review/SKILL.md`** — added `report_only: true` frontmatter field. Formalizes the `/review` contract that has been implicit since v1.0.0: `/review` produces audit reports to stdout, never mutates files. This unblocks M-I9b for the `/review → code-reviewer` pair.
+
+### New frontmatter field: `report_only`
+
+`report_only: true` is a new optional frontmatter field for skills whose entire contract is "produce a report to stdout, apply no mutations". Currently used only by `/review`. Candidates for future adoption (not in v1.14.1 scope, to avoid mixing structural changes with the gate):
+- `/security-audit` — read-only OWASP-style audit with optional fix suggestions (no patches applied).
+- `/deps-audit` — read-only CVE/license/abandoned-package audit.
+- `/explain` — read-only walkthrough, stdout only.
+- `/project`, `/task` — routers that only print routing decisions.
+
+Claude Code ignores unknown frontmatter fields, so there is no compatibility risk. The field is purely contract metadata for the methodology's own gates.
+
+### Changed
+
+- **`.claude-plugin/plugin.json`** — version `1.14.0` → `1.14.1`.
+- **`.claude-plugin/marketplace.json`** — `plugins[0].version` `1.14.0` → `1.14.1`.
+- **`README.md`** / **`README.ru.md`** — version badges `1.14.0` → `1.14.1`.
+
+### Why PATCH, not MINOR
+
+No new behaviour surface for users:
+- Only one skill got a new frontmatter field, and it is internally-consumed metadata, not a new capability.
+- The M-I9 gate is CI-only, invisible to end users.
+- No trigger changes, no keyword changes, no new checks that block the user's own workflow.
+
+Per SemVer this is a PATCH release — a bug-prevention fix, not a feature addition.
+
+### Migration
+
+```bash
+git pull
+bash scripts/sync-to-active.sh
+python3 tests/meta_review.py --verbose
+```
+
+No configuration changes required. The gate runs on the maintainer's CI only; end users of the plugin see nothing different.
+
+### What the gate catches
+
+Concrete regression scenarios this gate prevents:
+
+1. **Typo in agent rename.** If v2.0.0 renames `code-reviewer` → `reviewer` and misses one `agent:` reference, M-I9a fires Critical.
+2. **New skill `/audit` with forgotten Write/Edit.** If a contributor adds a skill with `agent: code-reviewer` and `allowed-tools: Read Glob Grep` without declaring it report-only, M-I9b fires Critical before the PR can merge.
+3. **Silent removal of Write/Edit from an existing skill.** If `/blueprint` loses `Write Edit` in a refactor, M-I9b fires because `architect` is read-only and `/blueprint` is not declared report_only.
+
+### 10/10 structural tier
+
+This PR closes the last cheap structural win identified in the v1.13.2 audit. The methodology now has **14 Critical + 8 Important** meta-review checks, covering every class of drift previously observed in v1.4.0 → v1.13.2 history. Further structural hardening would require significantly more complex machinery (LLM-as-judge, snapshot testing, runtime integration checks) and enters the behavioural tier — next target for v1.15.0.
+
+---
+
 ## [1.14.0] - 2026-04-11
 
 Polish release closing the three Nice-to-have items from the v1.13.2 qualitative audit, plus a new `M-I8` meta-review gate that makes the subagent contract pattern auditable and regression-proof. All improvements are backward-compatible additions — MINOR bump, no user-facing behaviour changes.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#skills)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#subagents)
-[![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.14.1](https://img.shields.io/badge/Version-1.14.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#скиллы)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#субагенты)
-[![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.14.1](https://img.shields.io/badge/Version-1.14.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -6,6 +6,7 @@ license: MIT
 allowed-tools: Read Glob Grep
 context: fork
 agent: code-reviewer
+report_only: true
 metadata:
   author: HiH-DimaN
   version: 1.13.0

--- a/tests/meta_review.py
+++ b/tests/meta_review.py
@@ -408,6 +408,77 @@ def run_rubric(repo: Path) -> Report:
     except Exception as e:
         r.imp("M-C11", f"could not run verify_triggers.py: {e}")
 
+    # --- M-I9: caller-skill tool superset over delegated subagent (v1.14.1) ---
+    # When a skill delegates to a subagent via frontmatter `agent: X`, there
+    # are three contract-consistent patterns:
+    #
+    #   Pattern A: subagent is read-only, skill has Write/Edit
+    #     → subagent returns structured text, skill persists it.
+    #     Examples: /blueprint → architect, /perf → perf-analyzer.
+    #
+    #   Pattern B: skill AND subagent both read-only, skill is report_only
+    #     → entire chain produces stdout reports, nothing is written.
+    #     Example: /review → code-reviewer (audit output to user).
+    #     Requires explicit `report_only: true` in skill frontmatter.
+    #
+    #   Pattern C: subagent has Write/Edit itself
+    #     → subagent writes files directly in its forked context.
+    #     Currently no such agent exists (all 5 are read-only by design),
+    #     but the gate permits this for forward compatibility.
+    #
+    # Anything outside these three patterns is a bug. Critical findings:
+    #   - M-I9a: `agent: X` refers to non-existent agent (typo / rename miss)
+    #   - M-I9b: both read-only + missing `report_only: true` → silent write
+    #     failures when the skill tries to persist subagent output
+    agents_tools: dict[str, str] = {}
+    if agents_dir.is_dir():
+        for agent_md in sorted(agents_dir.glob("*.md")):
+            fm_a, _ = read_frontmatter(agent_md)
+            agents_tools[agent_md.stem] = fm_a.get("allowed-tools", "")
+
+    write_tool_re = re.compile(r"\b(?:Write|Edit|MultiEdit)\b")
+    for skill in skills:
+        sd = skills_dir / skill
+        fm, _ = read_frontmatter(sd / "SKILL.md")
+        agent_ref = fm.get("agent", "").strip()
+        if not agent_ref:
+            continue
+        # Strip inline comments in frontmatter value (the `#` case)
+        agent_ref = agent_ref.split("#", 1)[0].strip().strip('"').strip("'")
+        if not agent_ref:
+            continue
+        if agent_ref not in agents_tools:
+            r.crit(
+                "M-I9a",
+                f"/{skill}: frontmatter `agent: {agent_ref}` points to "
+                f"non-existent subagent. Available: {sorted(agents_tools)}",
+            )
+            continue
+
+        agent_has_write = bool(write_tool_re.search(agents_tools[agent_ref]))
+        skill_has_write = bool(write_tool_re.search(fm.get("allowed-tools", "")))
+
+        # Parse report_only flag, stripping inline comments
+        report_only_raw = fm.get("report_only", "false")
+        report_only_value = report_only_raw.split("#", 1)[0].strip().lower()
+        skill_is_report_only = report_only_value == "true"
+
+        if agent_has_write:
+            continue  # Pattern C
+        if skill_has_write:
+            continue  # Pattern A
+        if skill_is_report_only:
+            continue  # Pattern B
+        r.crit(
+            "M-I9b",
+            f"/{skill}: delegates to read-only subagent `{agent_ref}` "
+            f"(allowed-tools: {agents_tools[agent_ref]!r}) but has no Write/Edit itself "
+            f"and no `report_only: true` in frontmatter. Either add Write/Edit to "
+            f"the skill (if it must persist subagent output) or add "
+            f"`report_only: true` to formally declare the skill produces only "
+            f"stdout reports.",
+        )
+
     # --- M-I8: subagent contract — read-only agents must declare it (v1.14.0) ---
     # Any `agents/*.md` whose `allowed-tools` frontmatter does NOT include
     # Write/Edit must say so EXPLICITLY in its body — otherwise the model


### PR DESCRIPTION
## Summary

PATCH release closing the **last cheap structural win** identified during v1.13.2/v1.14.0 Defense-in-depth deliberation. Adds one new meta-review gate (`M-I9`) + one new formal frontmatter field (`report_only: true`) to make the subagent-delegation contract auditable and regression-proof. Zero user-facing changes, pure CI-level defense-in-depth.

### What `M-I9` checks

For every skill with a `agent: X` frontmatter field, validates that one of three legitimate patterns holds:

| Pattern | Subagent tools | Skill tools | Example |
|---|---|---|---|
| **A** | read-only | has Write/Edit | `/blueprint → architect`, `/perf → perf-analyzer` |
| **B** | read-only | read-only + `report_only: true` | `/review → code-reviewer` |
| **C** | has Write/Edit | any | (none currently; forward compat) |

Anything outside these three patterns is a bug:
- **M-I9a (Critical)** — `agent: X` refers to non-existent subagent. Catches typos and missed renames.
- **M-I9b (Critical)** — both skill and subagent read-only without `report_only: true`. Catches silent-write-failure scenarios where a skill needs to persist subagent output but forgot Write/Edit.

### New frontmatter field: `report_only: true`

Formalizes the contract of skills that produce only stdout reports and apply no mutations. Currently used by `/review` (which has always been read-only but never declared it formally).

Claude Code ignores unknown frontmatter fields, so there is **zero compatibility risk**. The field is pure contract metadata for the methodology's own gates.

Candidates for future adoption (deferred, not in v1.14.1 scope):
- `/security-audit`, `/deps-audit`, `/explain`, `/project`, `/task`

### Why PATCH, not MINOR

No new user behaviour surface:
- Only one skill gained a new frontmatter field (internal metadata).
- The M-I9 gate is CI-only, invisible to end users.
- No new trigger phrases, no new keywords, no changes to any user-facing instruction.

Per SemVer this is strictly a bug-prevention fix. MINOR would be wrong because nothing new is exposed to users.

### Gate worked during development

Running `meta_review.py` immediately after adding M-I9 surfaced one Critical finding:

```
M-I9b: /review: delegates to read-only subagent code-reviewer but has no
Write/Edit itself and no `report_only: true` in frontmatter.
```

This is exactly the class of bug M-I9 is supposed to catch — `/review` has always been read-only, but the contract was implicit. Adding `report_only: true` formalizes it and unblocks the gate. Confirmation that the check works as designed before merging.

### Concrete regressions this prevents

1. **Agent rename miss** — if v2.0.0 renames `code-reviewer → reviewer` and misses one `agent:` reference, M-I9a fires Critical before the PR can merge.
2. **New skill `/audit` with forgotten Write/Edit** — if a contributor adds a skill with `agent: code-reviewer` and `allowed-tools: Read Glob Grep` without declaring it report-only, M-I9b fires.
3. **Silent removal of Write/Edit from an existing skill** — if `/blueprint` loses `Write Edit` in a refactor, M-I9b fires because `architect` is read-only and `/blueprint` has no `report_only: true`.

### Verified locally

```
python3 tests/meta_review.py --verbose
=== META-REVIEW (idea-to-deploy @ /home/hihol/projects/idea-to-deploy) ===
Critical (0):
Important (0):
FINAL STATUS: PASSED
```

### 10/10 structural tier

This PR closes the last cheap structural win identified in the v1.13.2 qualitative audit. The methodology now has **14 Critical + 8 Important** meta-review checks covering every class of drift observed across the v1.4.0 → v1.14.0 history.

Further structural hardening would require more complex machinery (runtime integration tests, LLM-as-judge, snapshot diffing) and enters the **behavioural tier**, which is the target for v1.15.0.

### What's deferred to v1.15.0

**Snapshot testing for behavioural fixtures.** Documented in `tests/README.md` since v1.13.2 as one of three future automation paths. Requires a POC of non-interactive Claude Code SDK invocation + CI compute cost estimate before full rollout. Starting work on this after v1.14.1 merges.

### Push mechanics note

Landed via `gh api graphql createCommitOnBranch` — `git push` over SSH/HTTPS still hangs in the maintainer's WSL environment (tracked in `memory/session_2026-04-11.md`). Content-identical to what a normal push would produce; only the parent-chain differs from local git state.

## Test plan

- [ ] CI meta-review workflow passes (expected green)
- [ ] After merge: `grep -c 'report_only' skills/*/SKILL.md` returns 1 (`/review` only)
- [ ] After merge: `bash scripts/sync-to-active.sh` picks up the new /review SKILL.md without drift-detection warnings
- [ ] Spot-check: `python3 tests/meta_review.py --verbose` reports `Critical (0), Important (0), FINAL STATUS: PASSED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)