### PR TITLE
fix(hook): review-sentinel sync gap — add mtime fallback

### DIFF
--- a/hooks/check-review-before-commit.sh
+++ b/hooks/check-review-before-commit.sh
@@ -27,6 +27,7 @@ from pathlib import Path
 
 GIT_COMMIT_RE = re.compile(r"(^|\s|;|&&|\|\|)git\s+commit(\s|$)")
 MAX_FILES_WITHOUT_REVIEW = 2
+REVIEW_FRESHNESS_SECONDS = 900  # 15 min — post-/review commit window
 
 
 def get_session_id() -> str:
@@ -38,7 +39,43 @@ def review_marker_path() -> Path:
 
 
 def review_was_done() -> bool:
-    return review_marker_path().exists()
+    """Check for a recent /review invocation.
+
+    Fast path: exact session-id match (works when CLAUDE_SESSION_ID is
+    stable across harness and skill fork).
+
+    Fallback: any /tmp/claude-review-done-* sentinel whose mtime is
+    within REVIEW_FRESHNESS_SECONDS. Tolerates the PID mismatch where
+    the /review skill writes the sentinel under `$$` (its own process
+    PID) while this hook later runs under a different `os.getppid()`
+    inside a separate harness subprocess. See PR #56 for the workaround
+    history this replaces.
+
+    Trade-offs:
+    - Cross-project false positive: a recent /review sentinel from
+      project A also unblocks a >2-file commit in project B within the
+      same 15-minute window. Acceptable — /review was still run in the
+      session, just maybe not on this exact file set, and commit
+      frequency is low enough that collisions are rare in practice.
+    - Reboot behaviour is clean: /tmp/ is wiped on reboot, so stale
+      sentinels never persist across boots and cannot leak across
+      unrelated work sessions separated by a machine restart.
+    """
+    # Fast path — exact session match
+    if review_marker_path().exists():
+        return True
+    # Fallback — any fresh sentinel from a recent /review run
+    import glob
+    import time
+
+    cutoff = time.time() - REVIEW_FRESHNESS_SECONDS
+    for path in glob.glob("/tmp/claude-review-done-*"):
+        try:
+            if os.path.getmtime(path) > cutoff:
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def mark_review_done() -> None:


### PR DESCRIPTION
## Summary

Fixes the PID mismatch between `/review` skill and `check-review-before-commit.sh` that forced the 12-commit workaround in PR #56.

## Root cause

- `/review` skill writes `/tmp/claude-review-done-${CLAUDE_SESSION_ID:-$$}` under the **skill process's own `$$`** (SKILL.md:137)
- The hook later reads `/tmp/claude-review-done-{get_session_id()}` under **`os.getppid()` of a separate harness subprocess** (hook:33)
- When `CLAUDE_SESSION_ID` is empty (default Claude Code behaviour), the two PIDs never match → strict lookup fails → hook blocks legit post-review commits
- v1.20.1 "sync gap closed" fix only worked inside a single plugin session with stable env — real multi-subprocess harness usage still fails

## Fix: two-tier lookup in `review_was_done()`

```python
# Fast path — exact session match (existing behaviour)
if review_marker_path().exists():
    return True

# Fallback — any fresh sentinel from a recent /review run
import glob, time
cutoff = time.time() - REVIEW_FRESHNESS_SECONDS  # 900s = 15 min
for path in glob.glob("/tmp/claude-review-done-*"):
    try:
        if os.path.getmtime(path) > cutoff:
            return True
    except OSError:
        continue
return False
```

- **Backward compatible**: strict match runs first, preserves existing behaviour when `CLAUDE_SESSION_ID` is stable
- **Cross-OS**: no `/proc` ancestry walks (macOS-incompatible); `glob` + `getmtime` work everywhere
- **Race-tolerant**: `OSError` caught for the `stat` race between `glob` and `getmtime`

## Trade-offs (documented in docstring)

- **Cross-project false positive**: a recent `/review` sentinel from project A also unblocks a >2-file commit in project B within the 15-minute window. Accepted — `/review` was still run in the session, just maybe not on this exact file set, and commit frequency is low in practice.
- **Post-reboot**: `/tmp/` is wiped on reboot, so stale sentinels cannot leak across unrelated sessions separated by a machine restart. Behaviour is clean.

## Why this approach vs alternatives

| Alternative | Verdict |
|---|---|
| Harness exports `CLAUDE_SESSION_ID` | Out of our control (Claude Code core) |
| Multi-candidate sentinels in `/review` skill | Harder to reason about, more failure points |
| PID ancestry walk (`/proc/{PID}/status`) | Linux-only, breaks macOS support |
| **mtime-based fallback** | **Cross-OS, simple, single-file change** |

## Validation

- **AST parse**: `python3 -c "import ast; ast.parse(...)"` → OK
- **Behavioural** (throwaway repo with 4 staged files):
  - Test A — no sentinel → `exit 2` DENY (strict preserved when no signal)
  - Test B — fresh sentinel (now) → `exit 0` PASS (new fallback works)
  - Test C — stale sentinel only (16 min) → `exit 2` DENY (cutoff enforced)
- `python3 tests/meta_review.py --verbose`: `FINAL STATUS: PASSED` (0 Critical / 0 Important)
- `python3 tests/verify_triggers.py`: `No drift detected`
- `/review`: PASSED_WITH_WARNINGS 9.4/10 → trade-offs added to docstring → now PASSED

## Scope respected (ROADMAP v1.21 DEFERRED)

- **1 file**, `hooks/check-review-before-commit.sh`, 38 insertions / 1 deletion
- No changes to `/review` skill
- No changes to other hooks
- No version bump (v1.20.3 stays — reliability fix, not feature)
- No CHANGELOG entry

## Bootstrap (post-merge action required)

The fix lives in `hooks/check-review-before-commit.sh` (repo), but the harness executes `~/.claude/hooks/check-review-before-commit.sh` (active install). **After merge, run:**

```bash
bash scripts/sync-to-active.sh
```

...to copy the fix into the active install. Until that runs, the old hook continues to enforce strict-PID matching and the 12-commit workaround from PR #56 is still needed. `sync-to-active.sh` is idempotent — re-running it is always safe.

## Test plan

- [x] `/review` PASSED
- [x] AST parseable
- [x] Behavioural tests: DENY / PASS / DENY for 3 cases
- [x] `meta_review.py`: PASSED
- [x] `verify_triggers.py`: no drift
- [x] Scope: 1 file, no code outside `hooks/`
- [ ] CI Gate 1 meta-review — awaiting server-side run
- [ ] Post-merge: run `sync-to-active.sh` to activate the fix locally

## History reference

See [PR #56](https://github.com/hihol-labs/idea-to-deploy/pull/56) body, section "Known sync gap (candidate v1.20.5 follow-up)" — this PR is that follow-up.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)