### PR TITLE
fix(hooks): skill-active grace window + fork-fallback notes (v1.24.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Complete project lifecycle methodology — 33 skills + 10 specialized subagents + 16 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/.github/workflows/meta-review.yml
+++ b/.github/workflows/meta-review.yml
@@ -50,5 +50,8 @@ jobs:
       - name: Run DoD pre-commit gate unit tests (v1.23.0)
         run: python3 tests/verify_dod_gate.py
 
+      - name: Run skill-enforcement gate unit tests (v1.24.0)
+        run: python3 tests/verify_skill_enforcement.py
+
       - name: Verify sync-to-active hook registration (drift guard, v1.20.1+)
         run: bash scripts/verify-sync-to-active.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-06-27
+
+**Two infrastructure fixes: the skill-enforcement gate no longer dead-ends a legitimate skill-driven Edit flow, and heavy fork skills have a documented escape from autocompact-thrash on large `CLAUDE.md` repos.** Both are additive and backward-compatible (minor bump per SemVer); the never-block enforcement guarantee is preserved and now regression-tested.
+
+### Fixed
+
+- **Skill-enforcement gate falsely blocked active skill work (`hooks/check-tool-skill.sh`).** PreToolUse/PostToolUse hooks do **not** fire for the `Skill` tool, so the gate's `tool == "Skill"` counter-reset branch was dead code in production — the ignore counter accumulated *through* a legitimately-active skill and then blocked it. The block was a true dead-end for `Edit`/`Write`/`NotebookEdit`, which carry no `description` field and therefore cannot supply an in-band `SKILL_BYPASS`. Fix: a per-session **skill-active sentinel** (`/tmp/claude-skill-active-<session>.state`) grants a bounded **grace window** (`SKILL_ACTIVE_TTL_SECONDS = 900`). The sentinel is written by `check-skills.sh` (a UserPromptSubmit hook, which *does* fire reliably) whenever the prompt matches a skill trigger, and by `check-tool-skill.sh` itself whenever a `SKILL_BYPASS` is accepted. A *fresh* sentinel resets the counter and allows silently; a *stale* one does not — so enforcement always resumes (never-block-forever guard).
+
+### Added
+
+- **`tests/verify_skill_enforcement.py`** — 9-case behavioural regression test for the enforcement gate, wired into `.github/workflows/meta-review.yml`. Locks the two guarantees against regression: the gate **still blocks** after `MAX_IGNORES` consecutive ignores, and a **stale** skill-active sentinel does **not** suppress the block. Also covers the end-to-end `check-skills.sh → check-tool-skill.sh` sentinel contract.
+- **Runner-selection fallback in the agent-backed fork skills (`/review`, `/perf`, `/blueprint`, `/discover`).** A `context: fork` skill inherits a copy of the current conversation including the project `CLAUDE.md`; on heavily-onboarded repos (> ~12 KB) the fork starts near the context limit and autocompact-thrashes until it dies. Each skill now documents the escape: when `CLAUDE.md` is large, **dispatch the backing agent via the Agent tool** (fresh thin context, files referenced by path) instead of relying on the fork.
+
+### Changed
+
+- **`Skill` added to the `check-tool-skill.sh` PreToolUse matcher** (active settings in both environments + `skills/adopt/references/project-settings-template.json`) as forward-compat: if a future harness starts emitting Skill hook events, the existing reset+sentinel branch activates automatically. Harmless no-op until then.
+
 ## [1.23.0] - 2026-06-26
 
 **Definition-of-Done enforcement: high-risk commits can no longer quietly skip their mandatory skill.** Adds a narrow pre-commit gate (Layer 1) that blocks a `git commit` touching a DB migration/schema, a payments/auth/secrets path, or a brand-new source file when the matching skill (`/migrate`+`/test`, `/security-audit`, `/test`) was not run this session — plus a skill-bypass ledger and a `/session-save` self-audit (Layer 2) so a skipped gate is impossible to miss at session end. Generalises the existing `/review`-before-commit gate to the other risk signals; deliberately narrow to avoid alarm fatigue. Additive and backward-compatible (minor bump per SemVer).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 33](https://img.shields.io/badge/Skills-33-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.24.0](https://img.shields.io/badge/Version-1.24.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 33](https://img.shields.io/badge/Skills-33-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.24.0](https://img.shields.io/badge/Version-1.24.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/hooks/check-skills.sh
+++ b/hooks/check-skills.sh
@@ -8,9 +8,58 @@ Outputs JSON on stdout with hookSpecificOutput.additionalContext (injected
 back into the model context for the current turn).
 
 Silent (exit 0, no output) if no triggers match — keeps normal turns clean.
+
+v1.24.0: when a trigger matches, this hook also stamps the per-session
+"skill-active" sentinel that check-tool-skill.sh reads to grant a grace
+window. Because PreToolUse/PostToolUse hooks do NOT fire for the Skill tool,
+this UserPromptSubmit hook is the reliable place to record that the current
+task is methodology/skill work, so a legitimate Edit/Bash flow is not falsely
+blocked by the enforcement gate. The session-id derivation below MUST stay
+identical to check-tool-skill.sh or the sentinel paths will not match.
 """
 import json
+import os
 import sys
+import tempfile
+import time
+
+
+# NOTE: this function MUST stay byte-for-byte behaviourally identical to the
+# copy in hooks/check-tool-skill.sh — both derive the per-session sentinel path,
+# and any divergence silently breaks the skill-active grace window. The
+# drift-guard in tests/verify_skill_enforcement.py asserts the two bodies match.
+def session_id() -> str:
+    """Identical to check-tool-skill.sh: env var → per-day anchor → default."""
+    sid = os.environ.get("CLAUDE_SESSION_ID")
+    if sid:
+        return sid
+    try:
+        anchor = os.path.join(tempfile.gettempdir(), "claude-skill-session-anchor")
+        try:
+            with open(anchor) as f:
+                tok = f.read().strip()
+            if tok:
+                return tok
+        except Exception:
+            pass
+        tok = time.strftime("day%Y%m%d")
+        with open(anchor, "w") as f:
+            f.write(tok)
+        return tok
+    except Exception:
+        return "default"
+
+
+def mark_skill_active() -> None:
+    """Stamp the skill-active sentinel read by check-tool-skill.sh. Best-effort."""
+    try:
+        path = os.path.join(
+            tempfile.gettempdir(), "claude-skill-active-%s.state" % session_id()
+        )
+        with open(path, "w") as f:
+            f.write(str(time.time()))
+    except Exception:
+        pass
 
 
 # Each tuple: (regex pattern, hint text). All patterns are matched
@@ -400,6 +449,11 @@ def main() -> int:
 
     if not hints:
         return 0
+
+    # A skill trigger matched → methodology context is established for this
+    # task. Open a grace window so the enforcement gate (check-tool-skill.sh)
+    # does not falsely block the resulting skill-driven Edit/Bash flow.
+    mark_skill_active()
 
     context = (
         "[SKILL HINT — Idea-to-Deploy methodology]\n"

--- a/hooks/check-tool-skill.sh
+++ b/hooks/check-tool-skill.sh
@@ -23,9 +23,35 @@ New behavior (v1.19.0):
   - The ignore counter also resets when Claude provides a bypass
     justification (detected by checking tool_input for SKILL_BYPASS marker).
 
+v1.24.0 change: **skill-active grace window** (infra fix #2).
+
+  Problem fixed: PreToolUse/PostToolUse hooks do NOT fire for the Skill tool
+  (confirmed: the harness does not emit hook events for Skill invocations), so
+  the `tool == "Skill"` reset branch below was dead code in production. The
+  ignore counter therefore accumulated *through* a legitimately-active skill
+  and then falsely blocked its flow — fatally so for Edit/Write/NotebookEdit,
+  which carry no `description` field and thus cannot supply an in-band
+  SKILL_BYPASS to escape the block (a true dead-end).
+
+  Fix: a per-session "skill-active" sentinel grants a grace window.
+    1. The sentinel is written by `check-skills.sh` (a UserPromptSubmit hook,
+       which DOES fire reliably) whenever the user's prompt matches a skill
+       trigger — i.e. methodology context is established for this task. It is
+       ALSO written here whenever a SKILL_BYPASS is accepted, so one bypass
+       opens a grace window instead of resetting a single call.
+    2. On any Bash/Edit/Write/NotebookEdit call, a *fresh* sentinel
+       (age < SKILL_ACTIVE_TTL_SECONDS) is treated as "a skill is running":
+       the counter resets and the call is allowed silently. The TTL bounds
+       the grace so enforcement resumes once the skill window lapses — this is
+       the never-block-FOREVER guard (regression-tested).
+    3. `Skill` is also added to the PreToolUse matcher for forward-compat: if
+       a future harness starts emitting Skill hook events, the reset+sentinel
+       branch below activates automatically. Harmless no-op until then.
+
 State files (per-session):
   /tmp/claude-skill-check-{session}.state    — last reminder timestamp
   /tmp/claude-skill-ignores-{session}.state  — ignore count (int)
+  /tmp/claude-skill-active-{session}.state    — last Skill-call timestamp (grace)
 
 Session id: CLAUDE_SESSION_ID env var → parent pid → "default".
 
@@ -41,8 +67,16 @@ import time
 
 REMIND_WINDOW_SECONDS = 60
 MAX_IGNORES = 3  # block after this many consecutive ignored reminders
+# A Skill call grants this many seconds of grace before enforcement resumes.
+# Bounded on purpose: an expired sentinel must NOT suppress the block, otherwise
+# one early skill would disable enforcement for the whole session (never-block).
+SKILL_ACTIVE_TTL_SECONDS = 900  # 15 minutes
 
 
+# NOTE: this function MUST stay byte-for-byte behaviourally identical to the
+# copy in hooks/check-skills.sh — both derive the per-session sentinel path, and
+# any divergence silently breaks the skill-active grace window. The drift-guard
+# in tests/verify_skill_enforcement.py asserts the two bodies match.
 def session_id() -> str:
     sid = os.environ.get("CLAUDE_SESSION_ID")
     if sid:
@@ -77,6 +111,37 @@ def state_paths() -> tuple[str, str]:
         os.path.join(tmp, f"claude-skill-check-{sid}.state"),
         os.path.join(tmp, f"claude-skill-ignores-{sid}.state"),
     )
+
+
+def skill_active_path() -> str:
+    """Per-session sentinel stamped with the timestamp of the last Skill call."""
+    return os.path.join(
+        tempfile.gettempdir(), f"claude-skill-active-{session_id()}.state"
+    )
+
+
+def mark_skill_active() -> None:
+    """Record that a Skill is running. Best-effort, never raises."""
+    try:
+        with open(skill_active_path(), "w") as f:
+            f.write(str(time.time()))
+    except Exception:
+        pass
+
+
+def skill_active_fresh() -> bool:
+    """True if a Skill was invoked within SKILL_ACTIVE_TTL_SECONDS.
+
+    A stale or missing sentinel returns False so enforcement resumes — this is
+    the never-block-forever guard. Reads the stored timestamp rather than the
+    file mtime so the TTL is explicit and testable.
+    """
+    try:
+        with open(skill_active_path()) as f:
+            ts = float(f.read().strip() or "0")
+    except Exception:
+        return False
+    return (time.time() - ts) < SKILL_ACTIVE_TTL_SECONDS
 
 
 def read_ignore_count(path: str) -> int:
@@ -160,14 +225,26 @@ def main() -> int:
     tool = (payload or {}).get("tool_name") or "?"
     reminder_path, ignore_path = state_paths()
 
-    # --- Skill call detected → reset ignore counter, allow silently ---
+    # --- Skill call detected → reset ignore counter, open grace window ---
     if tool == "Skill":
         write_ignore_count(ignore_path, 0)
+        mark_skill_active()
         return 0
 
-    # --- Bypass marker in tool input → log to ledger, reset counter, allow ---
+    # --- Bypass marker in tool input → log, reset, open grace window, allow ---
     if has_bypass_marker(payload):
         log_bypass(payload)
+        write_ignore_count(ignore_path, 0)
+        mark_skill_active()  # one bypass opens a grace window, not a single call
+        return 0
+
+    # --- Fresh skill-active sentinel → a skill is running, grant grace ---
+    # A legitimate skill-driven Edit/Bash flow must never be falsely blocked.
+    # Edit/Write/NotebookEdit carry no 'description' field, so they cannot
+    # supply an in-band SKILL_BYPASS — the grace window is their only escape.
+    # Reset and allow silently. The TTL (checked inside skill_active_fresh)
+    # bounds this so enforcement resumes after the skill window lapses.
+    if skill_active_fresh():
         write_ignore_count(ignore_path, 0)
         return 0
 

--- a/skills/adopt/references/project-settings-template.json
+++ b/skills/adopt/references/project-settings-template.json
@@ -15,7 +15,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash|Edit|Write|NotebookEdit",
+        "matcher": "Bash|Edit|Write|NotebookEdit|Skill",
         "hooks": [
           { "type": "command", "command": "{{PLUGIN_HOOKS_DIR}}/check-tool-skill.sh", "timeout": 5 }
         ]

--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -38,6 +38,20 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
+### Step -2 (pre): Runner selection — avoid fork-thrash on a large CLAUDE.md (v1.24.0)
+
+This skill is declared `context: fork`; the fork inherits a **copy of the current
+conversation** including the project root `CLAUDE.md`. If that `CLAUDE.md` is
+large (> ~12 KB) or you have already seen autocompact churn this session, the
+fork starts near the context limit and **thrashes until it dies** before
+finishing. **Fallback:** don't fork — dispatch the `architect` agent via the
+Agent tool (`Agent(subagent_type: "architect", …)`) with a **thin prompt** that
+references files/dirs **by path** (don't paste `CLAUDE.md` or large file bodies;
+the agent reads them itself). Quick check: `wc -c CLAUDE.md` — if small/absent,
+the normal fork path below is fine. **Caveat:** this Step runs *inside* the
+fork, but the Agent tool is still callable from there — so do the check and
+switch first thing if `CLAUDE.md` is large.
+
 ### Step -1: Detect model and select mode (Lite vs Full)
 
 Before starting, determine which mode to use:

--- a/skills/discover/SKILL.md
+++ b/skills/discover/SKILL.md
@@ -42,6 +42,20 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
+### Step 0 (pre): Runner selection — avoid fork-thrash on a large CLAUDE.md (v1.24.0)
+
+This skill is declared `context: fork`; the fork inherits a **copy of the current
+conversation** including the project root `CLAUDE.md`. If that `CLAUDE.md` is
+large (> ~12 KB) or you have already seen autocompact churn this session, the
+fork starts near the context limit and **thrashes until it dies** before
+finishing. **Fallback:** don't fork — dispatch the `business-analyst` agent via
+the Agent tool (`Agent(subagent_type: "business-analyst", …)`) with a **thin
+prompt** that references files/dirs **by path** (don't paste `CLAUDE.md` or large
+file bodies; the agent reads them itself). Quick check: `wc -c CLAUDE.md` — if
+small/absent, the normal fork path below is fine. **Caveat:** this Step runs
+*inside* the fork, but the Agent tool is still callable from there — so do the
+check and switch first thing if `CLAUDE.md` is large.
+
 ### Step 0: Detect model and select mode
 
 - Opus → **Full mode** (default)

--- a/skills/perf/SKILL.md
+++ b/skills/perf/SKILL.md
@@ -39,6 +39,20 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
+### Step 0 (pre): Runner selection — avoid fork-thrash on a large CLAUDE.md (v1.24.0)
+
+This skill is declared `context: fork`; the fork inherits a **copy of the current
+conversation** including the project root `CLAUDE.md`. If that `CLAUDE.md` is
+large (> ~12 KB) or you have already seen autocompact churn this session, the
+fork starts near the context limit and **thrashes until it dies** before
+finishing. **Fallback:** don't fork — dispatch the `perf-analyzer` agent via the
+Agent tool (`Agent(subagent_type: "perf-analyzer", …)`) with a **thin prompt**
+that references files/dirs **by path** (don't paste `CLAUDE.md` or large file
+bodies; the agent reads them itself). Quick check: `wc -c CLAUDE.md` — if
+small/absent, the normal fork path below is fine. **Caveat:** this Step runs
+*inside* the fork, but the Agent tool is still callable from there — so do the
+check and switch first thing if `CLAUDE.md` is large.
+
 ### Step 0: Auto-freeze scope (v1.17.0)
 
 After identifying the target file/directory from $ARGUMENTS or profiling results, automatically activate scope freeze:

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -41,6 +41,39 @@ Set via `/model {model}` before invoking this skill, or via the project's defaul
 
 ## Instructions
 
+### Step 0 (pre): Runner selection — avoid fork-thrash on a large CLAUDE.md (v1.24.0)
+
+This skill is declared `context: fork`. A fork inherits a **copy of the current
+conversation**, including the project root `CLAUDE.md`. When that `CLAUDE.md` is
+large (heavily-onboarded repos: rough rule of thumb **> ~12 KB**, or you have
+already seen autocompact churn this session), the fork starts near the context
+limit and **autocompact-thrashes until it dies** before producing a verdict.
+
+**Fallback:** do NOT rely on the fork. Instead run the review by dispatching the
+`code-reviewer` agent via the **Agent tool**, which starts from a fresh, thin
+context instead of a copy of the bloated conversation:
+
+- Call `Agent(subagent_type: "code-reviewer", …)` with a **thin prompt**: state
+  the review target and pass files/dirs **by path** — do NOT paste `CLAUDE.md`
+  or large file bodies into the prompt (the agent reads them itself with
+  Read/Grep).
+- Keep the same Step 0 mode detection below: tell the agent whether this is a
+  methodology self-review or a regular project review (`agents/code-reviewer.md`
+  carries the matching logic).
+
+Quick size check before deciding:
+
+```bash
+wc -c CLAUDE.md 2>/dev/null   # > ~12000 bytes → prefer Agent-tool dispatch over fork
+```
+
+If `CLAUDE.md` is small / absent, the normal fork path is fine — continue below.
+
+**Caveat:** this Step runs *inside* the fork, so by the time you read it the fork
+already exists. Dispatching the Agent is still possible from within a fork, so do
+the size check and switch to Agent-tool dispatch **first thing** — before loading
+any more context — if `CLAUDE.md` is large.
+
 ### Step 0: Detect review mode (v1.13.0)
 
 Before anything else, determine whether this is a **methodology self-review** or a **regular project review**. The two modes use different rubrics and different runners — mixing them produces nonsense reports.

--- a/tests/verify_skill_enforcement.py
+++ b/tests/verify_skill_enforcement.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Behavioural unit test for hooks/check-tool-skill.sh (v1.24.0).
+
+Covers the skill-enforcement counter and the new skill-active grace window
+(infra fix #2). Drives the hook with synthetic PreToolUse payloads on stdin,
+toggling the per-session state files, and asserts both the exit code
+(0 = allow, 2 = deny / enforcement block) and the resulting counter / sentinel
+state.
+
+The headline guarantees, locked here against regression:
+  * enforcement STILL blocks after MAX_IGNORES consecutive ignores
+    (the "never-block" bug must never come back), and
+  * a STALE skill-active sentinel does NOT suppress the block
+    (one early skill must not disable enforcement for the whole session).
+
+Run: python3 tests/verify_skill_enforcement.py
+Exits non-zero if any case fails (CI-friendly).
+"""
+import json
+import os
+import subprocess
+import tempfile
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HOOK = os.path.join(REPO, "hooks", "check-tool-skill.sh")
+CHECK_SKILLS = os.path.join(REPO, "hooks", "check-skills.sh")
+SID = "skillenf-test-session"
+TMP = tempfile.gettempdir()
+
+IGNORES = os.path.join(TMP, "claude-skill-ignores-%s.state" % SID)
+REMINDER = os.path.join(TMP, "claude-skill-check-%s.state" % SID)
+ACTIVE = os.path.join(TMP, "claude-skill-active-%s.state" % SID)
+
+# Must mirror the constants in the hook.
+MAX_IGNORES = 3
+TTL = 900
+
+
+def _rm(*paths):
+    for p in paths:
+        try:
+            os.remove(p)
+        except OSError:
+            pass
+
+
+def reset_state():
+    _rm(IGNORES, REMINDER, ACTIVE)
+
+
+def set_count(n):
+    with open(IGNORES, "w") as f:
+        f.write(str(n))
+
+
+def read_count():
+    try:
+        with open(IGNORES) as f:
+            return int(f.read().strip() or "0")
+    except OSError:
+        return 0
+
+
+def allow_reminder():
+    """Make should_remind() return True (no recent reminder)."""
+    _rm(REMINDER)
+
+
+def suppress_reminder():
+    """Make should_remind() return False (reminded just now)."""
+    with open(REMINDER, "w") as f:
+        f.write(str(time.time()))
+
+
+def set_active(age_seconds):
+    with open(ACTIVE, "w") as f:
+        f.write(str(time.time() - age_seconds))
+
+
+def run_hook(tool, description=""):
+    payload = json.dumps(
+        {"tool_name": tool, "tool_input": {"description": description}}
+    )
+    env = dict(os.environ)
+    env["CLAUDE_SESSION_ID"] = SID
+    p = subprocess.run(
+        ["python3", HOOK], input=payload,
+        capture_output=True, text=True, env=env,
+    )
+    return p.returncode, (p.stdout or "")
+
+
+# Each case returns (ok, detail).
+def c_block_after_max_ignores():
+    """REGRESSION: enforcement must still block (never-block guard)."""
+    reset_state()
+    set_count(MAX_IGNORES)
+    rc, out = run_hook("Edit")
+    return rc == 2 and "deny" in out, "rc=%d" % rc
+
+
+def c_skill_resets_and_marks_active():
+    reset_state()
+    set_count(MAX_IGNORES)
+    rc, _ = run_hook("Skill")
+    fresh = os.path.exists(ACTIVE)
+    return rc == 0 and read_count() == 0 and fresh, \
+        "rc=%d count=%d active=%s" % (rc, read_count(), fresh)
+
+
+def c_fresh_sentinel_grants_grace():
+    reset_state()
+    set_count(MAX_IGNORES)
+    set_active(5)  # 5s old -> fresh
+    rc, _ = run_hook("Edit")
+    return rc == 0 and read_count() == 0, \
+        "rc=%d count=%d" % (rc, read_count())
+
+
+def c_stale_sentinel_still_blocks():
+    """REGRESSION: an expired grace window must NOT disable enforcement."""
+    reset_state()
+    set_count(MAX_IGNORES)
+    set_active(TTL + 100)  # older than TTL -> stale
+    rc, out = run_hook("Edit")
+    return rc == 2 and "deny" in out, "rc=%d" % rc
+
+
+def c_bypass_marker_resets():
+    reset_state()
+    set_count(MAX_IGNORES)
+    rc, _ = run_hook("Bash", "SKILL_BYPASS: legitimate reason")
+    return rc == 0 and read_count() == 0, \
+        "rc=%d count=%d" % (rc, read_count())
+
+
+def c_reminder_increments():
+    reset_state()
+    set_count(0)
+    allow_reminder()
+    rc, out = run_hook("Edit")
+    return rc == 0 and read_count() == 1 and "SKILL CHECK" in out, \
+        "rc=%d count=%d" % (rc, read_count())
+
+
+def c_rate_limited_no_increment():
+    reset_state()
+    set_count(1)
+    suppress_reminder()
+    rc, _ = run_hook("Edit")
+    return rc == 0 and read_count() == 1, \
+        "rc=%d count=%d" % (rc, read_count())
+
+
+def _run_check_skills(prompt):
+    env = dict(os.environ)
+    env["CLAUDE_SESSION_ID"] = SID
+    subprocess.run(
+        ["python3", CHECK_SKILLS], input=json.dumps({"prompt": prompt}),
+        capture_output=True, text=True, env=env,
+    )
+
+
+def c_e2e_trigger_prompt_opens_grace():
+    """End-to-end contract: a skill-trigger prompt in check-skills.sh writes
+    the sentinel that check-tool-skill.sh honours -> Edit flow not blocked."""
+    reset_state()
+    _run_check_skills("почини баг в users.py")  # matches /bugfix trigger
+    set_count(MAX_IGNORES)
+    rc, _ = run_hook("Edit")
+    return rc == 0 and read_count() == 0, "rc=%d count=%d" % (rc, read_count())
+
+
+def c_e2e_nontrigger_prompt_keeps_enforcement():
+    """A non-methodology prompt writes no sentinel -> enforcement still blocks."""
+    reset_state()
+    _run_check_skills("привет, как дела")  # no trigger
+    set_count(MAX_IGNORES)
+    rc, out = run_hook("Edit")
+    return rc == 2 and "deny" in out, "rc=%d" % rc
+
+
+def _session_id_code(path):
+    """Return the executable lines of `def session_id` in a hook file, stripped
+    of comments, docstrings and blank lines, so two copies can be compared for
+    behavioural drift regardless of surrounding comments."""
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    after = src.split("def session_id", 1)[1]
+    body = after.split("\ndef ", 1)[0]  # up to the next top-level def
+    out = []
+    for raw in body.splitlines():
+        s = raw.strip()
+        if not s or s.startswith("#"):
+            continue
+        if s.startswith('"""') or s.startswith("'''"):  # one-line docstring
+            continue
+        out.append(s)
+    return out
+
+
+def c_session_id_no_drift():
+    """M-1 guard: session_id() must be behaviourally identical in both hooks,
+    or the sentinel paths silently stop matching."""
+    a = _session_id_code(HOOK)
+    b = _session_id_code(CHECK_SKILLS)
+    return a == b and len(a) > 5, "tool=%d skills=%d" % (len(a), len(b))
+
+
+CASES = [
+    ("block after MAX_IGNORES (never-block guard)", c_block_after_max_ignores),
+    ("Skill call resets counter + marks active", c_skill_resets_and_marks_active),
+    ("fresh skill-active sentinel grants grace", c_fresh_sentinel_grants_grace),
+    ("stale sentinel still blocks (no forever-grace)", c_stale_sentinel_still_blocks),
+    ("SKILL_BYPASS in description resets", c_bypass_marker_resets),
+    ("reminder increments counter below max", c_reminder_increments),
+    ("rate-limited reminder does not increment", c_rate_limited_no_increment),
+    ("e2e: trigger prompt opens grace window", c_e2e_trigger_prompt_opens_grace),
+    ("e2e: non-trigger prompt keeps enforcement", c_e2e_nontrigger_prompt_keeps_enforcement),
+    ("session_id() has no drift between hooks", c_session_id_no_drift),
+]
+
+
+def main():
+    passed = failed = 0
+    for name, fn in CASES:
+        try:
+            ok, detail = fn()
+        except Exception as e:  # noqa: BLE001
+            ok, detail = False, "exception: %r" % e
+        print("%s  %-50s %s" % ("PASS" if ok else "FAIL", name, detail))
+        if ok:
+            passed += 1
+        else:
+            failed += 1
+    reset_state()
+    print("\n%d passed, %d failed" % (passed, failed))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Two infrastructure fixes for idea-to-deploy (v1.24.0)

Both additive and backward-compatible (minor bump per SemVer). The never-block enforcement guarantee is preserved and now regression-tested.

### #2 — Skill-enforcement gate falsely blocked active skill work (core fix)
`PreToolUse`/`PostToolUse` hooks do **not** fire for the `Skill` tool (confirmed via claude-code-guide + live observation), so the `tool == "Skill"` counter-reset branch in `check-tool-skill.sh` was **dead code in production**. The ignore counter accumulated *through* a legitimately-active skill and then blocked it — a true dead-end for `Edit`/`Write`/`NotebookEdit`, which carry no `description` field and so cannot supply an in-band `SKILL_BYPASS`.

**Fix:** a per-session **skill-active sentinel** (`/tmp/claude-skill-active-<session>.state`) grants a bounded **grace window** (`SKILL_ACTIVE_TTL_SECONDS = 900`):
- written by `check-skills.sh` (a `UserPromptSubmit` hook, which *does* fire) on a skill-trigger match, and by `check-tool-skill.sh` on an accepted `SKILL_BYPASS`;
- a **fresh** sentinel resets the counter + allows silently; a **stale** one does not — enforcement always resumes (never-block-forever guard).

`tests/verify_skill_enforcement.py` — **10 cases**, wired into CI — locks both guarantees (still blocks after `MAX_IGNORES`; stale sentinel does not suppress the block), plus the e2e `check-skills.sh → check-tool-skill.sh` contract and a `session_id()` cross-hook drift guard.

### #1 — Heavy `context: fork` skills autocompact-thrash on large `CLAUDE.md`
Documentation-level (the fork is a harness mechanism). The agent-backed fork skills (`/review`, `/perf`, `/blueprint`, `/discover`) now document the escape: when `CLAUDE.md` is large (> ~12 KB), **dispatch the backing agent via the Agent tool** (fresh thin context, files by path) instead of forking.

### Misc
- `Skill` added to the `check-tool-skill` PreToolUse matcher (both envs + adopt template) as forward-compat.
- Version cascade bumped to **1.24.0** (plugin.json, marketplace.json, README badges, CHANGELOG).

### Validation
meta-review **PASSED**, `verify_dod_gate` 14/14, `verify_skill_enforcement` 10/10, `verify_triggers` no drift, sync-to-active OK. Reviewed by the `code-reviewer` agent (methodology mode): **PASSED, 0 critical / 0 major**; the two Minor/Nit findings were addressed. Already deployed to both active environments (WSL + Windows `~/.claude/hooks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)