### PR TITLE
feat(day5): Spec-Driven Production enrichment — Zero-Trust + SDD (v1.33.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 19 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.33.0] - 2026-06-28
+
+**Day-5 Spec-Driven Production enrichment — Zero-Trust agent guardrails + spec-as-source, all as врезки, no new runtime.** Final study in the Google *New SDLC With Vibe Coding* series (Day 5, *Spec-Driven Production* — Boonstra et al., 2026). A two-lens review (business-analyst + devils-advocate) found ~70% of the paper already covered by the methodology (evals, prompt-injection, agent-memory, cross-vendor review, cost/model-routing — from the Day-1 and Day-3 ports). The real delta is **Zero-Trust Development** (policy server, sandboxing, human-in-the-loop, semantic gating, context hygiene) — for which the canon had zero coverage — plus the **spec-driven culture shift** (spec as durable source of truth, single `AGENTS.md`, Conditional LGTM). All land as opt-in врезки the methodology emits when designing/auditing a stateful, tool-calling agent. The paper's `agents-cli scaffold/eval/deploy` runtime is explicitly iceboxed (ADR-001). Zero new skills, zero new hook files; counts unchanged (38 skills / 19 hooks). Scope recorded in the new Day-5 note in `docs/adr/ADR-001-no-own-runtime.md`.
+
+### Added
+
+- **`/harden` Tier-3 `ZT-1` — Zero-Trust guardrail layer.** Informational, scoped to LLM/agent services that call tools or act: a deterministic policy server (allow/deny by role+env), sandboxing of agent-invoked code/tools (`GEMINI_SANDBOX=docker`-style), human-in-the-loop on irreversible/ambiguous actions, and optional semantic gating wired as an **ASK/advisory signal only, never a hard block** (a hook cannot pause the model loop — ADR-001, the retired score-gate lesson). N/A for non-agent services.
+- **`/security-audit` `MEM-7` — context hygiene & tool-call sanitization.** Tool/function-call arguments (and downstream-prompt interpolations) are sanitized and policy-checked before execution — a resolver substitutes trusted values for placeholders and a tool-policy middleware vets the call, rather than passing model-produced strings straight to a side-effecting tool. Complements `MEM-1` (MEM-1 guards what enters context; MEM-7 guards what leaves it as an action).
+- **`/blueprint` Step 1.6 point 8 + spec-as-source pointer.** Step 1.6 (opt-in, stateful-agent) gains a zero-trust guardrail-layer design item (policy + sandbox + HITL + advisory semantic gating). The 6-document section gains a **spec-as-source (SDD)** note: treat PRD + acceptance criteria as the durable source of truth (code is comparatively disposable), keep agent instructions in a single `CLAUDE.md` (the `AGENTS.md` equivalent), change the spec then regenerate code — not the reverse.
+- **`/adopt` consolidation pointer.** When a legacy project scatters agent instructions across many files, `/adopt` flags *instructional fragmentation* in its report and suggests consolidating into a single `CLAUDE.md` (no auto-merge).
+- **`/review` high-velocity report add-ons (optional, not new checks).** The report may surface a **Bundled Summary + Risk Assessment** and a **Conditional LGTM** ("approve provided X is fixed") — reporting formats over the same binary rubric; they never turn a Critical `BLOCKED` into a pass.
+- **`docs/adr/ADR-001-no-own-runtime.md` — Day-5 note.** Iceboxes `agents-cli`/owned agent-runtime; frames Zero-Trust Development as product design the methodology teaches and audits (not its own engine); records that semantic gating is ASK/advisory only, never a hard inferential gate.
+
+### Changed
+
+- **Version 1.32.0 → 1.33.0** across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the Version badge in `README.md` / `README.ru.md` (MINOR — additive врезки, zero breaking). Per-skill frontmatter versions bumped on edited skills: `/blueprint` 1.3.1 → 1.4.0, `/harden` 1.20.0 → 1.21.0, `/security-audit` 1.19.0 → 1.20.0, `/adopt` 1.21.0 → 1.22.0, `/review` 1.15.0 → 1.16.0. **Skill count (38) and hook count (19) unchanged** — all changes are врезки into existing skills + an ADR note, so no count cascade (M-C7/M-C12/M-C15/M-C16 unaffected).
+
+### Verified
+
+- `tests/meta_review.py --verbose` → FINAL STATUS PASSED (Critical 0), including M-C5 (badge=1.33.0), M-C6 (CHANGELOG [1.33.0] entry), M-C13 (marketplace=plugin version).
+- `scripts/verify_skill_profiles.py` clean (edited skills keep valid `effort`/`side_effect`/`explicit_invocation` frontmatter).
+- `tests/verify_dod_gate.py` → 19 passed, 0 failed (unchanged — no DoD-hook change this release).
+- `/review --self` run before commit.
+
 ## [1.32.0] - 2026-06-28
 
 **Day-3 Context Engineering enrichment — memory & context discipline for stateful agents, all as врезки + one new review check, no new runtime.** Second study in the Google *New SDLC With Vibe Coding* series (Day 3, *Context Engineering: Sessions, Memory* — Milam, Gulli, Nawalgaria, 2026). A two-lens review (business-analyst + devils-advocate) found ~80% of the paper is **product-design** guidance (how the agent the *user* builds should manage its context/memory), not methodology process — so it lands mostly as **opt-in врезки the methodology emits when designing a stateful agent**, plus the one place it is genuinely a guardrail for the money portfolio: provenance/freshness of remembered facts before an irreversible action. Zero new skills, zero new hook *files*, counts unchanged (38 skills / 19 hooks). Scope recorded in the new Day-3 note appended to `docs/adr/ADR-001-no-own-runtime.md`.

--- a/LAUNCH_PLAN.md
+++ b/LAUNCH_PLAN.md
@@ -80,12 +80,30 @@ methodology emits when designing a stateful agent, plus one money-portfolio guar
   19/19. Decisions: gate (not advice) + opt-in flag (not new product type) — confirmed
   by the user.
 
+## Block F — Day-5 Spec-Driven Production (Zero-Trust + SDD) — P1 — ✅ DONE (v1.33.0)
+
+Source: Google *New SDLC With Vibe Coding*, Day 5 (*Spec-Driven Production* — Boonstra
+et al., 2026). Two-lens review: ~70% already covered (evals, prompt-injection,
+agent-memory, cross-review, cost/routing from Day-1/3). Real delta = Zero-Trust runtime
+guardrails (no prior coverage) + spec-driven culture shift. Scope C (Zero-Trust + SDD),
+semantic gating advisory-only — user-confirmed.
+
+- **Zero-Trust (the differentiated gap):** `/harden` `ZT-1` (policy server, sandbox,
+  HITL, advisory semantic gating), `/security-audit` `MEM-7` (context hygiene /
+  tool-arg sanitization), `/blueprint` Step 1.6 point 8 (guardrail-layer design).
+- **SDD culture:** `/blueprint` spec-as-source + single-AGENTS.md pointer, `/adopt`
+  instructional-fragmentation flag, `/review` Conditional-LGTM / Bundled-Risk format.
+- **Icebox (ADR-001):** `agents-cli` owned runtime rejected; semantic gating = ASK,
+  never a hard inferential gate (retired score-gate lesson).
+- Counts unchanged (38/19); no new skill, no new hook file. ADR-001 Day-5 note.
+
 ## Backlog / next
 
 - **P2 (deferred):** analyze Day 3 (Context Engineering) and Day 5 (Spec-Driven
   Production) of the series — technically more concrete than Day 1; likely a
   "context-design step for agent products" follow-up on top of `context-mode-setup`.- **P2 (deferred):** analyze Day 5 (Spec-Driven Production) of the series. Day 3
-  (Context Engineering) — ✅ done in v1.32.0 (Block E above).
+  (Context Engineering) — ✅ done in v1.32.0 (Block E above).- **Series complete.** Day 1 (v1.31.0, Blocks A/D/C/B), Day 3 (v1.32.0, Block E),
+  Day 5 (v1.33.0, Block F) all ported. No further whitepaper days outstanding.
 - **Marketing (free win):** use the whitepaper as external validation in
   `docs/competitive-analysis.md` / promo ("structure scales, vibes don't", "agent =
   model + harness") — the user's portfolio *is* the agentic-engineering thesis.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.32.0](https://img.shields.io/badge/Version-1.32.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.33.0](https://img.shields.io/badge/Version-1.33.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.32.0](https://img.shields.io/badge/Version-1.32.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.33.0](https://img.shields.io/badge/Version-1.33.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/adr/ADR-001-no-own-runtime.md
+++ b/docs/adr/ADR-001-no-own-runtime.md
@@ -103,3 +103,27 @@ unchanged:
 врезки, one new review check (`C-code-7`), and one new risk-signal (`MEMORY_RE`) inside
 the existing DoD hook. Counts stay 38 skills / 19 hooks. The Review date above is
 unchanged; this note is re-evaluated on the same 2026-09-28 cycle.
+
+---
+
+## Note (2026-06-28) — Day-5 Spec-Driven Production scope (v1.33.0)
+
+Day 5 of the series (*Spec-Driven Production*) tempts hardest toward an owned runtime:
+its summary ships an `agents-cli scaffold / eval run / deploy` — exactly the `itd` CLI
+this ADR rejects. The decision is unchanged:
+
+- **`agents-cli` / owned agent-runtime → icebox.** Scaffolding, eval-running and deploy
+  are delegated to the existing substrate (skills generate artifacts into the user's
+  project; the user's CI runs them). We do not ship a CLI / daemon.
+- **Zero-Trust Development is product design we help build, not our engine.** Policy
+  server, sandboxing, human-in-the-loop, context hygiene — врезки the methodology
+  *teaches and audits* (`/harden` `ZT-1`, `/security-audit` `MEM-7`, `/blueprint`
+  Step 1.6), realized inside the *user's* deployed agent.
+- **Semantic gating is an ASK, never a hard gate.** An LLM "referee" over an action is
+  inferential; a blocking inferential gate is non-deterministic (the retired score-gate
+  lesson). It is surfaced as advisory / ASK only — a hook cannot pause the model loop,
+  the same realization as `cost-tracker.sh` v1.30.0 and the `MEMORY_RE` signal.
+
+**Consequence:** Day-5 adds zero runtime, zero new skill, zero new hook file — only
+врезки (`ZT-1`, `MEM-7`, blueprint/adopt/review pointers). Counts stay 38 skills /
+19 hooks. Re-evaluated on the same 2026-09-28 cycle.

--- a/skills/adopt/SKILL.md
+++ b/skills/adopt/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   side_effect: local-write
   explicit_invocation: false
   author: HiH-DimaN
-  version: 1.21.0
+  version: 1.22.0
   category: methodology
   tags: [adopt, legacy, onboarding, methodology, bootstrap, initialization]
 ---
@@ -110,6 +110,12 @@ Branch on existing state:
 - **File present with marker** → skip. Report «CLAUDE.md уже содержит idea-to-deploy блок, не трогаю».
 
 **Never** rewrite or remove the user's existing content. The marker is the source of truth for future updates — a user who wants to re-adopt can delete the block manually.
+
+> **Consolidation (Day-5 SDD).** Prefer a **single** `CLAUDE.md` as the agent's
+> operational manifest (the `AGENTS.md` equivalent). If the project scatters agent
+> instructions across many files (READMEs, ad-hoc prompt docs, multiple `*.cursorrules`
+> / `*.md`), flag it as *instructional fragmentation* in the Step 4 report and suggest
+> consolidating into `CLAUDE.md` — do not auto-merge their content here.
 
 ### Step 2: Write / merge .claude/settings.json
 

--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   side_effect: local-write
   explicit_invocation: false
   author: HiH-DimaN
-  version: 1.3.1
+  version: 1.4.0
   category: project-planning
   tags: [documentation, architecture, planning, prd]
 ---
@@ -192,6 +192,12 @@ Vibe Coding", 2026 — Day 3, Context Engineering). Decide it once, in
    instructions; memory is isolated per tenant; no secrets/PII in a shared store (handed
    to `/security-audit`'s context & memory integrity checks).
 
+8. **Zero-trust guardrail layer (Day-5)** — for an agent that calls tools / acts: a
+   deterministic policy layer (allow/deny by role + env), a sandbox boundary for
+   agent-invoked code/tools, human-in-the-loop on irreversible actions, and optional
+   semantic gating as an *advisory* referee (never a hard auto-block). Designed here,
+   audited by `/security-audit`, hardened by `/harden` `ZT-1`.
+
 Output: a `## Memory & context architecture` section in `PROJECT_ARCHITECTURE.md`. The
 threat side is audited by `/security-audit`; runtime hygiene by `/harden`.
 
@@ -207,6 +213,13 @@ Before writing, consult `references/document-templates.md` for the exact structu
 4. **PRD.md** — user stories, функциональные требования (P0/P1/P2), kill criteria
 5. **README.md** — быстрый старт за 30 секунд, стек, структура
 6. **CLAUDE_CODE_GUIDE.md** — готовые промпты для каждого шага (формат /guide)
+
+> **Spec-as-source (Day-5 SDD).** Treat these documents — especially PRD + acceptance
+> criteria — as the **durable source of truth**: the spec is the asset, generated code
+> is comparatively disposable and regenerable from it. Keep agent instructions in a
+> **single** `CLAUDE.md` (the `AGENTS.md` equivalent), not scattered across many files
+> (instructional fragmentation). When behavior must change, change the spec, then
+> regenerate/adjust the code — not the reverse.
 
 #### Step 2.1: Architecture Decision Trees (NEW in v1.18.0)
 

--- a/skills/harden/SKILL.md
+++ b/skills/harden/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   side_effect: local-write
   explicit_invocation: false
   author: HiH-DimaN
-  version: 1.20.0
+  version: 1.21.0
   category: operations
   tags: [production, hardening, sre, monitoring, observability, reliability]
 ---
@@ -97,6 +97,18 @@ Consult `references/harden-checklist.md` for the full rubric. The checklist has 
   async-memory note). Pair with an observability signal on memory-store size/staleness.
   N/A (passes) for services with no agent memory. Informational, not blocking — scoped
   to AI products only.
+- `ZT-1` **(Day-5 Zero-Trust port, v1.33.0)** If the service runs an LLM/agent that
+  can call tools or take actions, a **zero-trust guardrail layer** is in place: (a) a
+  **policy server** — deterministic allow/deny on each action by role + environment
+  (computational rules, not vibes); (b) **sandboxing** — agent-invoked code/tools run
+  in an isolated boundary (container / `GEMINI_SANDBOX=docker`-style), not on the host;
+  (c) **human-in-the-loop** on irreversible/ambiguous actions (the agent surfaces a
+  failing test or repro before a fix, and waits for approval on side effects); (d)
+  optional **semantic gating** — an LLM "referee" that judges action intent — wired as
+  an **ASK / advisory signal only, never a hard block** (a hook cannot pause the model
+  loop; an inferential gate is non-deterministic — ADR-001, the retired score-gate
+  lesson). N/A (passes) for services with no agent / tool-calling component.
+  Informational, not blocking — scoped to AI products only.
 
 ### Step 3: Generate missing artifacts
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   side_effect: read-only
   explicit_invocation: false
   author: HiH-DimaN
-  version: 1.15.0
+  version: 1.16.0
   category: quality-assurance
   tags: [validation, quality-check, review, consistency, solid, code-smells, methodology-review]
 ---
@@ -176,6 +176,13 @@ score = ((Critical_pass / Critical_total) * 0.6
        + (Nice_pass / Nice_total) * 0.1) * 10
 ```
 and is reported as **informational only** — never used for gating.
+
+> **High-velocity report add-ons (Day-5, optional — not new checks).** For fast-moving
+> teams the report may additionally surface a **Bundled Summary + Risk Assessment** (one
+> paragraph: what changed + the single biggest risk) and a **Conditional LGTM** —
+> "approve provided X is fixed" — instead of escalating a non-Critical warning. These
+> are *reporting formats* over the same binary rubric; they never turn a Critical
+> `BLOCKED` into a pass.
 
 ### Step 4: Offer fixes
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   side_effect: read-only
   explicit_invocation: false
   author: HiH-DimaN
-  version: 1.19.0
+  version: 1.20.0
   category: quality-assurance
   tags: [security, audit, vulnerabilities, owasp]
 ---

--- a/skills/security-audit/references/security-checklist.md
+++ b/skills/security-audit/references/security-checklist.md
@@ -182,6 +182,15 @@ Check: background jobs that update long-term memory after the turn pass through 
 validation/review gate, not a blind write (cross-ref ADR-001 async-memory note + the
 `MEMORY_RE` DoD signal).
 
+### MEM-7: Context hygiene & tool-call sanitization (Important) — Day-5 Zero-Trust, v1.33.0
+Check: arguments assembled for a tool / function call (or interpolated into a downstream
+prompt) are sanitized and policy-checked **before execution** — a resolver substitutes
+trusted values for placeholders and a tool-policy middleware vets the call, rather than
+passing model-produced strings straight to a side-effecting tool (shell, HTTP, DB,
+file). Fail if an LLM-produced argument reaches such a tool with no sanitization /
+allow-list. Complements `MEM-1`: MEM-1 guards what enters the context, MEM-7 guards what
+leaves it as an action.
+
 ## Stack-specific gotchas
 
 ### Next.js / React


### PR DESCRIPTION
## What

Port of Google New-SDLC **Day 5 — Spec-Driven Production** (Boonstra et al., 2026) into idea-to-deploy. Final study in the series. Two-lens review (business-analyst + devils-advocate): ~70% already covered by the Day-1 and Day-3 ports (evals, prompt-injection, agent-memory, cross-vendor review, cost/model-routing). The real delta is **Zero-Trust Development** (no prior coverage) + the **spec-driven culture shift**.

Scope C (Zero-Trust + SDD), semantic gating advisory-only — user-confirmed. The paper's `agents-cli` runtime is iceboxed (ADR-001). Zero new skills, zero new hook files; counts unchanged (38 skills / 19 hooks).

## Changes

- **Zero-Trust (the differentiated gap):**
  - `/harden` `ZT-1` — policy server (deterministic allow/deny by role+env), sandboxing of agent-invoked code/tools, human-in-the-loop on irreversible actions, optional semantic gating as **ASK/advisory only, never a hard block**.
  - `/security-audit` `MEM-7` — context hygiene & tool-call argument sanitization (complements `MEM-1`).
  - `/blueprint` Step 1.6 point 8 — guardrail-layer design for agentic products.
- **SDD culture:**
  - `/blueprint` — spec-as-source (PRD/acceptance = durable truth, code disposable) + single-`AGENTS.md`/`CLAUDE.md` pointer.
  - `/adopt` — instructional-fragmentation flag.
  - `/review` — Conditional-LGTM / Bundled-Risk reporting format (not a new gate).
- **ADR-001 Day-5 note** — `agents-cli` iceboxed; Zero-Trust = product design we teach/audit; semantic gating = ASK only.

## Verification

- `tests/meta_review.py --verbose` → **FINAL STATUS PASSED** (Critical 0, Important 0)
- `scripts/verify_skill_profiles.py` → 38 skills OK
- `tests/verify_dod_gate.py` → **19 passed, 0 failed** (unchanged — no DoD-hook change)
- self-review of diff: additive only (+123/-10), no product-code changes

## Series complete

Day 1 (v1.31.0) · Day 3 (v1.32.0) · **Day 5 (v1.33.0)** — all whitepaper days ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
