### PR TITLE
chore: migrate repo URLs HiH-DimaN → hihol-labs (docs + promo)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,12 +17,12 @@
       },
       "source": {
         "source": "github",
-        "repo": "HiH-DimaN/idea-to-deploy"
+        "repo": "hihol-labs/idea-to-deploy"
       },
-      "homepage": "https://github.com/HiH-DimaN/idea-to-deploy",
+      "homepage": "https://github.com/hihol-labs/idea-to-deploy",
       "version": "1.20.3",
       "images": [
-        "https://raw.githubusercontent.com/HiH-DimaN/idea-to-deploy/main/docs/demo.svg"
+        "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],
       "tags": ["community-managed"],
       "keywords": [

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Install in 30 seconds:**
 
 ```bash
-/plugin install HiH-DimaN/idea-to-deploy
+/plugin install hihol-labs/idea-to-deploy
 ```
 
 Then just describe what you want in Claude Code — methodology routes you automatically. [Full install guide](#quick-start) · [End-to-End Example](#end-to-end-example) · [Skill Contracts](#skill-contracts).
@@ -14,7 +14,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![Skills: 25](https://img.shields.io/badge/Skills-25-green.svg)](#skills)
 [![Agents: 7](https://img.shields.io/badge/Agents-7-orange.svg)](#subagents)
 [![Version: 1.20.3](https://img.shields.io/badge/Version-1.20.3-purple.svg)](.claude-plugin/plugin.json)
-[![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
+[![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
 
@@ -62,7 +62,7 @@ Every step is verified. Every feature is tested. Every decision is documented. E
 **Install the plugin:**
 
 ```bash
-/plugin install HiH-DimaN/idea-to-deploy
+/plugin install hihol-labs/idea-to-deploy
 ```
 
 **Verify the installation:**
@@ -87,13 +87,13 @@ If the router prompt appears and offers routes A / B / C, the plugin is live.
 **Updating:**
 
 ```bash
-/plugin update HiH-DimaN/idea-to-deploy
+/plugin update hihol-labs/idea-to-deploy
 ```
 
 **Uninstalling:**
 
 ```bash
-/plugin uninstall HiH-DimaN/idea-to-deploy
+/plugin uninstall hihol-labs/idea-to-deploy
 ```
 
 See the [CHANGELOG](CHANGELOG.md) for release notes.
@@ -354,7 +354,7 @@ The methodology is only effective if Claude actually invokes the skills. Trigger
 **Recommended — one command:**
 
 ```bash
-git clone https://github.com/HiH-DimaN/idea-to-deploy ~/idea-to-deploy-src
+git clone https://github.com/hihol-labs/idea-to-deploy ~/idea-to-deploy-src
 cd ~/idea-to-deploy-src && bash scripts/sync-to-active.sh
 ```
 
@@ -538,10 +538,10 @@ See [CHANGELOG v1.4.0](CHANGELOG.md) for the detailed breakdown.
 Claude Code may default to ad-hoc tool calls on ambiguous prompts. Install the [skill discovery hooks](#recommended-setup-skill-discovery-hooks) — they inject `[SKILL HINT]` and `[SKILL CHECK]` reminders that raise the invocation rate significantly. You can also invoke a skill explicitly: `/bugfix`, `/test`, etc.
 
 **How do I update the plugin?**
-`/plugin update HiH-DimaN/idea-to-deploy`. Check the [CHANGELOG](CHANGELOG.md) for what changed.
+`/plugin update hihol-labs/idea-to-deploy`. Check the [CHANGELOG](CHANGELOG.md) for what changed.
 
 **How do I uninstall?**
-`/plugin uninstall HiH-DimaN/idea-to-deploy`. Hooks in `~/.claude/settings.json` (if you installed them) must be removed manually.
+`/plugin uninstall hihol-labs/idea-to-deploy`. Hooks in `~/.claude/settings.json` (if you installed them) must be removed manually.
 
 **Conflicts with other plugins.**
 Skills are namespaced by plugin, so two plugins can coexist even if both define `/test`. The router will ask which one to use. Hooks are global — if another plugin also registers UserPromptSubmit hooks, they run in the order defined in `settings.json`.
@@ -567,7 +567,7 @@ Three mechanisms work together:
 `~/.claude/plugins/idea-to-deploy/skills/`. Each skill has a `SKILL.md` you can read to understand its contract.
 
 **Something else is broken.**
-Open an issue: [github.com/HiH-DimaN/idea-to-deploy/issues](https://github.com/HiH-DimaN/idea-to-deploy/issues). Include your Claude Code version, the model in use, the prompt, and the unexpected behavior.
+Open an issue: [github.com/hihol-labs/idea-to-deploy/issues](https://github.com/hihol-labs/idea-to-deploy/issues). Include your Claude Code version, the model in use, the prompt, and the unexpected behavior.
 
 ## Contributing
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@
 **Установка за 30 секунд:**
 
 ```bash
-/plugin install HiH-DimaN/idea-to-deploy
+/plugin install hihol-labs/idea-to-deploy
 ```
 
 Затем просто опишите задачу в Claude Code — методология сама направит в нужный скилл. [Полный гайд по установке](#быстрый-старт) · [End-to-End пример](#end-to-end-пример) · [Контракты скиллов](#контракты-скиллов).
@@ -14,7 +14,7 @@
 [![Skills: 25](https://img.shields.io/badge/Skills-25-green.svg)](#скиллы)
 [![Agents: 7](https://img.shields.io/badge/Agents-7-orange.svg)](#субагенты)
 [![Version: 1.20.3](https://img.shields.io/badge/Version-1.20.3-purple.svg)](.claude-plugin/plugin.json)
-[![meta-review](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/HiH-DimaN/idea-to-deploy/actions/workflows/meta-review.yml)
+[![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)
 
@@ -62,7 +62,7 @@ Claude Code мощный, но без инструкций работает ка
 **Установка плагина:**
 
 ```bash
-/plugin install HiH-DimaN/idea-to-deploy
+/plugin install hihol-labs/idea-to-deploy
 ```
 
 **Проверка установки:**
@@ -87,13 +87,13 @@ Claude Code мощный, но без инструкций работает ка
 **Обновление:**
 
 ```bash
-/plugin update HiH-DimaN/idea-to-deploy
+/plugin update hihol-labs/idea-to-deploy
 ```
 
 **Удаление:**
 
 ```bash
-/plugin uninstall HiH-DimaN/idea-to-deploy
+/plugin uninstall hihol-labs/idea-to-deploy
 ```
 
 Заметки о релизах — в [CHANGELOG](CHANGELOG.md).
@@ -354,7 +354,7 @@ Claude: Шаг 1/9 — скаффолд проекта, коммит
 **Рекомендуемый способ — одна команда:**
 
 ```bash
-git clone https://github.com/HiH-DimaN/idea-to-deploy ~/idea-to-deploy-src
+git clone https://github.com/hihol-labs/idea-to-deploy ~/idea-to-deploy-src
 cd ~/idea-to-deploy-src && bash scripts/sync-to-active.sh
 ```
 
@@ -540,10 +540,10 @@ chmod +x ~/.claude/hooks/*.sh
 Claude Code может скатиться в ad-hoc tool calls на неоднозначных промптах. Установите [хуки обнаружения скиллов](#рекомендуемая-настройка-хуки-обнаружения-скиллов) — они инжектят напоминания `[SKILL HINT]` и `[SKILL CHECK]`, что заметно поднимает частоту срабатывания. Можно также вызвать скилл явно: `/bugfix`, `/test` и т.д.
 
 **Как обновить плагин?**
-`/plugin update HiH-DimaN/idea-to-deploy`. Что изменилось — в [CHANGELOG](CHANGELOG.md).
+`/plugin update hihol-labs/idea-to-deploy`. Что изменилось — в [CHANGELOG](CHANGELOG.md).
 
 **Как удалить?**
-`/plugin uninstall HiH-DimaN/idea-to-deploy`. Хуки в `~/.claude/settings.json` (если вы их ставили) нужно удалить вручную.
+`/plugin uninstall hihol-labs/idea-to-deploy`. Хуки в `~/.claude/settings.json` (если вы их ставили) нужно удалить вручную.
 
 **Конфликты с другими плагинами.**
 Скиллы неймспейсятся по плагину, поэтому два плагина могут сосуществовать даже если оба определяют `/test` — роутер спросит, какой использовать. Хуки — глобальные; если другой плагин тоже вешает UserPromptSubmit-хуки, они выполняются в порядке из `settings.json`.
@@ -569,7 +569,7 @@ By design — см. таблицу [Рекомендуемые модели](#р
 `~/.claude/plugins/idea-to-deploy/skills/`. У каждого скилла есть `SKILL.md`, который можно прочитать, чтобы понять его контракт.
 
 **Что-то сломалось.**
-Заведите issue: [github.com/HiH-DimaN/idea-to-deploy/issues](https://github.com/HiH-DimaN/idea-to-deploy/issues). Приложите версию Claude Code, используемую модель, промпт и описание неожиданного поведения.
+Заведите issue: [github.com/hihol-labs/idea-to-deploy/issues](https://github.com/hihol-labs/idea-to-deploy/issues). Приложите версию Claude Code, используемую модель, промпт и описание неожиданного поведения.
 
 ## Контрибьютинг
 

--- a/ROADMAP_v1.21.md
+++ b/ROADMAP_v1.21.md
@@ -46,7 +46,7 @@ save lands).
 
 - Repo-level weekly dashboard: stars, issues opened/closed, discussions,
   marketplace-install counts (if exposed by any of the 7 directories we
-  submitted to), `/plugin install HiH-DimaN/idea-to-deploy` telemetry.
+  submitted to), `/plugin install hihol-labs/idea-to-deploy` telemetry.
 - **Nothing to decide until there are numbers.** All v1.21 candidates
   are currently based on n=1 — decisions on that signal are cargo-cult.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -46,7 +46,7 @@ The workflow **runs** automatically once merged to `main`, but to make it **bloc
 
 ### Step-by-step
 
-1. Open the repo on GitHub: `https://github.com/HiH-DimaN/idea-to-deploy`
+1. Open the repo on GitHub: `https://github.com/hihol-labs/idea-to-deploy`
 2. Navigate: **Settings** → **Branches** → **Branch protection rules** → **Add rule** (or edit existing)
 3. Set **Branch name pattern**: `main`
 4. Enable: **Require a pull request before merging**

--- a/docs/promotion/drafts/devto-three-tier-testing.md
+++ b/docs/promotion/drafts/devto-three-tier-testing.md
@@ -4,7 +4,7 @@
 - **Target length:** ~2000 words
 - **Tags:** #ai, #testing, #claudecode, #opensource, #devtools
 - **Hook:** How do you test a methodology that runs inside an LLM? We built three tiers of automated testing -- and each tier catches bugs the others miss.
-- **CTA:** The full test suite and plugin are MIT-licensed at https://github.com/HiH-DimaN/idea-to-deploy. PRs and feedback welcome.
+- **CTA:** The full test suite and plugin are MIT-licensed at https://github.com/hihol-labs/idea-to-deploy. PRs and feedback welcome.
 
 ---
 
@@ -220,7 +220,7 @@ The `claude -p` flags work but the documentation is sparse. We discovered most g
 
 ### Try it
 
-The full test suite and plugin are MIT-licensed at https://github.com/HiH-DimaN/idea-to-deploy.
+The full test suite and plugin are MIT-licensed at https://github.com/hihol-labs/idea-to-deploy.
 
 Key files:
 - `tests/meta_review.py` -- Tier 1 structural gates (25+ checks)

--- a/docs/promotion/drafts/habr-intro-idea-to-deploy.md
+++ b/docs/promotion/drafts/habr-intro-idea-to-deploy.md
@@ -4,7 +4,7 @@
 - **Target length:** ~2500 words
 - **Tags:** claude, ai, devtools, opensource, methodology, claude-code, automation
 - **Hook:** Claude Code умеет всё. Проблема в том, что без инструкций он делает всё одновременно, непоследовательно и без тестов. Я написал плагин, который превращает его в разработчика с чётким пайплайном — от идеи до задеплоенного продукта.
-- **CTA:** Плагин MIT-лицензирован: https://github.com/HiH-DimaN/idea-to-deploy
+- **CTA:** Плагин MIT-лицензирован: https://github.com/hihol-labs/idea-to-deploy
 
 ---
 
@@ -23,7 +23,7 @@
 
 ## Решение: idea-to-deploy
 
-[idea-to-deploy](https://github.com/HiH-DimaN/idea-to-deploy) — это плагин для Claude Code, который превращает хаотичную генерацию в структурированный пайплайн:
+[idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy) — это плагин для Claude Code, который превращает хаотичную генерацию в структурированный пайплайн:
 
 ```
 Идея → Вопросы → План → Архитектура → Код → Тесты → Ревью → Деплой
@@ -31,7 +31,7 @@
 
 Установка одной командой:
 ```bash
-/install github:HiH-DimaN/idea-to-deploy
+/install github:hihol-labs/idea-to-deploy
 ```
 
 После этого Claude Code получает **25 скиллов**, **7 специализированных субагентов** и **13 enforcement-хуков**.
@@ -127,7 +127,7 @@
 
 ```bash
 # Установка плагина
-/install github:HiH-DimaN/idea-to-deploy
+/install github:hihol-labs/idea-to-deploy
 
 # Новый проект
 /project
@@ -138,10 +138,10 @@
 
 Плагин MIT-лицензирован, работает на всех платформах (macOS, Linux, WSL, Windows).
 
-GitHub: [github.com/HiH-DimaN/idea-to-deploy](https://github.com/HiH-DimaN/idea-to-deploy)
+GitHub: [github.com/hihol-labs/idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy)
 
 ## Что дальше
 
 Методология развивается с каждым реальным использованием. Каждый баг, каждое пользовательское наблюдение порождает новый автоматический gate. Система становится строже с каждым релизом — и это by design.
 
-Буду рад фидбэку — особенно от тех, кто уже использует Claude Code для разработки. Что не хватает? Какие задачи не покрыты? Пишите в [issues](https://github.com/HiH-DimaN/idea-to-deploy/issues) или в комментариях.
+Буду рад фидбэку — особенно от тех, кто уже использует Claude Code для разработки. Что не хватает? Какие задачи не покрыты? Пишите в [issues](https://github.com/hihol-labs/idea-to-deploy/issues) или в комментариях.

--- a/docs/promotion/drafts/habr-meta-review-loop.md
+++ b/docs/promotion/drafts/habr-meta-review-loop.md
@@ -4,7 +4,7 @@
 - **Target length:** ~3000 words
 - **Tags:** claude, ai, devtools, opensource, testing, methodology, llm, claude-code
 - **Hook:** Мы написали плагин для Claude Code с 25 скилловми. Потом написали мета-ревью, которое проверяет сам плагин. А потом обнаружили, что каждый пользовательский баг-репорт порождает новый gate -- и система становится строже с каждым релизом. Вот как это работает.
-- **CTA:** Плагин MIT-лицензирован: https://github.com/HiH-DimaN/idea-to-deploy. Буду рад фидбэку -- особенно от тех, кто тоже пытается тестировать LLM-методологии.
+- **CTA:** Плагин MIT-лицензирован: https://github.com/hihol-labs/idea-to-deploy. Буду рад фидбэку -- особенно от тех, кто тоже пытается тестировать LLM-методологии.
 
 ---
 
@@ -198,11 +198,11 @@ claude -p \
 
 ### Попробовать
 
-Плагин MIT-лицензирован: [github.com/HiH-DimaN/idea-to-deploy](https://github.com/HiH-DimaN/idea-to-deploy)
+Плагин MIT-лицензирован: [github.com/hihol-labs/idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy)
 
 Установка:
 ```bash
-/plugin install HiH-DimaN/idea-to-deploy
+/plugin install hihol-labs/idea-to-deploy
 ```
 
 Ключевые файлы для тестирования:

--- a/docs/promotion/drafts/hn-headless-claude-poc.md
+++ b/docs/promotion/drafts/hn-headless-claude-poc.md
@@ -4,7 +4,7 @@
 - **Target length:** ~1500 words
 - **Tags:** N/A (HN has no tags)
 - **Hook:** We built a self-improving methodology plugin for Claude Code and needed to test it without a human in the loop. Here's what we learned about `claude -p` and headless LLM testing.
-- **CTA:** The plugin is MIT-licensed at https://github.com/HiH-DimaN/idea-to-deploy -- feedback welcome, especially from anyone else doing headless Claude Code automation.
+- **CTA:** The plugin is MIT-licensed at https://github.com/hihol-labs/idea-to-deploy -- feedback welcome, especially from anyone else doing headless Claude Code automation.
 
 ---
 
@@ -159,7 +159,7 @@ The headless runner is what makes this sustainable. Without it, testing a method
 
 ### The repo
 
-idea-to-deploy is MIT-licensed: https://github.com/HiH-DimaN/idea-to-deploy
+idea-to-deploy is MIT-licensed: https://github.com/hihol-labs/idea-to-deploy
 
 The headless runner, snapshot validator, and meta-review scripts are all in `tests/`. The methodology itself is 25 skills covering project creation, daily work (bugfix, refactor, test, perf, security audit, deps audit, migrate, harden, infra), product discovery, documentation, and session persistence.
 

--- a/docs/promotion/drafts/reddit-claude-ai-show.md
+++ b/docs/promotion/drafts/reddit-claude-ai-show.md
@@ -4,7 +4,7 @@
 - **Target length:** 500-800 words
 - **Tags/Flair:** Show (or Project Showcase, depending on subreddit rules)
 - **Hook:** I built a Claude Code plugin that audits itself and gets stricter with every release. Here's what 25 skills, 25 meta-review gates, and 3 tiers of testing look like in practice.
-- **CTA:** MIT-licensed at https://github.com/HiH-DimaN/idea-to-deploy -- would love feedback, especially on the testing approach.
+- **CTA:** MIT-licensed at https://github.com/hihol-labs/idea-to-deploy -- would love feedback, especially on the testing approach.
 
 ---
 
@@ -14,7 +14,7 @@ I built a Claude Code plugin that audits itself and gets stricter with every rel
 
 ### What it is
 
-idea-to-deploy is a Claude Code plugin (installed via `/plugin install HiH-DimaN/idea-to-deploy`) that gives Claude Code a structured development methodology instead of ad-hoc generation.
+idea-to-deploy is a Claude Code plugin (installed via `/plugin install hihol-labs/idea-to-deploy`) that gives Claude Code a structured development methodology instead of ad-hoc generation.
 
 **25 skills** covering the full lifecycle:
 - **Entry points:** `/project` (router), `/task` (daily work router), `/discover` (product discovery with MoSCoW/RICE)
@@ -64,7 +64,7 @@ The recent release series was a marathon of self-improvement:
 
 ```bash
 # Install
-/plugin install HiH-DimaN/idea-to-deploy
+/plugin install hihol-labs/idea-to-deploy
 
 # Start a new project
 /project
@@ -79,6 +79,6 @@ The recent release series was a marathon of self-improvement:
 2. **The operations skills** -- are `/migrate`, `/harden`, `/infra` useful in practice, or are you using other tools for that?
 3. **The safety guardrails** -- do you use any kind of destructive-command warning in your Claude Code workflow?
 
-MIT-licensed: [github.com/HiH-DimaN/idea-to-deploy](https://github.com/HiH-DimaN/idea-to-deploy)
+MIT-licensed: [github.com/hihol-labs/idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy)
 
 Happy to answer questions about the architecture, testing setup, or anything else.

--- a/docs/promotion/drafts/twitter-self-improving-thread.md
+++ b/docs/promotion/drafts/twitter-self-improving-thread.md
@@ -4,7 +4,7 @@
 - **Target length:** 12 tweets, each under 280 characters
 - **Hashtags:** #ClaudeCode #AI #DevTools #OpenSource #CodingWithAI #LLMTesting
 - **Hook:** What if your dev methodology could catch its own bugs?
-- **CTA:** Star and try the plugin at https://github.com/HiH-DimaN/idea-to-deploy
+- **CTA:** Star and try the plugin at https://github.com/hihol-labs/idea-to-deploy
 
 ---
 
@@ -106,7 +106,7 @@ Each tier catches what the others miss.
 
 ## Tweet 12
 
-The repo is MIT-licensed: github.com/HiH-DimaN/idea-to-deploy
+The repo is MIT-licensed: github.com/hihol-labs/idea-to-deploy
 
 25 skills, 7 subagents, 25+ meta-review gates, 3-tier testing, product discovery (MoSCoW/RICE), safety guardrails, Red/Blue Team security mode.
 

--- a/docs/promotion/marketplace-submissions.md
+++ b/docs/promotion/marketplace-submissions.md
@@ -13,8 +13,8 @@
 | Version     | 1.19.0                                                 |
 | License     | MIT                                                    |
 | Author      | HiH-DimaN                                              |
-| Repo        | https://github.com/HiH-DimaN/idea-to-deploy           |
-| Homepage    | https://github.com/HiH-DimaN/idea-to-deploy           |
+| Repo        | https://github.com/hihol-labs/idea-to-deploy           |
+| Homepage    | https://github.com/hihol-labs/idea-to-deploy           |
 | Category    | Development / Developer Tools                          |
 | Tags        | claude-code, methodology, project-lifecycle, developer-tools, ai-coding, testing, deployment, code-review, security-audit, session-persistence, meta-review, daily-work-router, product-discovery, safety-guardrails |
 
@@ -46,7 +46,7 @@ Core capabilities:
 - 3-tier behavioural testing: structural, snapshot, and headless validation.
 - Daily work router /task — a single entry point for 12 different task types.
 
-MIT licensed. Install: /plugin install HiH-DimaN/idea-to-deploy
+MIT licensed. Install: /plugin install hihol-labs/idea-to-deploy
 ```
 
 ### Categories / Tags
@@ -93,7 +93,7 @@ Instead of ad-hoc prompting, every task is routed through a structured methodolo
 
 The /task router automatically maps any request to the right skill among 12 task types. 7 subagents (architect, code-reviewer, doc-writer, perf-analyzer, test-generator, business-analyst) provide deep domain expertise.
 
-v1.19.0 | MIT | github.com/HiH-DimaN/idea-to-deploy
+v1.19.0 | MIT | github.com/hihol-labs/idea-to-deploy
 ```
 
 ### Status
@@ -129,7 +129,7 @@ What you get:
 - 3-tier behavioural testing: structural validation, snapshot comparison, headless execution.
 - /task router: one command routes to any of 12 task types.
 
-Install in one command: /plugin install HiH-DimaN/idea-to-deploy
+Install in one command: /plugin install hihol-labs/idea-to-deploy
 
 Open source, MIT licensed, actively maintained.
 ```
@@ -217,7 +217,7 @@ Quality enforcement:
 - 23 meta-review gates for methodology self-correction
 - 3-tier behavioural testing pipeline
 
-v1.19.0 | MIT | Install: /plugin install HiH-DimaN/idea-to-deploy
+v1.19.0 | MIT | Install: /plugin install hihol-labs/idea-to-deploy
 ```
 
 ### Status
@@ -254,7 +254,7 @@ Key numbers:
 - 12 task types: one /task command routes to the right skill automatically
 
 MIT licensed, actively maintained, install with one command.
-GitHub: https://github.com/HiH-DimaN/idea-to-deploy
+GitHub: https://github.com/hihol-labs/idea-to-deploy
 ```
 
 ### Status
@@ -275,7 +275,7 @@ Add idea-to-deploy — 25 skills + 7 subagents for full project lifecycle
 
 ### README entry (copy-paste into the appropriate section)
 ```markdown
-- [idea-to-deploy](https://github.com/HiH-DimaN/idea-to-deploy) — Complete project lifecycle methodology: 25 skills (discovery, planning, coding, testing, security audit, DB migrations, hardening, infra-as-code) + 7 specialized subagents + 13 enforcement hooks. Self-improving with 23 meta-review gates. MIT.
+- [idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy) — Complete project lifecycle methodology: 25 skills (discovery, planning, coding, testing, security audit, DB migrations, hardening, infra-as-code) + 7 specialized subagents + 13 enforcement hooks. Self-improving with 23 meta-review gates. MIT.
 ```
 
 ### PR body
@@ -283,7 +283,7 @@ Add idea-to-deploy — 25 skills + 7 subagents for full project lifecycle
 ## Add idea-to-deploy
 
 **Name:** idea-to-deploy
-**Repo:** https://github.com/HiH-DimaN/idea-to-deploy
+**Repo:** https://github.com/hihol-labs/idea-to-deploy
 **Version:** 1.19.0
 **License:** MIT
 **Author:** [HiH-DimaN](https://github.com/HiH-DimaN)
@@ -299,7 +299,7 @@ Open-source Claude Code plugin providing a structured methodology for the entire
 - **3-tier behavioural testing** (structural + snapshot + headless).
 - **/task router** — single entry point for 12 task types.
 
-Install: `/plugin install HiH-DimaN/idea-to-deploy`
+Install: `/plugin install hihol-labs/idea-to-deploy`
 ```
 
 ### Status

--- a/skills/adopt/references/claude-md-template.md
+++ b/skills/adopt/references/claude-md-template.md
@@ -16,7 +16,7 @@ markers manually and re-run /adopt.
 > Adopted into this project on {{ADOPTED_AT}} via `/adopt`.
 > These rules route Claude Code to the right skill automatically and keep
 > commits, tests, and documentation honest. Full methodology:
-> https://github.com/HiH-DimaN/idea-to-deploy
+> https://github.com/hihol-labs/idea-to-deploy
 
 ## ⚠️ Hard rule (violation = bug)
 


### PR DESCRIPTION
## Summary

- Mass-rename of repo path `HiH-DimaN/idea-to-deploy` → `hihol-labs/idea-to-deploy` across documentation, marketplace metadata, and promotion drafts
- Follows #51 which already updated `.claude-plugin/plugin.json` upstream — this PR covers the remaining 13 files
- Not a version bump — purely ops migration after repo transfer to `hihol-labs` org

## Scope (13 files)

| File | Change |
|---|---|
| `README.md` / `README.ru.md` | install/update/uninstall commands, badges, git clone, issues URL |
| `.claude-plugin/marketplace.json` | repo, homepage, icon URL |
| `docs/CI.md`, `ROADMAP_v1.21.md` | in-text references |
| `skills/adopt/references/claude-md-template.md` | URL in client CLAUDE.md template |
| `docs/promotion/marketplace-submissions.md` | Repo/Homepage fields + install commands (11 refs) |
| `docs/promotion/drafts/*.md` × 6 | Promotion draft URLs (devto, habr × 2, hn, reddit, twitter) |

## Deliberately preserved

- `author: HiH-DimaN` in 25 `SKILL.md` frontmatter files — author identity, not repo path
- `Copyright (c) 2026 HiH-DimaN` in `LICENSE`
- `author.name` / `author.email` / `author.url` in `plugin.json` / `marketplace.json` — human identity (email is `@users.noreply.github.com`, url is personal profile)
- `CHANGELOG.md` historical quotes of old install path (release history, not rewritten)
- `https://github.com/HiH-DimaN` — personal GitHub profile link in README "Author" section

## Test plan

- [x] `python3 -c "import json; json.load(...)"` for both `plugin.json` and `marketplace.json` — valid
- [x] `grep -rn HiH-DimaN` — remaining matches are all legitimate author/identity references (verified in `/review`)
- [x] `/review` — PASSED (0 Critical, 0 Important, URL consistency + JSON validity)
- [ ] CI `meta-review` workflow passes

## External follow-up (outside this PR)

After merge, the following external catalogs need manual updates (per `docs/promotion/marketplace-submissions.md`):

1. Anthropic Official Directory — resubmit via https://clau.de/plugin-directory-submission (if prior submission exists)
2. claudemarketplaces.com — auto-crawler should pick up new URL
3. claudepluginhub.com — form resubmission
4. claude-plugins.dev — form resubmission
5. buildwithclaude.com — form resubmission
6. aitmpl.com — form resubmission
7. quemsah/awesome-claude-plugins — PR if existing entry uses old URL
8. GitHub redirects from `HiH-DimaN/idea-to-deploy` still work (transfer confirmed), so there is no hard break — update is a polish/consistency measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)