### PR TITLE
fix(hooks): overridable Agent Teams auto-disable in cross-review hook (v1.34.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.34.1",
+      "version": "1.34.2",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.34.2] - 2026-06-29
+
+**Overridable Agent Teams auto-disable for `cross-review-precommit.sh`.** v1.34.0 disabled the background review whenever `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` was set. On a machine that runs Agent Teams as its *default*, that disabled the hook permanently — the background review could never fire. Split the guard: the **concrete** hazard (a linked/secondary worktree, where the index may hold another agent's staged work) remains an **unconditional** skip; the bare Agent Teams **flag** is now overridable with an explicit `CROSS_REVIEW_ALLOW_AGENT_TEAMS=1` (you thereby accept that an in-process parallel agent's staged change could ride along in the egressed diff). Safe-by-default is preserved; Agent-Teams-by-default users can now opt the hook back on. PATCH — no API/count change.
+
+### Fixed
+
+- **`hooks/cross-review-precommit.sh`** — the Agent Teams auto-disable is now overridable (`CROSS_REVIEW_ALLOW_AGENT_TEAMS=1`); the unconditional linked-worktree skip is unchanged. Verified on Windows (Agent Teams on): silent skip without the override, correct background dispatch with it.
+- **`tests/verify_cross_review_precommit.py`** — added an "Agent Teams + override -> DISPATCH" case (now 10 cases).
+- **Version 1.34.1 -> 1.34.2** across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the Version badge in `README.md` / `README.ru.md`.
+
 ## [1.34.1] - 2026-06-29
 
 **Cross-platform background dispatch for `cross-review-precommit.sh`.** The v1.34.0 hook detached its background worker with `os.fork` + `os.setsid`, which do not exist on Windows Python — there the worker silently no-op'd (fail-open, but the cross-vendor review never ran). Replaced with a portable `subprocess.Popen` that re-invokes the hook in a new `--worker` mode, using `start_new_session=True` on POSIX and `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows. The hook now actually dispatches on macOS/Linux/WSL **and** Windows. Behaviour, opt-in gating, scrubbing, and the never-a-gate invariant are unchanged; the 9-case test still passes and a live e2e confirms the detached worker writes its notes file. PATCH — no API/count change (still 20 hooks).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.34.1](https://img.shields.io/badge/Version-1.34.1-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.2](https://img.shields.io/badge/Version-1.34.2-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.34.1](https://img.shields.io/badge/Version-1.34.1-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.2](https://img.shields.io/badge/Version-1.34.2-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/adr/ADR-002-cross-review-opt-in-precommit.md
+++ b/docs/adr/ADR-002-cross-review-opt-in-precommit.md
@@ -67,8 +67,11 @@ The hook:
   background* codex→gemini review (or an honest "unavailable" note), and returns
   immediately. It MUST NOT block the commit and MUST NOT write the
   `/tmp/claude-review-done-*` sentinel — `/review` remains the mandatory floor.
-- **auto-disables** in Agent Teams / linked-worktree mode, and refuses to egress
-  if a high-confidence secret survives scrubbing.
+- **auto-disables** unconditionally in a linked/secondary worktree; the bare
+  Agent Teams flag also disables it but is overridable with
+  `CROSS_REVIEW_ALLOW_AGENT_TEAMS=1` (v1.34.2 — so machines that run Agent Teams
+  as their default can still use the hook). Refuses to egress if a high-confidence
+  secret survives scrubbing.
 - hard off-switch: `ITD_CROSS_REVIEW=0`.
 
 This is consistent with ADR-001 (no own runtime): the hook is code that runs on

--- a/hooks/cross-review-precommit.sh
+++ b/hooks/cross-review-precommit.sh
@@ -26,9 +26,11 @@ Design constraints (see docs/adr/ADR-002-cross-review-opt-in-precommit.md):
   • ASYNC. The external CLI (8-30s, can hang under a flaky VPN) runs in a
     detached child process (subprocess.Popen, cross-platform POSIX + Windows);
     the hook itself returns in well under its 5s registration timeout.
-  • AUTO-DISABLED in multi-agent / shared-worktree mode (Agent Teams, linked
-    worktree) — "which diff?" is undefined when concurrent agents share a tree,
-    and we must never egress another agent's uncommitted code.
+  • AUTO-DISABLED in a linked/secondary worktree (the index may hold another
+    agent's staged work) — unconditional. Also disabled when the Agent Teams flag
+    (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1) is set, UNLESS overridden with
+    CROSS_REVIEW_ALLOW_AGENT_TEAMS=1 (for machines that run Agent Teams as their
+    default and still want the background review).
   • SCRUB before egress (same patterns as pii-egress-guard.sh). If a live
     credential survives scrubbing, the diff is NOT sent — it degrades to a note.
   • Findings are NOTES, not a gate. This hook MUST NOT write the
@@ -240,7 +242,14 @@ def main() -> int:
         return 0
 
     # auto-disable in multi-agent / shared-worktree mode.
-    if os.environ.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS") == "1":
+    # The CONCRETE hazard is a linked/secondary worktree (the index may hold
+    # another agent's staged work) — that skip below is UNCONDITIONAL. The Agent
+    # Teams FLAG alone is a weaker proxy: on a machine where Agent Teams is the
+    # default it would disable the hook permanently, so it is overridable with an
+    # explicit CROSS_REVIEW_ALLOW_AGENT_TEAMS=1 (you thereby accept that an
+    # in-process parallel agent's staged change could ride along in the diff).
+    if (os.environ.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS") == "1"
+            and os.environ.get("CROSS_REVIEW_ALLOW_AGENT_TEAMS") != "1"):
         return 0
     gd, gcd = git(["rev-parse", "--git-dir"]), git(["rev-parse", "--git-common-dir"])
     if gd and gcd and os.path.realpath(gd) != os.path.realpath(gcd):

--- a/skills/cross-review/SKILL.md
+++ b/skills/cross-review/SKILL.md
@@ -129,9 +129,12 @@ instead of a phrase, and it keeps every invariant above:
   codex→gemini review, writes findings to a `claude-cross-review-*.md` notes file,
   and returns immediately. It NEVER blocks the commit and NEVER writes the
   `/review` sentinel — `/review` remains the mandatory floor.
-- **Auto-disabled** in Agent Teams / linked-worktree mode (where "the diff" is
-  ambiguous and egressing another agent's work would be unsafe), and it refuses to
-  egress at all if a live credential survives scrubbing.
+- **Auto-disabled** in a linked/secondary worktree (unconditional — the index may
+  hold another agent's staged work). Also disabled under the Agent Teams flag
+  (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) **unless** you override with
+  `CROSS_REVIEW_ALLOW_AGENT_TEAMS=1` (for machines that run Agent Teams as their
+  default and still want the background review). It also refuses to egress at all
+  if a live credential survives scrubbing.
 - **Hard off-switch:** `ITD_CROSS_REVIEW=0`.
 
 Why opt-in pre-commit and not always-on per-edit/per-turn: see

--- a/tests/verify_cross_review_precommit.py
+++ b/tests/verify_cross_review_precommit.py
@@ -117,6 +117,16 @@ def c_agent_teams_disabled(repo):
             SKIP)
 
 
+def c_agent_teams_override(repo):
+    # Agent Teams on, but explicit CROSS_REVIEW_ALLOW_AGENT_TEAMS=1 -> dispatch
+    stage(repo, "db/migrations/001_init.sql")
+    return ("git commit -m x",
+            {"CROSS_REVIEW_EGRESS_OK": "1",
+             "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+             "CROSS_REVIEW_ALLOW_AGENT_TEAMS": "1"},
+            DISPATCH)
+
+
 def c_payments_path(repo):
     open(os.path.join(repo, ".cross-review-egress-ok"), "w").close()
     stage(repo, "app/billing/payment_service.ts")
@@ -137,6 +147,7 @@ CASES = [
     ("not a commit -> SKIP", c_non_commit),
     ("off-switch ITD_CROSS_REVIEW=0 -> SKIP", c_off_switch),
     ("Agent Teams mode -> SKIP (auto-disable)", c_agent_teams_disabled),
+    ("Agent Teams + override -> DISPATCH", c_agent_teams_override),
     ("opt-in + payments path -> DISPATCH", c_payments_path),
     ("commit via && chain -> DISPATCH", c_amp_chain_commit),
 ]


### PR DESCRIPTION
PATCH on v1.34.1. v1.34.0 disabled the background review whenever CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 — on a machine that runs Agent Teams as its default this disabled the hook permanently. Split the guard: the concrete hazard (a linked/secondary worktree, where the index may hold another agent's staged work) stays an unconditional skip; the bare Agent Teams flag is now overridable with CROSS_REVIEW_ALLOW_AGENT_TEAMS=1. Safe-by-default preserved. Verified on Windows with Agent Teams on: silent skip without the override, correct background dispatch with it. Test now 10 cases; meta_review + all 6 CI checks green. Version 1.34.1 -> 1.34.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)