### PR TITLE
feat(v1.18.1): adversarial debates + decision trees + auto-sync

### DIFF
--- a/skills/session-save/SKILL.md
+++ b/skills/session-save/SKILL.md
@@ -210,6 +210,25 @@ The lockfile MUST be idempotent — it's rewritten on every `/session-save`
 call, never appended. Stale locks self-expire (the pre-flight hook
 ignores any lock older than 10 minutes).
 
+### Step 4.7: Auto-sync methodology (v1.18.1)
+
+If the current project IS the idea-to-deploy methodology repo (detected by
+`.claude-plugin/plugin.json` existence), run the sync script to propagate
+any changes to the active Claude Code install:
+
+```bash
+if [ -f ".claude-plugin/plugin.json" ]; then
+  bash scripts/sync-to-active.sh
+fi
+```
+
+This prevents the recurring bug where new skills/agents/hooks are added to
+the repo but not copied to `~/.claude/` (see: /discover not registered,
+business-analyst missing from global agents, 6 hooks missing after v1.18.0).
+
+**For non-methodology projects:** This step is a no-op (the guard clause
+skips it).
+
 ### Step 5: Confirm to user
 
 Tell the user:


### PR DESCRIPTION
## Summary
- New subagent: **devils-advocate** — adversarial architecture reviewer (Red/Blue Team for design)
- /blueprint Step 2.1: architecture **decision trees** (2-3 variants + trade-offs)
- /blueprint Step 2.5: **adversarial debate** protocol (Architect vs Devil's Advocate)
- /blueprint Step 2.6: **SAFe-inspired** patterns (Definition of Done, Architectural Runway, Sprint Boundaries)
- /session-save Step 4.7: **auto-sync** methodology repo → ~/.claude/ (prevents registration bugs)
- ## Self-validation added to all 20 skills (Anthropic compliance)
- Subagent count: 6 → 7 across all docs
- meta_review.py: **PASSED** (0 Critical)

## Test plan
- [x] meta_review.py passes (0 Critical)
- [x] sync-to-active.sh --check shows zero drift
- [x] All 20 trigger phrases fire correctly
- [x] All 11 hooks exit 0 on valid input
- [ ] Behavioural: /blueprint with adversarial debate on real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)