### PR TITLE
fix(v1.17.1): automatic safety guardrails — careful always-on, freeze auto-scoped

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -33,10 +33,9 @@ Layers 1–3 give fast local feedback. Layer 4 is the server-side last line of d
 | `careful.sh` | Before Bash (PreToolUse) | Detects destructive commands (rm -rf, DROP TABLE, git push --force, git reset --hard, chmod 777, pipe-to-bash) and injects a warning asking Claude to confirm with the user. Activated via `CAREFUL_MODE=1` env var or a state file. | No — soft warning only |
 | `freeze.sh` | Before Edit/Write/NotebookEdit (PreToolUse) | Restricts file modifications to a specific directory scope. Any edit outside the frozen scope triggers a warning. Activated via a state file written by `/freeze <path>`. Deactivated with `/unfreeze`. | No — soft warning only |
 
-**Activation:** These hooks are opt-in per session. They do nothing unless explicitly activated:
-- `/careful` → creates `/tmp/claude-careful-{session}.state` with content "active"
-- `/freeze src/auth` → creates `/tmp/claude-freeze-{session}.state` with content "src/auth"
-- `/unfreeze` → deletes the freeze state file
+**Activation:**
+- **`careful.sh`** — **always active** inside methodology repos (auto-detected via `.claude-plugin/plugin.json`). Outside methodology repos: opt-in via `CAREFUL_MODE=1` env var or state file.
+- **`freeze.sh`** — **automatic** when skills like `/bugfix`, `/refactor`, `/perf` start work (they write the scope to `/tmp/claude-freeze-{session}.state`). Can also be activated manually: `/freeze src/auth`. Deactivate with `/unfreeze` or skill completion.
 
 All seven hooks are written in Python 3 (works out of the box on macOS/Linux/WSL), depend only on the standard library, and exit silently in degenerate cases (bad JSON, empty payload, not in the methodology repo) — they never break your session on unrelated work.
 

--- a/hooks/careful.sh
+++ b/hooks/careful.sh
@@ -11,11 +11,10 @@ Does NOT block (exit 0, permissionDecision: allow) — it's a
 soft guardrail that adds friction, not a hard gate. The user
 can disable it by removing the hook from settings.json.
 
-Activation: set CAREFUL_MODE=1 env var, or the user says /careful
-in the session. The hook checks for a state file to persist
-activation across tool calls within a session.
-
-When NOT active: silent no-op (exit 0, no output).
+v1.17.0: Always active inside methodology repos (detected via
+.claude-plugin/plugin.json). No opt-in needed — safety is automatic.
+Outside methodology repos: opt-in via CAREFUL_MODE=1 env var or
+state file (backward-compatible with manual activation).
 
 Reads JSON on stdin: {"tool_name": "Bash", "tool_input": {"command": "..."}}
 """
@@ -62,8 +61,34 @@ def session_id() -> str:
         return "default"
 
 
+def find_methodology_repo() -> bool:
+    """Return True if cwd is inside a methodology repo."""
+    cwd = os.path.abspath(os.getcwd())
+    for parent in [cwd] + list(_parents(cwd)):
+        if os.path.isfile(os.path.join(parent, ".claude-plugin", "plugin.json")):
+            return True
+    return False
+
+
+def _parents(path: str):
+    """Yield parent directories up to root."""
+    while True:
+        parent = os.path.dirname(path)
+        if parent == path:
+            break
+        yield parent
+        path = parent
+
+
 def is_active() -> bool:
-    """Check if /careful mode is active for this session."""
+    """Check if /careful mode is active for this session.
+
+    Always active inside methodology repos (auto-detected).
+    Outside: opt-in via env var or state file.
+    """
+    # Auto-active inside methodology repos
+    if find_methodology_repo():
+        return True
     # Check env var
     if os.environ.get("CAREFUL_MODE") == "1":
         return True

--- a/hooks/freeze.sh
+++ b/hooks/freeze.sh
@@ -6,8 +6,14 @@ When active, restricts file modifications (Edit/Write/NotebookEdit) to
 a specific directory scope. Any attempt to modify files outside the
 frozen scope triggers a warning asking Claude to confirm with the user.
 
-Activation: user says "/freeze src/auth" → creates a state file with
-the allowed scope. Deactivated with "/unfreeze".
+Activation (two modes):
+1. Manual: user says "/freeze src/auth" → creates a state file
+2. Automatic (v1.17.0): skills like /bugfix, /refactor, /perf write
+   the freeze state file when they determine the target scope. The
+   skill writes to /tmp/claude-freeze-{session}.state before starting
+   work, and clears it on completion.
+
+Deactivated with "/unfreeze" or when the skill completes.
 
 State: /tmp/claude-freeze-{session}.state contains the allowed path
 prefix (e.g., "src/auth"). If empty or missing, freeze is inactive.

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -42,6 +42,17 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
+### Step 0: Auto-freeze scope (v1.17.0)
+
+After identifying the target file/directory from $ARGUMENTS or the error context, automatically activate scope freeze:
+
+```bash
+# Write freeze state — limits edits to the bug's directory
+echo "/path/to/bug/directory" > /tmp/claude-freeze-${CLAUDE_SESSION_ID:-default}.state
+```
+
+This prevents accidental edits outside the bug's scope during debugging. The freeze is cleared automatically when the skill completes (Step 5+). If the fix legitimately requires changes outside the frozen scope (e.g., a shared utility), the freeze hook will warn and ask for confirmation — which is correct behavior.
+
 ### Step 1: Reproduce
 Understand the exact symptoms. Find the error in logs/output.
 

--- a/skills/perf/SKILL.md
+++ b/skills/perf/SKILL.md
@@ -36,6 +36,17 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
+### Step 0: Auto-freeze scope (v1.17.0)
+
+After identifying the target file/directory from $ARGUMENTS or profiling results, automatically activate scope freeze:
+
+```bash
+# Write freeze state — limits edits to the optimization target
+echo "/path/to/perf/directory" > /tmp/claude-freeze-${CLAUDE_SESSION_ID:-default}.state
+```
+
+This prevents accidental edits outside the performance optimization scope. The freeze is cleared when the skill completes. If the optimization legitimately requires changes outside the frozen scope (e.g., adding a database index migration), the freeze hook will warn and ask for confirmation.
+
 ### Step 1: Profile
 Identify what exactly is slow. Read the code and look for:
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -34,6 +34,17 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
+### Step 0: Auto-freeze scope (v1.17.0)
+
+After identifying the target file/directory from $ARGUMENTS, automatically activate scope freeze:
+
+```bash
+# Write freeze state — limits edits to the refactoring target
+echo "/path/to/refactor/directory" > /tmp/claude-freeze-${CLAUDE_SESSION_ID:-default}.state
+```
+
+This prevents accidental edits outside the refactoring scope. The freeze is cleared when the skill completes. If the refactoring legitimately requires changes outside the frozen scope (e.g., updating callers), the freeze hook will warn and ask for confirmation.
+
 ### Step 1: Analyze
 Read the code, understand its purpose and ALL callers/usages.
 


### PR DESCRIPTION
## Summary
- **careful.sh**: always active inside methodology repos (auto-detect via `.claude-plugin/plugin.json`), no manual opt-in needed
- **freeze.sh**: auto-activated by `/bugfix`, `/refactor`, `/perf` when they identify target scope
- `/bugfix`, `/refactor`, `/perf`: added Step 0 auto-freeze scope
- hooks/README.md: updated activation docs

User feedback: "всё должно быть автоматически" — safety guardrails now fire without manual activation.

## Test plan
- [ ] CI meta-review passes
- [ ] `/careful` fires on destructive commands inside methodology repo without opt-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)