### PR TITLE
fix: resolve 4 Anthropic compliance audit findings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "idea-to-deploy",
-  "description": "Complete project lifecycle methodology — 23 skills + 7 specialized subagents + 13 hooks from idea to deployed product.",
+  "description": "Complete project lifecycle methodology — 23 skills + 7 specialized subagents + 12 hooks from idea to deployed product.",
   "owner": {
     "name": "HiH-DimaN",
     "email": "HiH-DimaN@users.noreply.github.com"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "idea-to-deploy",
-      "description": "Complete project lifecycle methodology for Claude Code — 23 skills + 7 specialized subagents + 13 hooks. Product discovery, planning, scaffolding, coding, testing, debugging, optimization, security audit (Red/Blue Team), dependency audit, DB migrations, production server migration, deployment, hardening, IaC, session persistence, strategic replanning, advisory mode, safety guardrails, skill enforcement.",
+      "description": "Complete project lifecycle methodology for Claude Code — 23 skills + 7 specialized subagents + 12 hooks. Product discovery, planning, scaffolding, coding, testing, debugging, optimization, security audit (Red/Blue Team), dependency audit, DB migrations, production server migration, deployment, hardening, IaC, session persistence, strategic replanning, advisory mode, safety guardrails, skill enforcement.",
       "category": "development",
       "author": {
         "name": "HiH-DimaN",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "idea-to-deploy",
   "version": "1.19.0",
-  "description": "Complete project lifecycle methodology — 23 skills + 7 specialized subagents + 13 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, strategic replanning, advisory/consulting mode, self-review mode, safety guardrails, skill enforcement with escalation, session-open diagnostics, context-switch detection, memory staleness warnings.",
+  "description": "Complete project lifecycle methodology — 23 skills + 7 specialized subagents + 12 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, session context persistence, daily-work routing, strategic replanning, advisory/consulting mode, self-review mode, safety guardrails, skill enforcement with escalation, session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",
     "email": "HiH-DimaN@users.noreply.github.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Skill count: 20 → 23 across docs, READMEs, marketplace.json.
-- Hook count: 11 → 13 across docs.
+- Hook count: 11 → 12 across docs.
 - Defense-in-depth table version bump to v1.19.0.
 - `check-tool-skill.sh` now shows ignore counter (X/3) in reminders.
 - `pre-flight-check.sh` now includes context-switch detection and memory staleness warnings.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,6 +1,6 @@
 # Hooks — Skill Discovery Enforcement
 
-These thirteen hooks turn the methodology from "use it if you remember" into "you literally cannot forget". Without them, even Claude itself will skip the methodology under time pressure (verified the hard way during a 2026-04-07 production incident — see [the case study](#case-study) below).
+These twelve hooks turn the methodology from "use it if you remember" into "you literally cannot forget". Without them, even Claude itself will skip the methodology under time pressure (verified the hard way during a 2026-04-07 production incident — see [the case study](#case-study) below).
 
 ## Defense-in-depth overview (v1.19.0)
 

--- a/hooks/check-tool-skill.sh
+++ b/hooks/check-tool-skill.sh
@@ -98,14 +98,15 @@ def should_remind(reminder_path: str) -> bool:
 
 
 def has_bypass_marker(payload: dict) -> bool:
-    """Check if the tool input contains a SKILL_BYPASS justification."""
+    """Check if the tool input contains a SKILL_BYPASS justification.
+
+    Only checks the 'description' field (human-visible Bash description)
+    to prevent accidental bypass via crafted command strings or file paths.
+    See Anthropic compliance audit I-3.
+    """
     tool_input = payload.get("tool_input") or {}
-    # Check common fields where Claude might embed the marker
-    for field in ("command", "content", "file_path", "description"):
-        val = tool_input.get(field, "")
-        if isinstance(val, str) and "SKILL_BYPASS:" in val:
-            return True
-    return False
+    val = tool_input.get("description", "")
+    return isinstance(val, str) and "SKILL_BYPASS:" in val
 
 
 def main() -> int:

--- a/skills/strategy/SKILL.md
+++ b/skills/strategy/SKILL.md
@@ -3,7 +3,7 @@ name: strategy
 description: 'Strategic replanning for existing projects — analyze current state, update LAUNCH_PLAN.md, create ADRs for pivot decisions. For NEW projects use /blueprint instead.'
 argument-hint: project path, LAUNCH_PLAN.md, or "from scratch"
 license: MIT
-allowed-tools: Read Write Edit Glob Grep Agent(business-analyst) Agent(devils-advocate)
+allowed-tools: Read Write Edit Glob Grep Bash(git:*) Bash(ls:*) Agent(business-analyst) Agent(devils-advocate)
 context: fork
 metadata:
   author: HiH-DimaN


### PR DESCRIPTION
I-2: Verified — no shell=True in any subprocess.run() (CLEAR) I-3: SKILL_BYPASS detection narrowed to 'description' field only,
     preventing accidental bypass via crafted command/file_path
I-5: /strategy allowed-tools now includes Bash(git:*) Bash(ls:*)
     matching the shell commands in Step 0 instructions
I-8: Hook count corrected 13 → 12 across plugin.json, marketplace.json,
     hooks/README.md, CHANGELOG.md (actual .sh files = 12)

Local meta_review.py: PASSED (0 Critical, 0 Important)