### PR TITLE
chore(release): v1.27.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Complete project lifecycle methodology — 35 skills + 10 specialized subagents + 17 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-06-28
+
 **New `/context-mode-setup` context-window optimization skill (integration with the Context Mode plugin).** Adds an idea-to-deploy-native companion that brings the upstream [Context Mode plugin](https://github.com/mksglu/context-mode) (by [@mksglu](https://github.com/mksglu), ELv2) into the methodology — it sandboxes large tool output into a local SQLite FTS5 store so the agent searches it (`ctx-search`) instead of dumping it into the context window (vendor claim ~98% per-call reduction). The skill is a **detect-and-advise integration**: it never vendors the upstream ELv2 engine (idea-to-deploy stays MIT and zero-native-dep), it detects install state and runs/prints the verified CLI commands, and it maps the plugin's components onto the lifecycle. It is named `context-mode-setup` (not `context-mode`) because the upstream plugin ships its own skill named `context-mode` — discovered via a live install test, see below. The methodology's gates are unaffected. Skill count 34 → 35.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 35](https://img.shields.io/badge/Skills-35-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.26.0](https://img.shields.io/badge/Version-1.26.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.27.0](https://img.shields.io/badge/Version-1.27.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 35](https://img.shields.io/badge/Skills-35-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.26.0](https://img.shields.io/badge/Version-1.26.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.27.0](https://img.shields.io/badge/Version-1.27.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)


### PR DESCRIPTION
Release **v1.27.0** - minor bump per SemVer (additive skill, no breaking changes).

Cuts the `[Unreleased]` CHANGELOG section into `[1.27.0] - 2026-06-28` and bumps the version in `plugin.json`, `marketplace.json`, and both README badges.

## Release content

New `/context-mode-setup` skill integrating the upstream [Context Mode plugin](https://github.com/mksglu/context-mode) (mksglu/context-mode, ELv2) into the methodology as a detect-and-advise companion (no vendoring of ELv2 source). Skill count 34 -> 35. Shipped in [#76](https://github.com/hihol-labs/idea-to-deploy/pull/76).

## Verification

- `meta_review.py` - PASSED (Critical 0, version sync consistent)
- `verify_triggers.py` - no drift, `verify_routing.py` - 64/64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
