### PR TITLE
chore(release): v1.28.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Complete project lifecycle methodology — 36 skills + 10 specialized subagents + 17 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 36](https://img.shields.io/badge/Skills-36-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.27.0](https://img.shields.io/badge/Version-1.27.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.28.0](https://img.shields.io/badge/Version-1.28.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 36](https://img.shields.io/badge/Skills-36-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.27.0](https://img.shields.io/badge/Version-1.27.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.28.0](https://img.shields.io/badge/Version-1.28.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)


### PR DESCRIPTION
Release **v1.28.0**.

Ships the `/seo-setup` skill ([#78](https://github.com/hihol-labs/idea-to-deploy/pull/78)) — a detect-and-advise companion integrating the upstream [Claude SEO plugin](https://github.com/AgriciDaniel/claude-seo) (MIT) into the methodology without vendoring it. Skill count 35 -> 36.

### Bumped
- `.claude-plugin/plugin.json` version 1.27.0 -> 1.28.0
- `.claude-plugin/marketplace.json` version 1.27.0 -> 1.28.0
- `README.md` + `README.ru.md` Version badge -> 1.28.0
- `CHANGELOG.md` `[1.28.0]` section (dated 2026-06-28) already present from #78

### After merge
- tag `v1.28.0` + GitHub Release

Gates: `meta_review.py` PASSED (0 critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
