### PR TITLE
release: v1.22.0 — observability, routing robustness, harness-engineering mapping

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Complete project lifecycle methodology — 33 skills + 10 specialized subagents + 15 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-**Closes the last open harness-engineering principle (observability) + the coverage-map positioning artefact.** Adds one opt-in observability hook (`execution-trace.sh`) plus the Harness Engineering map. No version bump (accumulates under `[Unreleased]` per Keep a Changelog); the hook is opt-in and additive, so it ships as ordinary tech-debt/observability maintenance without a ROADMAP doc.
+## [1.22.0] - 2026-06-24
+
+**Observability, routing robustness, and harness-engineering mapping.** Adds the opt-in `execution-trace.sh` hook (closes the last open harness-engineering principle — H5 observability), a deterministic routing-accuracy benchmark with a new Critical meta-review check (M-C17), the Harness Engineering coverage map plus a control-harness hook classification, and the "meeting / interview prep" router trigger — alongside cross-platform fixes that make the skill-enforcement gate actually block on Windows. All changes are additive and backward-compatible (minor bump per SemVer).
 
 ### Fixed
 
 - **`hooks/check-tool-skill.sh` — skill-enforcement gate now actually accumulates.** `session_id()` fell back to `getppid()`, which differs on every hook spawn (a fresh python process per call, especially on Windows), so the per-session ignore counter reset to 1 on every reminder and the gate **never blocked** (the documented v1.19.0 enforcement was inert on Windows). It now anchors to a single per-day file (or `CLAUDE_SESSION_ID` when set), so consecutive ignored skill reminders accumulate and block at 3 as designed.
 - **`hooks/check-tool-skill.sh` + `check-skills.sh` — closed the "continue" loophole and require a visible decision line.** The reminder text no longer says "if you're already inside a task, continue" — the escape hatch that let the model skip skills silently. Both hooks now require declaring the skill decision on the FIRST line of the response (`Скилл: /X` or `Скилл: не нужен — <reason>`); an explicit `SKILL_BYPASS: <reason>` stays a valid, counter-resetting decision (conscious refusal != ignore).
 - **`hooks/check-skills.sh` — router robustness (found by the new M-C17 benchmark, 92.2% → 100%).** Five trigger regexes required exact verb-target adjacency and missed natural paraphrases: `/guide` ("generate a step-by-step guide for the project"), `/migrate` ("apply **a** migration", "add **a** column"), `/session-save` ("wrap up **the** session"), and `/tool-sync` ("экспортируй **задачи** в Notion", "sync **our** roadmap to Linear"). Each was widened to admit optional articles / intervening words without broadening into neighbouring skills.
+- **`skills/{test,doc,bugfix}/SKILL.md` — three daily-work skills failed to register globally.** They carried a top-level `paths:` frontmatter key (globs scoping auto-load to test files / docs / logs); on the current CLI that also made the Skill tool report "Unknown skill" in non-matching directories, so `/task` could not route to `/test`, `/doc`, or `/bugfix` in any project lacking those files — inconsistent with their sibling daily-work skills (`/perf`, `/refactor`, `/explain` carry no `paths:`). Removed the key so they register everywhere.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 33](https://img.shields.io/badge/Skills-33-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 33](https://img.shields.io/badge/Skills-33-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)


### PR DESCRIPTION
## Release v1.22.0 — Observability, routing robustness, harness-engineering mapping

Cuts the accumulated `[Unreleased]` section into a dated `## [1.22.0] - 2026-06-24` and bumps the version everywhere.

### Why 1.22.0 (minor, per SemVer)
- **Not a patch** — there are genuine new features: `execution-trace.sh` hook, routing-accuracy benchmark + new Critical meta-review check **M-C17**, `HARNESS_ENGINEERING_MAP.md` (+ §8 control-harness classification), the "meeting / interview prep" router trigger.
- **Not a major** — zero breaking changes; everything is additive and backward-compatible (no skills/agents/hooks removed, no contracts broken).

### What's in this release (from `[Unreleased]`)
**Added:** `execution-trace.sh` (opt-in live tracing, closes H5 observability) · routing-accuracy benchmark (`verify_routing.py` + `benchmarks/routing-prompts.json`) + **M-C17** · Harness Engineering map + control-harness §8 · meeting/interview-prep trigger · `.gitattributes` · FAQ.
**Fixed:** enforcement gate now blocks cross-platform (getppid + Windows `/tmp`) · "continue" loophole closed + visible decision line · router robustness 92.2%→100% (5 regexes) · doc-pointer path · **path-scoping** registration of `/test`,`/doc`,`/bugfix` (entry was missing — added in this PR).
**Changed:** hook count 14→15 across docs · `DESIGN_SPACE.md` K15 ◐→✅.

### Version sites bumped (1.21.0 → 1.22.0)
`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md` + `README.ru.md` badges.

### Verification
- `python3 tests/meta_review.py` → **PASSED**, Critical 0 (M-C5 version consistency, M-C6 changelog entry, M-C7 badges, M-C13 marketplace all green).
- 5 files changed, +8/−5.

### After merge
- Tag `v1.22.0` on the merge commit (I can do this once merged, or create a GitHub Release).
- `scripts/sync-to-active.sh` to propagate to active installs.

> Merging publishes the new version to the marketplace (crawlers read `marketplace.json` from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
