### PR TITLE
test(fixture-11): flip /discover fixture from pending to active (v1.20.4 PoC)

### DIFF
--- a/tests/fixtures/fixture-11-discover/expected-files.txt
+++ b/tests/fixtures/fixture-11-discover/expected-files.txt
@@ -1,0 +1,25 @@
+# Expected files after /discover runs
+#
+# /discover produces a single artifact — DISCOVERY.md in the project root.
+# The file feeds /blueprint Step 1.5 which detects DISCOVERY.md and
+# skips its own lightweight MoSCoW prioritization in favor of the
+# deeper discovery output.
+
+DISCOVERY.md
+
+# Required sections inside DISCOVERY.md (validated by expected-snapshot.json):
+#   - Market Analysis (TAM / SAM / SOM)
+#   - Competitor Analysis (at least 3 named competitors, 5 in Full mode)
+#   - User Personas (at least 2, up to 4)
+#   - Value Proposition Canvas
+#   - MoSCoW prioritization (at least 8 features categorized)
+#   - RICE scoring (Full mode only, at least 5 features)
+#
+# The skill MUST NOT produce:
+#   - Code files (.py/.ts/.js) — /discover is analysis only, no scaffolding
+#   - STRATEGIC_PLAN.md / PROJECT_ARCHITECTURE.md — those belong to /blueprint
+#   - CLAUDE.md — bootstrap of project memory belongs to /kickstart or /adopt
+#   - .gitignore — out of scope
+#
+# If /discover writes any of the above, it is a contract violation.
+# Report as a regression.

--- a/tests/fixtures/fixture-11-discover/expected-snapshot.json
+++ b/tests/fixtures/fixture-11-discover/expected-snapshot.json
@@ -1,27 +1,47 @@
 {
-  "$schema_version": "1.0.0",
-  "fixture_type": "snapshot",
+  "$schema_version": "1.0",
+  "fixture_type": "discover-full",
   "skill_under_test": "/discover",
-  "fixture": "fixture-11-discover",
-  "skill": "/discover",
-  "status": "pending",
-  "description": "Product discovery for a SaaS booking platform. Validates DISCOVERY.md generation with TAM/SAM/SOM, competitors, personas, MoSCoW+RICE.",
-  "expected_files": [
-    "DISCOVERY.md"
-  ],
-  "required_sections": [
-    "Market Analysis",
-    "TAM",
-    "SAM",
-    "SOM",
-    "Competitor Analysis",
-    "User Personas",
-    "Value Proposition",
-    "MoSCoW",
-    "RICE"
-  ],
-  "min_competitors": 3,
-  "min_personas": 2,
-  "min_features_moscow": 8,
-  "prompt": "Проведи product discovery для SaaS-платформы онлайн-записи в салоны красоты. Целевая аудитория: владельцы салонов и их клиенты. Монетизация: подписка для салонов."
+  "mode": "full",
+  "status": "active",
+  "description": "Product discovery for a SaaS booking platform in the Russian beauty-salon niche. Validates that /discover produces a DISCOVERY.md with TAM/SAM/SOM, competitor analysis (minimum 3), user personas, MoSCoW + RICE, suitable as input for /blueprint Step 1.5.",
+
+  "files": {
+    "required": [
+      "DISCOVERY.md"
+    ],
+    "optional": [],
+    "min_count": 1
+  },
+
+  "content_contracts": {
+    "DISCOVERY.md": {
+      "required_sections": [
+        "Market Analysis|Анализ рынка|Рынок",
+        "TAM",
+        "SAM",
+        "SOM",
+        "Competitor|Конкурент",
+        "Persona|Персон",
+        "Value Proposition|Ценностное предложение|Value",
+        "MoSCoW",
+        "RICE|Приоритизация|Prioritization"
+      ],
+      "min_length_chars": 2000,
+      "must_contain_any_of": {
+        "booking_domain_terms": ["онлайн-запис", "онлайн запис", "booking", "appointment", "запись"],
+        "beauty_industry_terms": ["салон", "красоты", "beauty", "мастер"],
+        "subscription_monetization": ["подписк", "subscription", "SaaS", "тариф"],
+        "named_competitors": ["YCLIENTS", "Yclients", "Booksy", "Dikidi", "Альтера"],
+        "moscow_must": ["Must", "Must-have"],
+        "moscow_should": ["Should"],
+        "moscow_wont": ["Won't", "Won’t", "Wont"]
+      }
+    }
+  },
+
+  "rubric_status": {
+    "expected": ["PASSED", "PASSED_WITH_WARNINGS"],
+    "forbidden": ["BLOCKED"]
+  }
 }

--- a/tests/fixtures/fixture-11-discover/notes.md
+++ b/tests/fixtures/fixture-11-discover/notes.md
@@ -1,17 +1,124 @@
-# Fixture 11 notes
+# Manual verification — fixture 11 (/discover)
 
-## Why this fixture exists
+The `/discover` skill produces `DISCOVERY.md` with market analysis, competitor research, user personas, value proposition, and feature prioritization (MoSCoW + RICE in Full mode). Output feeds `/blueprint` Step 1.5.
 
-Регрессионно фиксирует, что /discover вызывается и выдаёт DISCOVERY.md с обязательными секциями.
+This fixture exercises the **Full mode** path (Opus recommended; Sonnet auto-falls to Lite). Lite-mode assertions are marked `[Lite OK]` where they relax.
 
-## Known limitations
+## /discover — Scenario A: full discovery on a concrete SaaS idea
 
-- Fixture is `status: pending` — verify_snapshot.py авто-пассит без content-валидации.
-- Качество рыночных оценок (TAM/SAM/SOM числа) не проверяется — только наличие секций.
+User pastes the prompt from `idea.md`: «Проведи product discovery для SaaS-платформы онлайн-записи в салоны красоты. Целевая аудитория: владельцы салонов и их клиенты. Монетизация: подписка для салонов.»
+
+### Market Analysis (TAM / SAM / SOM)
+- [ ] TAM, SAM, SOM are each present with a numeric estimate and a unit (₽, $, users)
+- [ ] TAM > SAM > SOM by at least one order of magnitude (sanity check on funnel math)
+- [ ] Every estimate has a short reasoning line (e.g., "2,000 салонов × ₽X/мес"), not a bare number
+- [ ] At least one reference to the beauty/salon industry specifically (not a generic booking-platform number)
+
+### Competitor Analysis
+- [ ] At least 3 competitors named (Full mode: aim for 5). Expected candidates: YCLIENTS, Booksy, Dikidi, Альтера, Fresha
+- [ ] Each competitor has a filled row: name, pricing, strengths, weaknesses, our differentiation
+- [ ] Our differentiation is *not* generic ("better UX") — must point to a concrete gap (pricing tier, language, integrations, mobile-first)
+- [ ] No made-up competitors with no URL / unverifiable names
+
+### User Personas
+- [ ] At least 2 personas (Full mode: 3–4)
+- [ ] Both primary audiences covered: **salon owner** AND **end customer** (per the prompt)
+- [ ] Each persona includes: Role, Pain, Goal, Current solution, Willingness to pay, Discovery channel
+- [ ] Willingness-to-pay for owners is compatible with subscription pricing (not "бесплатно" if monetization is subscription)
+
+### Value Proposition
+- [ ] Canvas filled: Customer jobs, Pains, Gains, Pain relievers, Gain creators, Products & services
+- [ ] Each cell is one sentence (not a bullet list within the cell)
+- [ ] The canvas is internally consistent with the personas (no "pain relievers" targeting a persona not defined above)
+
+### MoSCoW prioritization
+- [ ] At least 8 features in the table
+- [ ] At least 3 **Must** features identified
+- [ ] At least 1 **Won't** explicitly listed (proving scope discipline, not "we might"/"later")
+- [ ] Each row has a Rationale column, not just a label
+- [ ] Must features enable basic bookings (calendar, appointment creation, client database) — no Must features for "AI recommendations" or equivalent nice-to-haves
+
+### RICE scoring `[Full mode]` `[Lite mode skips]`
+- [ ] Table present with columns: Reach, Impact, Confidence, Effort, RICE score
+- [ ] At least 5 features scored (Full mode minimum)
+- [ ] RICE math checks out: score = R × I × C ÷ E (approximately — model rounding is fine)
+- [ ] Features sorted by RICE descending
+- [ ] Top 3 RICE features appear in the Must tier of the MoSCoW table (consistency check)
+
+### Integration handoff
+- [ ] Final paragraph of DISCOVERY.md explicitly mentions `/blueprint` as the next step
+- [ ] File is in the project root (not in `discovery/` or a subdirectory), so /blueprint Step 1.5 can detect it
+
+## /discover — Scenario B: thin idea (edge case)
+
+User says: «хочу что-то в бьюти-сфере, пока не знаю что».
+
+- [ ] Skill asks clarifying questions from Step 1 (What / Who / Why / How / Constraints) before producing output
+- [ ] Does NOT generate a DISCOVERY.md until clarifications are received
+- [ ] If user refuses to clarify, skill degrades gracefully: produces a shorter DISCOVERY.md with `⚠️` warnings for unknown fields, does not fabricate TAM numbers
+
+## /discover — Scenario C: handoff to /blueprint
+
+After DISCOVERY.md exists, user says "запусти blueprint".
+
+- [ ] `/blueprint` reads DISCOVERY.md, detects it in the root
+- [ ] `/blueprint` Step 1.5 is **skipped** (its internal MoSCoW prioritization does not re-run)
+- [ ] Features from DISCOVERY.md MoSCoW table appear in the generated PRD.md with matching priorities
+- [ ] Competitors from DISCOVERY.md appear in STRATEGIC_PLAN.md
+
+## /discover — Scenario D: guard rails (what /discover MUST NOT do)
+
+- [ ] Does NOT write code (`.py`, `.ts`, `.js`, etc.) — per `/discover` Rules §6
+- [ ] Does NOT write STRATEGIC_PLAN.md, PROJECT_ARCHITECTURE.md, PRD.md (those belong to /blueprint)
+- [ ] Does NOT write CLAUDE.md (belongs to /kickstart or /adopt)
+- [ ] Does NOT scaffold a project directory structure
+- [ ] Does NOT run on Haiku — refuses with: «Этот скилл требует Sonnet или Opus.»
+
+## Lite-mode downgrades `[Sonnet]`
+
+When Claude is on Sonnet and no `--full` flag is passed:
+
+- [ ] MoSCoW present, RICE absent (snapshot allows this via `[Lite mode skips]` above)
+- [ ] 2 personas minimum (not 3–4 as in Full)
+- [ ] 3 competitors minimum (not 5)
+- [ ] Section headings unchanged (same schema — only depth differs)
+
+## Self-validation (from `/discover` SKILL.md §Self-validation)
+
+- [ ] At least 3 competitors analyzed
+- [ ] At least 2 user personas defined
+- [ ] MoSCoW table with at least 8 features
+- [ ] At least 3 Must features identified
+- [ ] RICE table present (Full mode, ≥5 features scored)
+- [ ] TAM/SAM/SOM estimates present (can be rough)
+- [ ] Value proposition canvas filled
+
+If any item fails, `/discover` should self-detect and warn "⚠️ DISCOVERY.md не соответствует минимальным требованиям: {reason}." Absence of this warning + missing section = silent quality regression.
+
+## Cross-reference with `check-skill-completeness.sh`
+
+`/discover` satisfies the three Quality Gate 2 requirements:
+
+1. ✅ `skills/discover/references/discovery-template.md` exists and is non-empty
+2. ✅ `hooks/check-skills.sh` contains trigger phrases for `/discover`
+3. ✅ `tests/fixtures/fixture-11-discover/` exists with `idea.md`, `notes.md`, `expected-files.txt`, `expected-snapshot.json`
+
+## /review status
+
+- [ ] After DISCOVERY.md is generated, run `/review` on it
+- [ ] Expected status: `PASSED` or `PASSED_WITH_WARNINGS` (see `expected-snapshot.json` §rubric_status)
+- [ ] If `BLOCKED`, log the failing checks in the Failures section below
 
 ## Run manually
 
 1. `cd tests/fixtures/fixture-11-discover/`
 2. `mkdir -p output && cd output`
-3. Start Claude Code session, paste idea.md content, invoke /discover.
-4. After it finishes: `cd .. && python3 ../../verify_snapshot.py .`
+3. Start Claude Code session, paste `idea.md` content, invoke `/discover`
+4. Once DISCOVERY.md lands, optionally write `.rubric-status` next to it with the `/review` verdict (`PASSED` / `PASSED_WITH_WARNINGS` / `BLOCKED`)
+5. `cd .. && python3 ../../verify_snapshot.py .`
+
+Expected: `✅ fixture-11-discover: PASSED`.
+
+## Failures (fill in if any)
+
+(empty unless the fixture fails — leave space for documenting regressions)


### PR DESCRIPTION
## Summary

First PoC of **v1.20.4 tech-debt batch** — expand `fixture-11..17` from `status:pending` stubs into real behavioural fixtures. Explicitly allowed by `ROADMAP_v1.21.md §D` as low-risk tech-debt outside DEFERRED scope.

Flips `fixture-11-discover` (the only one touched in this PR) from auto-pass stub to active regression gate with full contract.

## Scope

Three files in `tests/fixtures/fixture-11-discover/`. Nothing else touched.

| File | Change |
|---|---|
| `expected-snapshot.json` | MOD — `pending → active`, `fixture_type: discover-full`, 9 `required_sections`, 7 `must_contain_any_of` groups, `min_length_chars: 2000`, `rubric_status` expected PASSED* |
| `expected-files.txt` | NEW — `DISCOVERY.md` as sole expected output + MUST-NOT-produce list |
| `notes.md` | MOD — 20-line stub → 90-line manual checklist (4 Scenarios + Lite-mode downgrades + Self-validation cross-ref + Failures placeholder) matches `fixture-01-saas-clinic` style |

## Why this, why now

- `/advisor` re-assessment this session confirmed ROADMAP v1.21 DEFERRED holds (no multi-point external signal for K4/K16 code-release). Solo-maintainer velocity outlet = §D tech-debt, not scope creep.
- `fixture-11..17` are explicitly named in ROADMAP §D as "expand stubs into real behavioural fixtures". This PR starts that thread.
- Single-fixture PoC — merge, evaluate delta, then decide whether to run a 6-fixture marathon for 12–17 or stop.

## Why `/discover` fixture is artifact-generating (not router-only)

Unlike `fixture-10-task` (router, needs stdout snapshot — deferred to v1.16.0), `/discover` produces exactly one file (`DISCOVERY.md`) with deterministic section schema from its SKILL.md. That matches the existing `verify_snapshot.py` schema perfectly (same shape as `fixture-01-saas-clinic`).

## Safety check — no CI breakage

Verified before push:

- `python3 tests/verify_snapshot.py tests/fixtures/fixture-11-discover/` → `exit 2 "output missing"` (**expected** — active fixture now requires a manual run + `output/` dir, instead of auto-pass).
- `tests/run-fixtures.sh` does not invoke `verify_snapshot.py` fleet-wide → CI untouched.
- `tests/meta_review.py` Phase 1 only parses snapshot (required fields + status validity) → our snapshot passes (all 5 required fields, `status: active`).
- `python3 -m json.tool` confirms JSON validity.

## `/review` results

PASSED 12/12 (Critical 5/5, Important 5/5, Nice-to-have 2/2). Informational score 10/10.

## Compatibility with ROADMAP v1.21 DEFERRED

- No version bump (v1.20.3 stays).
- No CHANGELOG touches.
- No code changes outside test fixtures.
- Fully within §D tech-debt allowance.

## Test plan

- [x] JSON validity (`python3 -m json.tool`)
- [x] `verify_snapshot.py` returns expected exit code for active-without-output state
- [x] `meta_review.py` required fields check mentally traced (all present)
- [x] `/review` PASSED 12/12
- [x] `run-fixtures.sh` does not call `verify_snapshot.py` fleet-wide (grep verified)
- [ ] CI Gate 1 meta-review — awaiting server-side run
- [ ] (future) Manual fixture run producing `output/DISCOVERY.md` + `.rubric-status` would then complete the gate

## Follow-ups (not in this PR)

- If PoC verdict is positive: six more PRs for `fixture-12-autopilot` / `13-strategy` / `14-migrate-prod` / `15-advisor` / `16-deploy` / `17-adopt`, each their own narrow tech-debt PR. `fixture-10-task` remains deferred to v1.16.0 (needs stdout snapshot scheme, not file snapshot).
- Update `ROADMAP_v1.21.md §D` after each fixture-NN lands to mark it done.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)