### PR TITLE
release: v1.26.0 — /caveman token-efficiency skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Complete project lifecycle methodology — 34 skills + 10 specialized subagents + 17 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-06-27
+
 **New `/caveman` token-efficiency skill (port of the public Caveman plugin).** Adds an idea-to-deploy-native communication-style control that cuts output tokens ~75% via terse "caveman" replies while keeping full technical accuracy. The methodology's gates still win over brevity: gate status, blockers, verification evidence, security warnings, and destructive-action confirmations are never compressed. Skill count 33 → 34.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 34](https://img.shields.io/badge/Skills-34-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.26.0](https://img.shields.io/badge/Version-1.26.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 34](https://img.shields.io/badge/Skills-34-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.26.0](https://img.shields.io/badge/Version-1.26.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)


### PR DESCRIPTION
## Release v1.26.0 (minor)

Cuts **v1.26.0** — minor per SemVer (new skill added).

### Highlights

- **New `/caveman` token-efficiency skill** (port of the public [Caveman plugin](https://github.com/JuliusBrussee/caveman), MIT) — terse caveman-style replies that cut output tokens ~75% while keeping full technical accuracy. Modes `lite`/`full`/`ultra`/`wenyan-*`. idea-to-deploy gates still win over brevity (Auto-Clarity + lifecycle carve-outs). Landed in #73.
- Skill count **33 → 34** (new **Efficiency** category); trigger in `check-skills.sh`; `fixture-26-caveman` pending stub.

### Release mechanics in this PR

- Version bumped to `1.26.0` in `plugin.json`, `marketplace.json`, and the `README.md` / `README.ru.md` Version badges.
- `CHANGELOG.md`: the `[Unreleased]` caveman section finalized as **`[1.26.0] - 2026-06-27`**.

### Verification

`python3 tests/meta_review.py` → **FINAL STATUS: PASSED** (0 critical).

### After merge

- Tag `v1.26.0` on the merge commit + GitHub Release from the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
