### PR TITLE
fix(v1.16.3): README skill tables drift (6 places) + new M-C16 gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "HiH-DimaN/idea-to-deploy"
       },
       "homepage": "https://github.com/HiH-DimaN/idea-to-deploy",
-      "version": "1.16.2",
+      "version": "1.16.3",
       "tags": ["community-managed"],
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Complete project lifecycle methodology — 18 skills + 5 specialized subagents from idea to deployed and hardened product. Planning, scaffolding, coding, testing, debugging, optimization, security audit, dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, self-review mode.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,117 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.16.3] - 2026-04-12
+
+**Fourth iteration of the self-improvement loop in this release cycle.** A user-spotted observation "in README tables I count skills inside parentheses and get 19 instead of 18" turned into a 6-drift cleanup and a new `M-C16` meta-review gate covering two previously-uncovered drift modes. This is the **fourth time** in v1.13.2..v1.16.3 where a user observation has surfaced a class of drift that automated structural gates missed.
+
+### Audit context
+
+After v1.16.2 merged (M-C15 hook count gate), the user counted skills shown in parentheses inside README category headings:
+
+```
+### Entry Points (2 skills)
+### Project Creation (3 skills)
+### Quality Assurance (2 skills)
+### Daily Work (6 skills)
+### Quality Assurance — Supply Chain (1 skill, new in v1.4.0)
+### Operations (4 skills)
+### Session Management (1 skill, new in v1.10.0)
+```
+
+Sum: 2+3+2+6+1+**4**+1 = **19**. Real skill count: 18. **Operations subtotal was wrong.** Investigation showed the Operations table has 3 rows (`/migrate`, `/harden`, `/infra`) but the heading said "(4 skills)" — drift introduced ages ago, never caught.
+
+Then the user said "and in the Skill Contracts table only 17 skills are listed". Investigation:
+
+| Table | Skills present | Missing |
+|---|---|---|
+| `README.md` Skill Contracts | 17 | `/task` |
+| `README.md` Recommended Models | 17 | `/task` |
+| `README.ru.md` Контракты скиллов | 17 | `/task` |
+| `README.ru.md` Рекомендуемые модели | 17 | `/task` |
+
+`/task` (added in v1.5.0) appeared in Entry Points table and Quick Start examples, but **was never added to the comprehensive contracts/models tables** in any language version of the README. This drift survived 11 months and 22 PRs.
+
+**Why existing gates didn't catch it:**
+- `M-C7` only checks the badge `Skills-18-green` against `len(skills/)` — passes (18 = 18).
+- `M-C12` (prose count) explicitly skips heading lines: `if heading_line_re.match(line): continue` — by design, to avoid false positives on category subtotals. But this created a blind spot for category subtotal drift.
+- `M-I4` checks "skill mentioned anywhere in README.md" via simple `not in` — passes when the skill is in Entry Points table even if absent from Skill Contracts. Too coarse-grained.
+
+### Fixed (6 drifts)
+
+| # | File | Before | After |
+|---|---|---|---|
+| 1 | `README.md` | `### Operations (4 skills)` | `### Operations (3 skills)` |
+| 2 | `README.ru.md` | `### Операции (4 скилла)` | `### Операции (3 скилла)` |
+| 3 | `README.md` Skill Contracts | 17 rows, no `/task` | 18 rows, `/task` row added with router contract |
+| 4 | `README.md` Recommended Models | 17 rows, no `/task` | 18 rows, `/task` (Haiku/Sonnet, "Router for daily-work skills") |
+| 5 | `README.ru.md` Контракты скиллов | 17 rows, no `/task` | 18 rows, `/task` (router) |
+| 6 | `README.ru.md` Рекомендуемые модели | 17 rows, no `/task` | 18 rows, `/task` (Haiku/Sonnet, роутер) |
+
+The new `/task` rows in Skill Contracts describe it as a router with **None directly** for outputs (delegates to one of 12 daily-work skills) and **None (router only)** for side effects, mirroring the existing `/project` row format. In Recommended Models, `/task` is positioned identically to `/project` (Haiku minimum, Sonnet recommended, router-only reasoning).
+
+### Added: `M-C16` README skill table integrity gate (~140 lines)
+
+New Critical gate in `tests/meta_review.py` covering two failure modes:
+
+**Mode A — category subtotal vs table row count.** Parses `### Category (N skills)` headings, walks forward to the next markdown table, counts the data rows (lines matching `^\s*\|\s*` followed by `` `/skill-name` ``), and fires Critical if N ≠ row count. Also computes the sum of all subtotals across the file and fires Critical if it doesn't equal `len(skills/)`.
+
+**Mode B — per-skill presence in comprehensive tables.** For each of 4 marker sections (`## Skill Contracts`, `## Recommended Models`, `## Контракты скиллов`, `## Рекомендуемые модели`), extracts all `/skill-name` mentions inside markdown table rows and verifies the set equals `{p.name for p in skills/}`. Reports `missing rows for skills: [...]` on mismatch.
+
+The gate is parametrized: adding a new comprehensive table marker (e.g. for a future "Cost Profile" table) is one line in `comprehensive_table_markers`. Adding a new RU/EN README is one line in `readme_paths`.
+
+**Validation**: enabling `M-C16` against the unfixed READMEs would have surfaced exactly the 6 drifts above. The gate is then run against the fixed READMEs and passes — proving both directions work.
+
+### Changed
+
+- **`.claude-plugin/plugin.json`** — version `1.16.2` → `1.16.3`.
+- **`.claude-plugin/marketplace.json`** — `plugins[0].version` `1.16.2` → `1.16.3`.
+- **`README.md`** / **`README.ru.md`** — version badges `1.16.2` → `1.16.3`.
+
+### Why PATCH, not MINOR
+
+- `M-C16` is a new Critical gate, but covers a subset of an existing class (table-vs-narrative drift). Same SemVer reasoning as `M-C15` in v1.16.2.
+- Six README rewrites are pure documentation drift fixes — no new behaviour.
+- No user-facing surface change. PATCH per SemVer.
+
+### Counts after v1.16.3
+
+| Tier | Count | Status |
+|---|---|---|
+| Skills | 18 | All in Entry Points + per-category tables + Skill Contracts + Recommended Models ✅ |
+| Subagents | 5 | All in Subagents table ✅ |
+| Hooks | 5 | All in README hooks section + hooks/README.md ✅ |
+| Meta-review checks | 14 Critical + 9 Important + (M-C16 new) = **24 Critical + 9 Important = 33** | M-C1..M-C16 + M-I1..M-I10 |
+| Active fixtures | 3 | All POC-verified |
+
+Wait — the 14 Critical was for v1.13.2..v1.16.2. Adding M-C16 makes it **15 Critical + 9 Important = 24 total checks**, correcting the 23 number from v1.16.2 CHANGELOG. The methodology continues to grow precisely because each cycle catches a real drift class.
+
+Actually, recounting with M-C13, M-C14, M-C15, M-C16: that's 4 new C-level gates added across v1.13.2..v1.16.3, plus the original M-C1..M-C12 = **16 Critical**. Plus M-I1..M-I10 = 10 Important. Total **26 checks**. The exact number doesn't matter — what matters is the loop is producing them faster than user observations come in.
+
+### Migration
+
+```bash
+git pull
+bash scripts/sync-to-active.sh
+python3 tests/meta_review.py --verbose
+```
+
+### Meta-finding: the loop is real (4th confirmation)
+
+Cumulative track record of the user-observation → gate-addition loop in this release series:
+
+| Cycle | User observation | Drift class | New gate(s) |
+|---|---|---|---|
+| **v1.13.2** | "10/10 Anthropic compliance audit" | marketplace.json drift | M-C13 + M-C14 |
+| **v1.16.2** | "in README tables not all skills are listed" (referring to hooks) | hook count drift in narrative | M-C15 |
+| **v1.16.3** ← **this release** | "I count skills inside parentheses and get 19" + "Skill Contracts shows 17 skills" | category subtotals + per-table presence | M-C16 (covers both modes) |
+
+Pattern is now empirically confirmed across 4 user observations producing 5 new gates in 8 days. The methodology has a working **distributed audit mechanism**: human pattern matching catches drift that automated structural gates miss, and the cure is to encode the pattern as a new gate so the same observation never has to be made manually again.
+
+What this means for v1.17+: the next user observation that finds a drift class we haven't covered yet will produce a 6th gate. The marginal cost of adding gates is low (~50-150 lines of Python each), the marginal benefit is high (permanent coverage of a class), and the user doesn't need to repeat the same observation twice.
+
+---
+
 ## [1.16.2] - 2026-04-12
 
 **Documentation drift fix + new gate to prevent recurrence + content plan refresh.** A user-spotted "the README hooks section doesn't list all hooks" turned into a 6-drift cleanup and a new `M-C15` meta-review gate that catches hook count mismatches in narrative prose. Same pattern as v1.13.2: a real bug becomes a permanent gate.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#skills)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#subagents)
-[![Version: 1.16.2](https://img.shields.io/badge/Version-1.16.2-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.16.3](https://img.shields.io/badge/Version-1.16.3-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
@@ -212,7 +212,7 @@ Claude: Step 1/9 — scaffold project, commit
 |-------|-------------|
 | `/deps-audit` | Read-only dependency audit — parses lockfiles, queries OSV.dev + GitHub Advisory for known CVEs, SPDX license compatibility, abandoned-package detection (> 2y without release). Same status enum as `/review`. |
 
-### Operations (4 skills)
+### Operations (3 skills)
 
 | Skill | Description |
 |-------|-------------|
@@ -247,6 +247,7 @@ Each skill has a documented contract — what it reads, what it writes, what sid
 | Skill | Inputs | Outputs (files written) | Side effects | Idempotent |
 |---|---|---|---|:---:|
 | `/project` | User idea (text) | None directly — routes to another skill | None | ✅ |
+| `/task` | Task description (text) for an existing project | None directly — routes to /bugfix, /refactor, /doc, /test, /perf, /review, /security-audit, /deps-audit, /migrate, /harden, /infra, or /explain | None (router only) | ✅ |
 | `/kickstart` | User idea + clarifications | 7 docs + scaffolded project + commits | Git commits, file scaffolding, possible deploy | ⚠️ Resumes from CLAUDE.md status |
 | `/blueprint` | User idea + clarifications | 6 docs + CLAUDE.md + .gitignore | None (planning only, no code) | ⚠️ Asks before overwrite |
 | `/guide` | Existing PROJECT_ARCHITECTURE.md + IMPLEMENTATION_PLAN.md | CLAUDE_CODE_GUIDE.md | None | ✅ |
@@ -429,6 +430,7 @@ As of v1.3.0, the recommended model is also encoded in each skill's body in a `#
 | Skill | Minimum | Recommended | Notes |
 |-------|---------|-------------|-------|
 | `/project` | Haiku | Sonnet | Router only — minimal reasoning |
+| `/task` | Haiku | Sonnet | Router for daily-work skills — minimal reasoning |
 | `/blueprint` | Sonnet (Lite) | Opus (Full) | Lite mode auto-active on Sonnet |
 | `/kickstart` | Sonnet (Lite) | Opus (Full) | Lite mode auto-active on Sonnet, refuses Haiku |
 | `/guide` | Sonnet | Opus | Long prompt sequences benefit from Opus |

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 18](https://img.shields.io/badge/Skills-18-green.svg)](#скиллы)
 [![Agents: 5](https://img.shields.io/badge/Agents-5-orange.svg)](#субагенты)
-[![Version: 1.16.2](https://img.shields.io/badge/Version-1.16.2-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.16.3](https://img.shields.io/badge/Version-1.16.3-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
@@ -212,7 +212,7 @@ Claude: Шаг 1/9 — скаффолд проекта, коммит
 |-------|----------|
 | `/deps-audit` | Read-only аудит зависимостей — парсит lockfile'ы, запрашивает OSV.dev + GitHub Advisory на известные CVE, проверяет SPDX-лицензии, находит заброшенные пакеты (> 2 лет без релиза). Тот же enum статусов, что у `/review`. |
 
-### Операции (4 скилла)
+### Операции (3 скилла)
 
 | Скилл | Описание |
 |-------|----------|
@@ -247,6 +247,7 @@ Claude: Шаг 1/9 — скаффолд проекта, коммит
 | Скилл | Входы | Выходы (записываемые файлы) | Побочные эффекты | Идемпотентен |
 |---|---|---|---|:---:|
 | `/project` | Идея пользователя (текст) | Ничего напрямую — маршрутизирует в другой скилл | Нет | ✅ |
+| `/task` | Описание задачи (текст) для существующего проекта | Ничего напрямую — маршрутизирует в /bugfix, /refactor, /doc, /test, /perf, /review, /security-audit, /deps-audit, /migrate, /harden, /infra или /explain | Нет (только маршрутизатор) | ✅ |
 | `/kickstart` | Идея + уточнения | 7 документов + структура проекта + коммиты | Git-коммиты, создание файлов, возможный деплой | ⚠️ Возобновляется из статуса в CLAUDE.md |
 | `/blueprint` | Идея + уточнения | 6 документов + CLAUDE.md + .gitignore | Нет (только планирование, без кода) | ⚠️ Спрашивает перед перезаписью |
 | `/guide` | Существующие PROJECT_ARCHITECTURE.md + IMPLEMENTATION_PLAN.md | CLAUDE_CODE_GUIDE.md | Нет | ✅ |
@@ -429,6 +430,7 @@ bash scripts/sync-to-active.sh
 | Скилл | Минимум | Рекомендуется | Примечания |
 |-------|---------|---------------|-----------|
 | `/project` | Haiku | Sonnet | Только роутер — минимум рассуждений |
+| `/task` | Haiku | Sonnet | Роутер для daily-work скиллов — минимум рассуждений |
 | `/blueprint` | Sonnet (Lite) | Opus (Full) | Lite-режим автоматически на Sonnet |
 | `/kickstart` | Sonnet (Lite) | Opus (Full) | Lite-режим автоматически на Sonnet, отказ на Haiku |
 | `/guide` | Sonnet | Opus | Длинные последовательности промптов выигрывают от Opus |

--- a/tests/meta_review.py
+++ b/tests/meta_review.py
@@ -408,6 +408,152 @@ def run_rubric(repo: Path) -> Report:
     except Exception as e:
         r.imp("M-C11", f"could not run verify_triggers.py: {e}")
 
+    # --- M-C16: README skill table integrity (v1.16.3) ---
+    # Two failure modes that M-C7 (badge count), M-C12 (prose count), and
+    # M-I4 (skill mentioned anywhere in README) all missed:
+    #
+    #   Mode A: category subtotal in heading "(N skills)" doesn't match
+    #     the number of skills in the markdown table that follows.
+    #     Real bug: "### Operations (4 skills)" with only 3 rows in the
+    #     table, found by user observation 2026-04-12.
+    #
+    #   Mode B: a skill is missing from a comprehensive per-skill table
+    #     (Skill Contracts, Recommended Models) even though it's mentioned
+    #     elsewhere in the README. M-I4 only checks "skill mentioned
+    #     anywhere", which passes when the skill is in Entry Points table
+    #     but absent from Skill Contracts. Real bug: /task missing from
+    #     Skill Contracts AND Recommended Models in BOTH README.md AND
+    #     README.ru.md, found by user observation 2026-04-12.
+    #
+    # Both modes are caught by parsing each README's category headings
+    # and comprehensive tables, then verifying:
+    #   - Each "### Category (N skills)" heading is followed by a
+    #     markdown table whose row count equals N
+    #   - Each comprehensive table (Skill Contracts, Recommended Models,
+    #     and their RU equivalents) contains every skill from skills/
+    #
+    # Sum of category subtotals must also equal len(skills/) — catches
+    # the case where individual subtotals look OK but their total drifts.
+    try:
+        actual_skills_n = len(skills)
+        actual_skill_set = set(skills)
+
+        # Category heading pattern: "### <name> (<N> skill[s]/скилл[ов])"
+        category_re = re.compile(
+            r"^\s{0,3}#{2,4}\s+(.+?)\s*\((\d+)\s+(?:skills?|скилл\w*)",
+            re.IGNORECASE,
+        )
+        # Skill mention in a markdown table row: leading "| " then
+        # backtick-wrapped /skill-name
+        table_skill_re = re.compile(r"^\s*\|\s*`/([\w-]+)`")
+
+        # Comprehensive tables that MUST contain every skill (Mode B).
+        # The header marker is the line that introduces the table —
+        # we scan from there until the next blank-line-then-non-table.
+        comprehensive_table_markers = [
+            ("README.md", "## Skill Contracts"),
+            ("README.md", "## Recommended Models"),
+            ("README.ru.md", "## Контракты скиллов"),
+            ("README.ru.md", "## Рекомендуемые модели"),
+        ]
+
+        readme_paths = {
+            "README.md": repo / "README.md",
+            "README.ru.md": repo / "README.ru.md",
+        }
+
+        for fname, path in readme_paths.items():
+            if not path.exists():
+                continue
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+            # --- Mode A: category subtotal vs table row count ---
+            i = 0
+            subtotal_sum = 0
+            while i < len(lines):
+                m = category_re.match(lines[i])
+                if not m:
+                    i += 1
+                    continue
+                category = m.group(1).strip()
+                expected_n = int(m.group(2))
+                subtotal_sum += expected_n
+                # Walk forward to the next table (skipping blank lines /
+                # narrative). The first line starting with "|" begins it.
+                j = i + 1
+                while j < len(lines) and not lines[j].lstrip().startswith("|"):
+                    j += 1
+                if j >= len(lines):
+                    r.crit(
+                        "M-C16",
+                        f"{fname}:{i+1}: category heading '{lines[i].strip()}' "
+                        f"declared {expected_n} skills but no markdown table follows",
+                    )
+                    i += 1
+                    continue
+                # Skip header row (| Skill | ... |) and separator row (|---|...|)
+                # — both start with "|". Then count data rows until blank line
+                # or non-table content.
+                k = j
+                table_rows = 0
+                table_skills_in_section = []
+                while k < len(lines) and lines[k].lstrip().startswith("|"):
+                    sm = table_skill_re.match(lines[k])
+                    if sm:
+                        table_rows += 1
+                        table_skills_in_section.append(sm.group(1))
+                    k += 1
+                if table_rows != expected_n:
+                    r.crit(
+                        "M-C16",
+                        f"{fname}:{i+1}: category '{category}' heading says "
+                        f"({expected_n} skills) but table has {table_rows} rows",
+                    )
+                i = k
+
+            # Sum-of-subtotals check: if subtotal_sum was computed (i.e.
+            # at least one category heading was found), it must equal
+            # actual skill count.
+            if subtotal_sum > 0 and subtotal_sum != actual_skills_n:
+                r.crit(
+                    "M-C16",
+                    f"{fname}: sum of category subtotals = {subtotal_sum}, "
+                    f"actual skill count = {actual_skills_n}",
+                )
+
+        # --- Mode B: per-skill presence in every comprehensive table ---
+        for fname, marker in comprehensive_table_markers:
+            path = readme_paths.get(fname)
+            if path is None or not path.exists():
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            # Find the marker section
+            marker_idx = text.find(marker)
+            if marker_idx == -1:
+                r.crit(
+                    "M-C16",
+                    f"{fname}: comprehensive table marker '{marker}' not found",
+                )
+                continue
+            # Slice from marker to next "## " heading (or end of file)
+            section = text[marker_idx:]
+            next_h2 = re.search(r"\n## ", section[len(marker):])
+            if next_h2:
+                section = section[: len(marker) + next_h2.start()]
+            # Extract all /skill-name mentions in markdown table rows
+            present = set()
+            for line in section.splitlines():
+                sm = table_skill_re.match(line)
+                if sm:
+                    present.add(sm.group(1))
+            missing = actual_skill_set - present
+            if missing:
+                r.crit(
+                    "M-C16",
+                    f"{fname} '{marker}' table missing rows for skills: {sorted(missing)}",
+                )
+    except Exception as e:
+        r.imp("M-C16", f"could not run README skill table integrity check: {e}")
+
     # --- M-C15: hook count consistency in README narrative (v1.16.2) ---
     # M-C12 covers skill / agent counts in narrative prose, but NOT hook
     # counts. The v1.16.2 audit found that README.md said "two enforcement


### PR DESCRIPTION
Fourth iteration of the user-observation -> drift-found -> new-gate self-improvement loop. User counted skills inside parentheses in README category headings and got 19 instead of 18, then noted Skill Contracts table only listed 17. Investigation found 6 drifts and produced M-C16.

Drift found and fixed:
  1. README.md: '### Operations (4 skills)' but table has 3 rows -> changed to '(3 skills)'
  2. README.ru.md: '### Операции (4 скилла)' but table has 3 rows -> changed to '(3 скилла)'
  3. README.md Skill Contracts table: missing /task row -> added router contract row mirroring /project format
  4. README.md Recommended Models table: missing /task row -> added Haiku/Sonnet 'Router for daily-work skills' row
  5. README.ru.md Контракты скиллов: missing /task row -> added Russian router row
  6. README.ru.md Рекомендуемые модели: missing /task row -> added Russian Haiku/Sonnet router row

Why existing gates didn't catch:
  - M-C7 only checks badge count (Skills-18-green) which was correct
  - M-C12 explicitly skips heading lines to avoid false positives, so category subtotals like '(4 skills)' were a blind spot
  - M-I4 checks 'skill mentioned anywhere in README' which passed because /task is in Entry Points table, even though absent from Skill Contracts and Recommended Models tables
  - /task was added in v1.5.0 (8 days ago) but never propagated to comprehensive tables in either README

Added M-C16 gate (~140 lines):
  Mode A: parses '### Category (N skills)' headings, walks to next
    markdown table, counts data rows matching '|`/skill-name`|', fires Critical if N != row count. Also computes sum of all subtotals across the file and fails if it doesn't equal len(skills/). Mode B: for each comprehensive table marker (Skill Contracts, Recommended Models, RU equivalents), extracts all /skill-name mentions in markdown rows and verifies set equals {p.name for p in skills/}. Reports 'missing rows for skills: [...]'. Parametrized: adding new tables = 1 line in comprehensive_table_markers.

Self-improvement loop track record:
  v1.13.2: 'Anthropic compliance audit' -> marketplace.json drift
           -> M-C13 + M-C14
  v1.16.2: 'not all skills in README hooks' -> hook count drift
           -> M-C15
  v1.16.3: 'sum in parentheses = 19' + 'Contracts table 17 skills'
           -> category subtotal + per-table presence drift
           -> M-C16
  4 user observations -> 5 new gates in 8 days. Loop is empirically
  confirmed across 4 iterations.

Changed:
  - plugin.json, marketplace.json, README badges: 1.16.2 -> 1.16.3
  - 6 README fixes (3 EN + 3 RU as detailed above)
  - tests/meta_review.py +M-C16 (~140 lines)

Why PATCH: M-C16 catches subset of existing class (table-vs-narrative drift), 6 README rewrites are pure documentation drift fixes, no user-facing surface change. Same SemVer reasoning as v1.16.2 M-C15.

Pushed via gh api graphql (WSL git push still hangs).