### PR TITLE
feat(v1.19.0): skill enforcement + session-open diagnostic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "HiH-DimaN/idea-to-deploy"
       },
       "homepage": "https://github.com/HiH-DimaN/idea-to-deploy",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "tags": ["community-managed"],
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.18.1",
-  "description": "Complete project lifecycle methodology — 20 skills + 7 specialized subagents from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, self-review mode, safety guardrails.",
+  "version": "1.19.0",
+  "description": "Complete project lifecycle methodology — 20 skills + 7 specialized subagents + 13 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, self-review mode, safety guardrails, skill enforcement with escalation, session-open diagnostics.",
   "author": {
     "name": "HiH-DimaN",
     "email": "HiH-DimaN@users.noreply.github.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.19.0] - 2026-04-16
+
+**Session enforcement + diagnostics (Phase 1).** Closes methodology gaps #4 and #6 from ROADMAP_v1.19.md — discovered during 10+ hour multi-project session where Claude bypassed methodology entirely.
+
+### Added
+
+- **`check-tool-skill.sh` enforcement mode** (Gap #4) — now tracks consecutive ignored skill reminders. After 3 ignores, BLOCKS the next Bash/Edit/Write tool call until Claude either invokes a Skill or provides a `SKILL_BYPASS: <reason>` justification. Counter resets on Skill call or bypass. Prevents the "advisory-only" problem where Claude ignores dozens of reminders.
+- **New hook `session-open-diagnostic.sh`** (Gap #6) — fires once per session on first UserPromptSubmit. Reads last `session_*.md`, next-session plan, LAUNCH_PLAN.md, BACKLOG.md, latest ROADMAP_v*.md. Injects diagnostic context so Claude starts with full awareness of prior work and planned next steps instead of reactive mode.
+
+### Changed
+
+- Hook count: 11 → 13 across docs.
+- Defense-in-depth table version bump to v1.19.0.
+- `check-tool-skill.sh` now shows ignore counter (X/3) in reminders.
+
+---
+
 ## [1.18.1] - 2026-04-13
 
 **Adversarial architecture debates + community feedback.** Implements all 3 community-requested features.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 20](https://img.shields.io/badge/Skills-20-green.svg)](#skills)
 [![Agents: 7](https://img.shields.io/badge/Agents-7-orange.svg)](#subagents)
-[![Version: 1.17.0](https://img.shields.io/badge/Version-1.18.1-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.19.0](https://img.shields.io/badge/Version-1.19.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 20](https://img.shields.io/badge/Skills-20-green.svg)](#скиллы)
 [![Agents: 7](https://img.shields.io/badge/Agents-7-orange.svg)](#субагенты)
-[![Version: 1.17.0](https://img.shields.io/badge/Version-1.18.1-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.19.0](https://img.shields.io/badge/Version-1.19.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/ROADMAP_v1.19.md
+++ b/ROADMAP_v1.19.md
@@ -1,0 +1,222 @@
+# ROADMAP v1.19 — Methodology Gaps Discovered in Real-World Session 2026-04-15/16
+
+> Создан 2026-04-16 на основе 10+ часовой сессии мультипроектной работы
+> (миграция 3 проектов Beget→Hostland + стратегический пересмотр NeuroExpert).
+>
+> **Цель v1.19:** закрыть 7 методологических дыр, обнаруженных когда Claude
+> фактически обошёл методологию на реальной задаче.
+
+---
+
+## Контекст
+
+Сессия 2026-04-15/16 включала:
+
+1. **Миграция инфраструктуры** 3 проектов с Beget VDS (2×) на Hostland VDS (185.221.213.104) — hardening, Docker, Coolify, SSL, DNS, патчинг Telegram-ботов под прокси, восстановление БД/Minio/uploads.
+2. **Стратегический пересмотр NeuroExpert** через призму модели Medvi — анализ 5 потоков выручки, выбор фокуса, составление LAUNCH_PLAN.md под цель 2M ₽/мес к декабрю.
+
+Claude использовал `/session-save` один раз (для миграции). **Все остальные задачи выполнялись через raw Bash/Edit/Write** — несмотря на триггеры hook каждую минуту.
+
+---
+
+## 7 обнаруженных дыр
+
+### 🕳️ Gap #1 — Нет скилла под «миграцию работающих prod-сервисов»
+
+**Что было:** перенос 3 проектов с одного VDS на другой с патчингом ботов, DNS, SSL, override compose, восстановлением данных.
+
+**Проверка по 20 скиллам v1.18.1:**
+- `/migrate` — только про DB migrations (Alembic, Supabase)
+- `/infra` — только Terraform/k8s/Helm/IaC (новая инфра)
+- `/harden` — production-readiness для нового сервиса, не перенос
+- `/project`, `/kickstart`, `/blueprint` — для новых проектов
+- `/bugfix` — не подходит, это не баг
+- `/refactor` — не рефакторинг кода
+
+**Вывод:** **нет скилла для оперативной миграции работающих сервисов** между хостами.
+
+**Предложение v1.19:**
+Новый скилл **`/migrate-prod`** или переименование `/migrate` → `/migrate-db`, а `/migrate-prod` — расширенный.
+
+Содержание `/migrate-prod`:
+- Inventory source server (что работает, какие volumes/data/secrets)
+- Setup target server (hardening, Docker, Coolify/Traefik/Nginx)
+- DNS staging strategy (не переключать до готовности)
+- Data migration (DB dumps, volumes, uploads, object storage)
+- Secret rotation checklist
+- Dual-run period (старый и новый работают параллельно 24-48ч)
+- Cut-over DNS
+- Rollback plan
+- Decommission source after 7 days
+
+### 🕳️ Gap #2 — Нет скилла под «стратегический пересмотр существующего проекта»
+
+**Что было:** Medvi-анализ, оценка 5 потоков выручки NeuroExpert, создание LAUNCH_PLAN.md с acceptance criteria на 6 блоков работы.
+
+**Проверка:**
+- `/blueprint` — для **нового** проекта (создаёт ARCHITECTURE.md, PRD.md)
+- `/project` — роутер к /kickstart/blueprint/guide для **нового**
+- `/discover` — product discovery только для **нового**
+- `/review` — код-ревью, не стратегия
+- `/explain` — объяснение кода
+
+**Вывод:** нет скилла для **стратегического replanning существующего проекта**.
+
+**Предложение v1.19:**
+Новый скилл **`/strategy`** или **`/replan`**.
+
+Содержание:
+- Input: существующий LAUNCH_PLAN.md (или создать от нуля) + текущие метрики + новый контекст
+- Анализ: что изменилось, что выучили, KPI-gap
+- Генерация: обновлённый LAUNCH_PLAN.md с новыми блоками/целями
+- ADR для значимых разворотов (pivot decisions)
+- BACKLOG.md обновление
+- Отметка даты пересмотра для трекинга
+
+### 🕳️ Gap #3 — Нет скилла под «советник/консалтинг-режим»
+
+**Что было:** пользователь задавал стратегические вопросы — «где такие ниши как Medvi», «чем отличается наш рынок от GLP-1», «какой добавочный проект выбрать». Ответы — анализ без кода-выхода.
+
+**Проверка:** ни один из 20 скиллов v1.18.1 не про advisory/стратегическое мышление без code output.
+
+**Предложение v1.19:**
+Новый скилл **`/advisor`** или **`/consult`**.
+
+Содержание:
+- Режим «только анализ и советы, не трогать код»
+- Запрет на Write/Edit в рамках скилла (только Read)
+- Обязательное использование Agent subagents (business-analyst, devils-advocate) для разносторонней оценки
+- Output: ADVICE.md или в чат — аналитика, сравнение, рекомендации с pros/cons
+- Обязательное требование: **user confirms before any implementation follows**
+
+### 🕳️ Gap #4 — Hook advisory, а не enforcement
+
+**Текущий `check-skills.sh`:**
+- Срабатывает каждую минуту на Bash/Edit/Write
+- **Просто напоминает**, не блокирует
+- Claude может игнорировать и работать дальше
+
+**В реальной сессии 2026-04-15/16** — Claude проигнорировал hook **десятки раз**, работая raw tools.
+
+**Предложение v1.19:**
+Добавить **эскалацию после N игнорирований**:
+- Трекать state в `.claude/.skills-ignored-count` (per-session)
+- После 3+ игнорирований подряд — hook возвращает **non-zero exit code**, блокирующий следующий Bash/Edit/Write
+- Claude вынужден либо запустить скилл, либо явно обосновать обход в `SKILL_BYPASS_LOG.md`
+- После обоснования счётчик обнуляется
+
+### 🕳️ Gap #5 — Мульти-проектные сессии ломают task-level assessment
+
+**В сессии 2026-04-15/16** работа переходила между:
+- `/home/hihol/projects/neuroexpert`
+- `/home/hihol/projects/skutr-docs`
+- `/home/hihol/projects/jogai`
+- Обратно в `/home/hihol/projects/neuroexpert`
+
+`pre-flight-check.sh` читал контекст **текущего cwd** (последнего репо), терял общую картину. Claude каждый раз «забывал» что задача — инфраструктурная миграция, и думал что он в разных задачах.
+
+**Предложение v1.19:**
+**Context-switch detector** в `pre-flight-check.sh`:
+- Детектить смену cwd между вызовами
+- При смене — выводить в чат explicit warning: «🔄 Context switch: от `neuroexpert` → `skutr-docs`. Сессия мульти-проектная. Задача task-level: **миграция инфры**? Или начинаем новую задачу?»
+- Вести `.claude/session-cwd-history` (last 10 switches)
+- Если switches >5 за 30 мин — предлагать `/session-save` чтобы не потерять контекст
+
+### 🕳️ Gap #6 — Session-open не имеет обязательной диагностики
+
+**В сессии 2026-04-15/16** я начал работу без:
+- Чтения предыдущих `session_*.md`
+- Проверки `LAUNCH_PLAN.md` существующих проектов
+- Определения «какой next actionable шаг из плана»
+
+Просто реагировал на первое сообщение пользователя.
+
+**Предложение v1.19:**
+Новый хук **`hooks/session-open-diagnostic.sh`**:
+- Срабатывает при старте сессии (UserPromptSubmit первый в session)
+- Читает: `MEMORY.md`, последний `session_*.md`, `LAUNCH_PLAN.md`, `BACKLOG.md` (если есть)
+- Формирует в контекст: «Прошлая сессия закончилась на X. LAUNCH_PLAN.md следующий шаг: Y. BACKLOG топ-3: Z. Какой скилл запускаешь?»
+- **Блокирует первый Bash/Edit** пока не будет явного выбора скилла или обоснования raw-режима
+
+### 🕳️ Gap #7 — Memory staleness не детектируется
+
+**В сессии 2026-04-15/16** Claude использовал версию idea-to-deploy «v1.13.1» из `session_2026-04-11_2.md`, **не сверяясь** с актуальным `.claude-plugin/plugin.json` (v1.18.1). Разница в 5 версий за 5 дней!
+
+**Предложение v1.19:**
+**Auto-verify fact claims** в `pre-flight-check.sh`:
+- При упоминании версий/файлов/путей в memory — проверять существование
+- Если memory говорит «файл X:ABC», а на самом деле `git log | grep X:ABC` пусто → mark memory stale
+- Warning в контекст: «⚠️ Memory упоминает v1.13.1, но CHANGELOG.md показывает v1.18.1 — используй актуальную»
+
+---
+
+## Приоритет реализации v1.19
+
+| Gap | Приоритет | Effort | Impact |
+|---|---|---|---|
+| #4 Hook enforcement | 🔴 P0 | 1 день | Высокий — останавливает обход методологии |
+| #6 Session-open diagnostic | 🔴 P0 | 1 день | Высокий — правильное начало сессии |
+| #2 `/strategy` скилл | 🟡 P1 | 2 дня | Средний — закрывает большой gap |
+| #5 Context-switch detector | 🟡 P1 | 0.5 дня | Средний — мульти-проектные сессии частые |
+| #1 `/migrate-prod` скилл | 🟢 P2 | 2 дня | Средний — частота раз в квартал |
+| #3 `/advisor` скилл | 🟢 P2 | 1 день | Низкий — можно обойтись без скилла |
+| #7 Memory stale detection | 🟢 P2 | 1 день | Низкий — редкий случай |
+
+**Общий effort v1.19:** ~8-9 дней работы.
+
+---
+
+## Предлагаемая последовательность реализации
+
+### Фаза 1: Enforcement foundation (2-3 дня)
+1. Gap #4 (Hook enforcement) — останавливает дальнейший обход
+2. Gap #6 (Session-open diagnostic) — гарантирует правильный старт
+
+### Фаза 2: Новые скиллы (5 дней)
+3. Gap #2 (`/strategy`) — через `/blueprint` самоприменение
+4. Gap #1 (`/migrate-prod`) — через `/blueprint` самоприменение
+5. Gap #3 (`/advisor`) — через `/blueprint` самоприменение
+
+### Фаза 3: Quality-of-life (1-2 дня)
+6. Gap #5 (Context-switch detector)
+7. Gap #7 (Memory staleness)
+
+Каждый скилл создавать через `/blueprint` (dog-fooding) + `/review` + `/test` + `/session-save`.
+
+---
+
+## Критерии приёмки v1.19
+
+- [ ] Hook enforcement блокирует tool calls после 3 игнорирований — тестировано на dry-run
+- [ ] Session-open diagnostic срабатывает на первом UserPromptSubmit
+- [ ] `/strategy` создан, self-tested на LAUNCH_PLAN.md NeuroExpert
+- [ ] `/migrate-prod` создан, self-tested на retro-описании миграции 2026-04-15
+- [ ] `/advisor` создан, self-tested на Medvi-обсуждении NeuroExpert
+- [ ] Context-switch detector интегрирован в pre-flight
+- [ ] Memory staleness warning работает
+- [ ] README.md + README.ru.md + CHANGELOG.md обновлены
+- [ ] Marketplace.json обновлён (skill count 20 → 23)
+- [ ] PR merged, sync-to-active прогнат, v1.19 задеплоена
+
+---
+
+## Следующая сессия в этом репо (idea-to-deploy) должна начать с
+
+**Чтения этого файла (`ROADMAP_v1.19.md`)** и ответа на вопрос:
+- Какую фазу стартуем первой?
+- Используем ли dog-fooding (применяем `/blueprint` для создания каждого нового скилла)?
+
+**Ориентир команд:**
+```
+cd ~/projects/idea-to-deploy
+git checkout -b feat/v1.19-session-gaps
+# /blueprint для первого скилла
+# /review после реализации
+# /test на dry-run примерах
+# PR когда все gaps закрыты
+```
+
+**Контекст доступен в:**
+- `~/.claude/projects/-home-hihol-projects/memory/session_2026-04-15_2.md` — основная миграция
+- `~/.claude/projects/-home-hihol-projects/memory/feedback_methodology_gaps.md` — (будет создан вместе с этим ROADMAP'ом)
+- `~/projects/neuroexpert/LAUNCH_PLAN.md` — пример LAUNCH_PLAN, который `/strategy` должен уметь генерировать

--- a/ROADMAP_v1.19.md
+++ b/ROADMAP_v1.19.md
@@ -187,14 +187,14 @@ Claude использовал `/session-save` один раз (для мигра
 
 ## Критерии приёмки v1.19
 
-- [ ] Hook enforcement блокирует tool calls после 3 игнорирований — тестировано на dry-run
-- [ ] Session-open diagnostic срабатывает на первом UserPromptSubmit
+- [x] Hook enforcement блокирует tool calls после 3 игнорирований — тестировано на dry-run (v1.19.0, 2026-04-16)
+- [x] Session-open diagnostic срабатывает на первом UserPromptSubmit (v1.19.0, 2026-04-16)
 - [ ] `/strategy` создан, self-tested на LAUNCH_PLAN.md NeuroExpert
 - [ ] `/migrate-prod` создан, self-tested на retro-описании миграции 2026-04-15
 - [ ] `/advisor` создан, self-tested на Medvi-обсуждении NeuroExpert
 - [ ] Context-switch detector интегрирован в pre-flight
 - [ ] Memory staleness warning работает
-- [ ] README.md + README.ru.md + CHANGELOG.md обновлены
+- [x] README.md + README.ru.md + CHANGELOG.md обновлены (v1.19.0 Phase 1, 2026-04-16)
 - [ ] Marketplace.json обновлён (skill count 20 → 23)
 - [ ] PR merged, sync-to-active прогнат, v1.19 задеплоена
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,8 +1,8 @@
 # Hooks — Skill Discovery Enforcement
 
-These eleven hooks turn the methodology from "use it if you remember" into "you literally cannot forget". Without them, even Claude itself will skip the methodology under time pressure (verified the hard way during a 2026-04-07 production incident — see [the case study](#case-study) below).
+These thirteen hooks turn the methodology from "use it if you remember" into "you literally cannot forget". Without them, even Claude itself will skip the methodology under time pressure (verified the hard way during a 2026-04-07 production incident — see [the case study](#case-study) below).
 
-## Defense-in-depth overview (v1.16.2)
+## Defense-in-depth overview (v1.19.0)
 
 Quality enforcement now spans **five layers**, from earliest-feedback to latest. Each layer catches something the previous ones missed:
 
@@ -10,7 +10,7 @@ Quality enforcement now spans **five layers**, from earliest-feedback to latest.
 |---|---|---|---|---|---|
 | 0 | `pre-flight-check.sh` *(v1.5.0)* | Local | UserPromptSubmit | Stale context, parallel session conflicts, missing memory | Soft context injection only |
 | 1 | `check-skills.sh` | Local | UserPromptSubmit | Ambiguous prompts → wrong routing | Soft reminder only |
-| 2 | `check-tool-skill.sh` | Local | PreToolUse on Bash/Edit/Write | Ad-hoc tool calls when a skill fits | Soft reminder only |
+| 2 | `check-tool-skill.sh` *(v1.19.0: enforcement mode)* | Local | PreToolUse on Bash/Edit/Write | Ad-hoc tool calls when a skill fits | **Soft → Hard after 3 ignores** |
 | 3 | `check-skill-completeness.sh` + `check-commit-completeness.sh` | Local | PreToolUse on Write/Edit/MultiEdit, PreToolUse on `git commit` | Incomplete skills (missing references/triggers/fixtures), incomplete commits | Only via `.methodology-self-extend-override` file |
 | 4 | **[CI workflow](../docs/CI.md)** (new in v1.8.0) | GitHub Actions | Push to main, every PR | Everything in the meta-rubric that local hooks missed OR scenarios where local hooks were never installed | Only by admin override of branch protection (audit-logged) |
 
@@ -22,7 +22,8 @@ Layers 1–3 give fast local feedback. Layer 4 is the server-side last line of d
 |---|---|---|---|
 | `pre-flight-check.sh` *(v1.5.0)* | Every user prompt (UserPromptSubmit) | Loads `git log -10`, `git status`, recent commits, and the project memory index (`MEMORY.md`) into Claude's context before each turn. Detects stale parallel-session lockfiles (`.active-session.lock`) and warns if another Claude session has touched this project in the last 10 minutes. | No — soft context injection only |
 | `check-skills.sh` | Every user prompt (UserPromptSubmit) | Scans the prompt for Russian/English trigger words. If matched, injects a system reminder telling Claude which skill should be invoked first. Silent if no trigger matches. | No — soft reminder only |
-| `check-tool-skill.sh` | Before every Bash/Edit/Write/NotebookEdit (PreToolUse) | Injects a checklist reminder asking Claude to verify a skill doesn't fit before doing raw tool calls. Rate-limited to one reminder per 60 seconds per session. | No — soft reminder only |
+| `check-tool-skill.sh` *(v1.19.0: enforcement)* | Before every Bash/Edit/Write/NotebookEdit (PreToolUse) | Rate-limited skill reminder (60s). **Now tracks consecutive ignores.** After 3 ignored reminders, BLOCKS the next tool call until Claude either invokes a Skill or provides a `SKILL_BYPASS: <reason>` justification. Counter resets on Skill call or bypass. | **Yes — after 3 ignores** |
+| `session-open-diagnostic.sh` *(v1.19.0)* | First user prompt of session (UserPromptSubmit) | Reads last `session_*.md`, next-session plan, LAUNCH_PLAN.md, BACKLOG.md, latest ROADMAP. Injects diagnostic context so Claude starts with full awareness of prior work and planned next steps. Fires once per session (sentinel file). | No — soft context injection only |
 | `check-skill-completeness.sh` *(v1.5.1)* | **Before** Write/Edit/MultiEdit on `skills/*/SKILL.md` (PreToolUse) | Parses the pending tool input, extracts the skill name from the file path, verifies that `references/` exists and is non-empty (if the pending content mentions it), that `hooks/check-skills.sh` has a trigger phrase for the skill, and that a matching fixture exists in `tests/fixtures/`. | **Yes — exit 2 with `hookSpecificOutput.permissionDecision: "deny"`.** The Write never runs, the file never lands on disk. |
 | `check-commit-completeness.sh` *(v1.5.1)* | Before every Bash command matching `git commit` (PreToolUse) | Parses the staged diff. If any `skills/<name>/SKILL.md` is staged, the hook requires matching references/hook/fixture to also be staged (or already present on disk). Written to be the last line of defense against the v1.4.0 "Potemkin release" pattern. | **Yes — exit 2 with `hookSpecificOutput.permissionDecision: "deny"`.** The commit never runs. |
 
@@ -52,6 +53,7 @@ cp hooks/check-skill-completeness.sh ~/.claude/hooks/   # v1.5.0 enforcement
 cp hooks/check-commit-completeness.sh ~/.claude/hooks/  # v1.5.0 enforcement
 cp hooks/careful.sh ~/.claude/hooks/                     # v1.17.0 safety guardrail
 cp hooks/freeze.sh ~/.claude/hooks/                      # v1.17.0 scope guardrail
+cp hooks/session-open-diagnostic.sh ~/.claude/hooks/     # v1.19.0 session diagnostic
 chmod +x ~/.claude/hooks/*.sh
 
 # 2. Register them in ~/.claude/settings.json
@@ -65,6 +67,11 @@ Add this `hooks` block to your `~/.claude/settings.json` (merge with existing se
     "UserPromptSubmit": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/session-open-diagnostic.sh",
+            "timeout": 5
+          },
           {
             "type": "command",
             "command": "~/.claude/hooks/check-skills.sh",

--- a/hooks/check-tool-skill.sh
+++ b/hooks/check-tool-skill.sh
@@ -1,26 +1,33 @@
 #!/usr/bin/env python3
 """
-PreToolUse hook — fires before Bash/Edit/Write/NotebookEdit. Gently
-reminds Claude to verify a skill from Idea-to-Deploy doesn't fit before
-raw tool calls. Does NOT block: always exits 0 with permission allow.
+PreToolUse hook — fires before Bash/Edit/Write/NotebookEdit.
+Reminds Claude to verify a skill from Idea-to-Deploy doesn't fit before
+raw tool calls.
 
-v1.5.0 change: **rate limited**. This hook used to fire on every single
-tool call, which trained the model to respond with a formal "скиллы не
-матчатся" brush-off before every Bash/Edit. That defeats the point —
-the reminder should be a prompt to think, not a recurring checkpoint.
+v1.19.0 change: **enforcement mode** (Gap #4 from ROADMAP_v1.19.md).
 
-New behavior:
-  - Only emits the reminder if no reminder has been shown in the last
-    60 seconds (per Claude session, tracked via /tmp/claude-skill-
-    check-<session>.state).
-  - Softer language: "подумай" instead of "STOP". The hard rule to
-    evaluate skills task-level is in ~/projects/.claude/CLAUDE.md; this
-    hook is a nudge, not an enforcement point.
-  - First tool call of a session always emits the reminder regardless
-    of the window (fresh session = fresh thinking).
+Previous behavior (v1.5.0–v1.18.1):
+  - Rate-limited reminder every 60s, always exit 0, never blocks.
+  - Claude could (and did) ignore reminders indefinitely.
 
-Session id: derived from CLAUDE_SESSION_ID env var if present, else
-from the parent process id. If neither is available, use "default".
+New behavior (v1.19.0):
+  - Still rate-limited to 60s between reminders.
+  - Tracks consecutive ignored reminders in a state file.
+  - After MAX_IGNORES (3) consecutive reminders without a Skill call,
+    the hook BLOCKS the next tool call (returns decision: "block")
+    with a message requiring Claude to either:
+      a) Call a Skill first, OR
+      b) Justify the bypass by including "SKILL_BYPASS: <reason>"
+         in the model's response text before retrying.
+  - Skill tool calls reset the ignore counter to 0.
+  - The ignore counter also resets when Claude provides a bypass
+    justification (detected by checking tool_input for SKILL_BYPASS marker).
+
+State files (per-session):
+  /tmp/claude-skill-check-{session}.state    — last reminder timestamp
+  /tmp/claude-skill-ignores-{session}.state  — ignore count (int)
+
+Session id: CLAUDE_SESSION_ID env var → parent pid → "default".
 
 Reads JSON on stdin: {"tool_name": "...", "tool_input": {...}}
 """
@@ -32,26 +39,49 @@ import sys
 import time
 
 REMIND_WINDOW_SECONDS = 60
+MAX_IGNORES = 3  # block after this many consecutive ignored reminders
 
 
 def session_id() -> str:
     sid = os.environ.get("CLAUDE_SESSION_ID")
     if sid:
         return sid
-    # Fall back to parent pid — stable within a single Claude Code session
     try:
         return f"pid{os.getppid()}"
     except Exception:
         return "default"
 
 
-def should_remind() -> bool:
-    """Return True if we should emit the reminder (no recent emit)."""
-    state_file = f"/tmp/claude-skill-check-{session_id()}.state"
-    now = time.time()
+def state_paths() -> tuple[str, str]:
+    """Return (reminder_state_path, ignore_count_path)."""
+    sid = session_id()
+    return (
+        f"/tmp/claude-skill-check-{sid}.state",
+        f"/tmp/claude-skill-ignores-{sid}.state",
+    )
 
+
+def read_ignore_count(path: str) -> int:
     try:
-        with open(state_file) as f:
+        with open(path) as f:
+            return int(f.read().strip() or "0")
+    except Exception:
+        return 0
+
+
+def write_ignore_count(path: str, count: int) -> None:
+    try:
+        with open(path, "w") as f:
+            f.write(str(count))
+    except Exception:
+        pass
+
+
+def should_remind(reminder_path: str) -> bool:
+    """Return True if enough time passed since last reminder."""
+    now = time.time()
+    try:
+        with open(reminder_path) as f:
             last = float(f.read().strip() or "0")
     except Exception:
         last = 0
@@ -60,11 +90,22 @@ def should_remind() -> bool:
         return False
 
     try:
-        with open(state_file, "w") as f:
+        with open(reminder_path, "w") as f:
             f.write(str(now))
     except Exception:
-        pass  # best effort — if we can't write state, still emit
+        pass
     return True
+
+
+def has_bypass_marker(payload: dict) -> bool:
+    """Check if the tool input contains a SKILL_BYPASS justification."""
+    tool_input = payload.get("tool_input") or {}
+    # Check common fields where Claude might embed the marker
+    for field in ("command", "content", "file_path", "description"):
+        val = tool_input.get(field, "")
+        if isinstance(val, str) and "SKILL_BYPASS:" in val:
+            return True
+    return False
 
 
 def main() -> int:
@@ -74,9 +115,53 @@ def main() -> int:
         return 0
 
     tool = (payload or {}).get("tool_name") or "?"
+    reminder_path, ignore_path = state_paths()
 
-    if not should_remind():
+    # --- Skill call detected → reset ignore counter, allow silently ---
+    if tool == "Skill":
+        write_ignore_count(ignore_path, 0)
+        return 0
+
+    # --- Bypass marker in tool input → reset counter, allow ---
+    if has_bypass_marker(payload):
+        write_ignore_count(ignore_path, 0)
+        return 0
+
+    # --- Check if we should enforce (block) ---
+    ignore_count = read_ignore_count(ignore_path)
+
+    if ignore_count >= MAX_IGNORES:
+        # BLOCK: too many consecutive ignores
+        block_msg = (
+            f"[SKILL ENFORCEMENT — БЛОКИРОВКА] ⛔ Подряд {ignore_count} "
+            "напоминаний о скиллах были проигнорированы. Tool call ЗАБЛОКИРОВАН.\n\n"
+            "Чтобы продолжить, выбери ОДНО из двух:\n"
+            "1. Вызови подходящий скилл через инструмент Skill "
+            "(/bugfix, /test, /refactor, /doc, /review, /explain, /perf, "
+            "/project, /task, /blueprint, /guide, /session-save, "
+            "/security-audit, /deps-audit, /migrate, /harden, /infra)\n"
+            "2. Обоснуй обход — добавь в description Bash/Edit/Write текст "
+            "'SKILL_BYPASS: <причина почему ни один скилл не подходит>'\n\n"
+            "Подробности: ROADMAP_v1.19.md Gap #4, "
+            "~/projects/.claude/CLAUDE.md раздел «ЖЁСТКОЕ ПРАВИЛО»."
+        )
+        out = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": block_msg,
+                "permissionDecision": "block",
+                "reason": f"Skill enforcement: {ignore_count} consecutive ignores exceeded threshold ({MAX_IGNORES})",
+            }
+        }
+        sys.stdout.write(json.dumps(out, ensure_ascii=False))
+        return 0
+
+    # --- Rate-limited reminder ---
+    if not should_remind(reminder_path):
         return 0  # silent no-op when recently reminded
+
+    # Increment ignore counter (will be reset if Skill is called next)
+    write_ignore_count(ignore_path, ignore_count + 1)
 
     context = (
         f"[SKILL CHECK — периодическое напоминание] Сейчас вызов {tool}. "
@@ -86,7 +171,9 @@ def main() -> int:
         "скилл подходит, вызови его ПЕРВЫМ, не руками. Если уже работаешь "
         "внутри задачи (выбор сделан) — продолжай, это напоминание "
         "следующее увидишь не раньше чем через минуту. Подробности: "
-        "~/projects/.claude/CLAUDE.md раздел «ЖЁСТКОЕ ПРАВИЛО»."
+        "~/projects/.claude/CLAUDE.md раздел «ЖЁСТКОЕ ПРАВИЛО».\n\n"
+        f"⚠️ Счётчик игнорирований: {ignore_count + 1}/{MAX_IGNORES}. "
+        f"После {MAX_IGNORES} подряд — tool calls будут ЗАБЛОКИРОВАНЫ."
     )
 
     out = {

--- a/hooks/session-open-diagnostic.sh
+++ b/hooks/session-open-diagnostic.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook — Session-open diagnostic (Gap #6 from ROADMAP_v1.19.md).
+
+Fires ONCE per session (on the first UserPromptSubmit). Reads project context
+and injects a diagnostic summary so Claude starts with full awareness of:
+  1. What the last session accomplished
+  2. What the next planned steps are (from session memory or LAUNCH_PLAN.md)
+  3. Active BACKLOG items (if any)
+
+This prevents the "reactive mode" problem where Claude just responds to the
+first message without consulting prior context.
+
+After firing once, writes a sentinel file so subsequent prompts in the same
+session skip this hook silently.
+
+Session id: CLAUDE_SESSION_ID → parent pid → "default".
+
+Reads JSON on stdin: {"prompt": "..."}
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Max lines to include from each source to avoid blowing context
+MAX_SESSION_LINES = 40
+MAX_PLAN_LINES = 30
+MAX_BACKLOG_LINES = 20
+
+
+def session_id() -> str:
+    sid = os.environ.get("CLAUDE_SESSION_ID")
+    if sid:
+        return sid
+    try:
+        return f"pid{os.getppid()}"
+    except Exception:
+        return "default"
+
+
+def sentinel_path() -> str:
+    return f"/tmp/claude-session-diag-{session_id()}.done"
+
+
+def already_fired() -> bool:
+    """Check if diagnostic already ran this session."""
+    return os.path.exists(sentinel_path())
+
+
+def mark_fired() -> None:
+    """Write sentinel so we don't fire again."""
+    try:
+        with open(sentinel_path(), "w") as f:
+            f.write("1")
+    except Exception:
+        pass
+
+
+def find_project_memory_dir(cwd: Path) -> Path | None:
+    """Find the Claude project memory dir for cwd (same logic as pre-flight-check)."""
+    home = Path.home()
+    projects_root = home / ".claude" / "projects"
+    if not projects_root.is_dir():
+        return None
+
+    cwd_resolved = cwd.resolve()
+    expected = "-" + str(cwd_resolved).lstrip("/").replace("/", "-")
+    candidate = projects_root / expected / "memory"
+    if candidate.is_dir():
+        return candidate
+
+    # Fallback: suffix match
+    parts = cwd_resolved.parts
+    for i in range(1, len(parts)):
+        suffix = "-".join(parts[i:])
+        for entry in projects_root.iterdir():
+            if not entry.is_dir() or not entry.name.startswith("-"):
+                continue
+            if entry.name.endswith("-" + suffix) or entry.name == "-" + suffix:
+                mem = entry / "memory"
+                if mem.is_dir():
+                    return mem
+    return None
+
+
+def find_latest_session_file(mem_dir: Path) -> Path | None:
+    """Find the most recent session_*.md file by modification time."""
+    candidates = sorted(
+        mem_dir.glob("session_*.md"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def read_truncated(path: Path, max_lines: int) -> str:
+    """Read a file, truncating to max_lines."""
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return ""
+    lines = content.splitlines()
+    if len(lines) > max_lines:
+        return "\n".join(lines[:max_lines]) + f"\n(…truncated, {len(lines) - max_lines} more lines)"
+    return content
+
+
+def find_project_file(cwd: Path, name: str) -> Path | None:
+    """Look for a file in cwd or common subdirectories."""
+    for candidate in [cwd / name, cwd / "docs" / name]:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def build_diagnostic(cwd: Path) -> str | None:
+    """Build the diagnostic context string. Returns None if nothing useful found."""
+    sections: list[str] = []
+
+    mem_dir = find_project_memory_dir(cwd)
+
+    # --- 1. Last session summary ---
+    if mem_dir:
+        latest = find_latest_session_file(mem_dir)
+        if latest:
+            content = read_truncated(latest, MAX_SESSION_LINES)
+            if content:
+                sections.append(
+                    f"**Последняя сессия** (`{latest.name}`):\n\n{content}"
+                )
+
+        # --- Check NEXT SESSION PLAN in MEMORY.md ---
+        memory_index = mem_dir / "MEMORY.md"
+        if memory_index.is_file():
+            try:
+                idx_text = memory_index.read_text(encoding="utf-8", errors="replace")
+                # Look for lines with NEXT SESSION PLAN or next_session
+                for line in idx_text.splitlines():
+                    if re.search(r"(next.session|следующ)", line, re.IGNORECASE):
+                        # Try to read the referenced file
+                        match = re.search(r"\(([^)]+\.md)\)", line)
+                        if match:
+                            ref_file = mem_dir / match.group(1)
+                            if ref_file.is_file():
+                                plan_content = read_truncated(ref_file, MAX_PLAN_LINES)
+                                if plan_content:
+                                    sections.append(
+                                        f"**План следующей сессии** (`{ref_file.name}`):\n\n{plan_content}"
+                                    )
+                        break
+            except Exception:
+                pass
+
+    # --- 2. LAUNCH_PLAN.md ---
+    launch_plan = find_project_file(cwd, "LAUNCH_PLAN.md")
+    if launch_plan:
+        content = read_truncated(launch_plan, MAX_PLAN_LINES)
+        if content:
+            sections.append(
+                f"**LAUNCH_PLAN.md** (текущий план проекта):\n\n{content}"
+            )
+
+    # --- 3. BACKLOG.md ---
+    backlog = find_project_file(cwd, "BACKLOG.md")
+    if backlog:
+        content = read_truncated(backlog, MAX_BACKLOG_LINES)
+        if content:
+            sections.append(
+                f"**BACKLOG.md** (активные задачи):\n\n{content}"
+            )
+
+    # --- 4. ROADMAP (current version) ---
+    # Look for ROADMAP_v*.md files, pick latest
+    roadmaps = sorted(cwd.glob("ROADMAP_v*.md"), reverse=True)
+    if roadmaps:
+        rm = roadmaps[0]
+        content = read_truncated(rm, MAX_PLAN_LINES)
+        if content:
+            sections.append(
+                f"**Текущий ROADMAP** (`{rm.name}`):\n\n{content}"
+            )
+
+    if not sections:
+        return None
+
+    header = (
+        "[SESSION DIAGNOSTIC — старт сессии]\n\n"
+        "Перед началом работы изучи контекст предыдущей сессии и текущие планы. "
+        "Определи: какой следующий шаг по плану? Какой скилл запускаешь?\n\n"
+        "---\n\n"
+    )
+
+    return header + "\n\n---\n\n".join(sections)
+
+
+def main() -> int:
+    try:
+        json.load(sys.stdin)  # consume
+    except Exception:
+        pass
+
+    # Only fire once per session
+    if already_fired():
+        return 0
+
+    mark_fired()
+
+    cwd = Path(os.getcwd())
+    diagnostic = build_diagnostic(cwd)
+
+    if not diagnostic:
+        return 0
+
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": diagnostic,
+        }
+    }
+    sys.stdout.write(json.dumps(out, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync-to-active.sh
+++ b/scripts/sync-to-active.sh
@@ -228,8 +228,9 @@ DESIRED_HOOKS=$(cat <<'JSON'
   "UserPromptSubmit": [
     {
       "hooks": [
-        { "type": "command", "command": "~/.claude/hooks/pre-flight-check.sh", "timeout": 5 },
-        { "type": "command", "command": "~/.claude/hooks/check-skills.sh",     "timeout": 5 }
+        { "type": "command", "command": "~/.claude/hooks/session-open-diagnostic.sh", "timeout": 5 },
+        { "type": "command", "command": "~/.claude/hooks/pre-flight-check.sh",        "timeout": 5 },
+        { "type": "command", "command": "~/.claude/hooks/check-skills.sh",            "timeout": 5 }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- **Gap #4**: `check-tool-skill.sh` now tracks consecutive ignored skill reminders. After 3 ignores → BLOCKS tool calls until Skill is called or `SKILL_BYPASS: <reason>` justification provided
- **Gap #6**: New `session-open-diagnostic.sh` hook — fires once per session, reads last session memory + LAUNCH_PLAN + BACKLOG + ROADMAP, injects diagnostic context
- Version bump to 1.19.0, CHANGELOG, badges, marketplace.json sync

## Test plan
- [x] Pipe-test: check-tool-skill.sh shows counter 1/3 on first reminder
- [x] Pipe-test: Skill call resets ignore counter to 0
- [x] Pipe-test: session-open-diagnostic.sh outputs full context on first prompt
- [x] Pipe-test: session-open-diagnostic.sh is silent on second prompt (sentinel)
- [x] Live test: enforcement counter visible in real session (confirmed via hook output)
- [x] /review passed (2 Critical found and fixed: M-C13 version mismatch, M-C10 permissionDecision field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)