### PR TITLE
fix(hooks): cross-platform background dispatch for cross-review-precommit (v1.34.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.34.0",
+      "version": "1.34.1",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.34.1] - 2026-06-29
+
+**Cross-platform background dispatch for `cross-review-precommit.sh`.** The v1.34.0 hook detached its background worker with `os.fork` + `os.setsid`, which do not exist on Windows Python — there the worker silently no-op'd (fail-open, but the cross-vendor review never ran). Replaced with a portable `subprocess.Popen` that re-invokes the hook in a new `--worker` mode, using `start_new_session=True` on POSIX and `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows. The hook now actually dispatches on macOS/Linux/WSL **and** Windows. Behaviour, opt-in gating, scrubbing, and the never-a-gate invariant are unchanged; the 9-case test still passes and a live e2e confirms the detached worker writes its notes file. PATCH — no API/count change (still 20 hooks).
+
+### Fixed
+
+- **`hooks/cross-review-precommit.sh`** — background review now runs on Windows too (was a no-op there because `os.fork` is POSIX-only). Detach is now via `subprocess.Popen` with platform-appropriate flags; added a `--worker` self-invocation entry point.
+- **Version 1.34.0 -> 1.34.1** across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the Version badge in `README.md` / `README.ru.md`.
+
 ## [1.34.0] - 2026-06-29
 
 **Opt-in cross-vendor pre-commit review — continuous second opinion without the always-on tax.** A two-perspective advisory pass (business-analyst + devils-advocate) evaluated making `/cross-review` continuous/automatic. The verdict: keep it on-demand by default, and add a continuous variant ONLY as an opt-in pre-commit hook, never an always-on per-edit (`PostToolUse`) or per-turn (`Stop`) layer. Rationale (privacy/governance of third-party egress, latency under a flaky VPN, multi-agent shared-worktree hazard, and non-duplication of the in-vendor `/security-guidance-setup` continuous layer) is recorded in the new `docs/adr/ADR-002-cross-review-opt-in-precommit.md`. Hook count 19 -> 20; skill/agent counts unchanged (38 / 10).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.34.0](https://img.shields.io/badge/Version-1.34.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.1](https://img.shields.io/badge/Version-1.34.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.34.0](https://img.shields.io/badge/Version-1.34.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.1](https://img.shields.io/badge/Version-1.34.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/hooks/cross-review-precommit.sh
+++ b/hooks/cross-review-precommit.sh
@@ -24,8 +24,8 @@ Design constraints (see docs/adr/ADR-002-cross-review-opt-in-precommit.md):
         nothing lands in the reviewed repo. Committing it is reserved for a
         deliberate team-wide opt-in, not the default.
   • ASYNC. The external CLI (8-30s, can hang under a flaky VPN) runs in a
-    detached child (os.fork + setsid); the hook itself returns in well under its
-    5s registration timeout.
+    detached child process (subprocess.Popen, cross-platform POSIX + Windows);
+    the hook itself returns in well under its 5s registration timeout.
   • AUTO-DISABLED in multi-agent / shared-worktree mode (Agent Teams, linked
     worktree) — "which diff?" is undefined when concurrent agents share a tree,
     and we must never egress another agent's uncommitted code.
@@ -189,27 +189,27 @@ def _cleanup(promptf: str) -> None:
 
 
 def dispatch(promptf: str, notes: str) -> None:
-    """Fork a detached child to run the (slow) external review; parent returns."""
+    """Spawn a fully detached child process to run the (slow) external review;
+    the parent returns immediately. Cross-platform (POSIX + Windows): re-invokes
+    THIS file in `--worker` mode via subprocess.Popen with platform-appropriate
+    detach flags, so a hung CLI never ties to the parent/terminal. (We avoid
+    os.fork, which does not exist on Windows.)"""
+    cmd = [sys.executable, os.path.abspath(__file__), "--worker", promptf, notes]
     try:
-        pid = os.fork()
+        devnull = open(os.devnull, "r+b")
     except OSError:
-        # No fork (shouldn't happen on Linux/WSL/macOS) — skip background work
-        # rather than block synchronously on a 120s external call.
         return
-    if pid == 0:
-        # Child: fully detach so a hung CLI never ties to the parent/terminal.
-        try:
-            os.setsid()
-            devnull = os.open(os.devnull, os.O_RDWR)
-            for fd in (0, 1, 2):
-                try:
-                    os.dup2(devnull, fd)
-                except OSError:
-                    pass
-            run_worker(promptf, notes)
-        finally:
-            os._exit(0)
-    # Parent: reap nothing (child is in its own session); return immediately.
+    kwargs = {"stdin": devnull, "stdout": devnull, "stderr": devnull}
+    if os.name == "nt":
+        # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP — no console, survives parent.
+        kwargs["creationflags"] = 0x00000008 | 0x00000200
+    else:
+        kwargs["start_new_session"] = True  # setsid — own session, no controlling tty
+    try:
+        subprocess.Popen(cmd, **kwargs)
+    except Exception:
+        # Fail-open: if we cannot spawn the worker, the commit still proceeds.
+        pass
 
 
 def main() -> int:
@@ -307,4 +307,8 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Detached background worker entry point (spawned by dispatch()).
+    if len(sys.argv) >= 4 and sys.argv[1] == "--worker":
+        run_worker(sys.argv[2], sys.argv[3])
+        sys.exit(0)
     sys.exit(main())


### PR DESCRIPTION
PATCH on v1.34.0. The background worker was detached with os.fork + os.setsid (POSIX-only), so on Windows Python it silently no-op'd — the cross-vendor review never ran there (fail-open, but ineffective). Replaced with a portable subprocess.Popen that re-invokes the hook in a new --worker mode: start_new_session on POSIX, DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP on Windows. Now dispatches on macOS/Linux/WSL AND Windows. Opt-in gating, scrubbing, and the never-a-gate invariant unchanged. Verified: meta_review PASSED, all 6 CI checks green, verify_cross_review_precommit 9/9, py_compile clean, live e2e confirms the detached worker writes its notes file. Version 1.34.0 -> 1.34.1. See CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)