### PR TITLE
fix(hooks): full-path engine resolution so codex/gemini launch on Windows (v1.34.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.34.2",
+      "version": "1.34.3",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.34.3] - 2026-06-29
+
+**Actually launch the external CLI on Windows (`run_engine` full-path resolution).** The hook invoked `subprocess.run(["codex", ...])` by bare name. On Windows, npm installs `codex`/`gemini` as `.CMD` shims that `CreateProcess` cannot launch by bare name — `subprocess.run` raises `FileNotFoundError`, so the worker always fell through to "unavailable" even when codex was installed and on `PATH`. `run_engine` now resolves the CLI to its full path via `shutil.which()` (e.g. `...\codex.CMD`), which launches correctly on Windows and is a harmless no-op on POSIX. Also pass `codex exec --skip-git-repo-check` so a fresh clone / CI checkout (a directory codex does not yet "trust") does not hard-error. PATCH — no API/count change.
+
+### Fixed
+
+- **`hooks/cross-review-precommit.sh`** — `run_engine` resolves the engine binary via `shutil.which()` and invokes the full path, so the external review actually runs on Windows (where the CLI is a `.CMD` shim). Added `--skip-git-repo-check` to the codex invocation for untrusted/fresh repos.
+- **Version 1.34.2 -> 1.34.3** across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the Version badge in `README.md` / `README.ru.md`.
+
+> Note: this fix makes the methodology *invoke* codex/gemini correctly. Whether the external model then returns findings still depends on the user's CLI being healthy (authenticated, network-reachable, and — for codex — a `config.toml` the installed version accepts). The hook remains fail-open: any CLI error degrades to an honest "unavailable" note and never blocks the commit.
+
 ## [1.34.2] - 2026-06-29
 
 **Overridable Agent Teams auto-disable for `cross-review-precommit.sh`.** v1.34.0 disabled the background review whenever `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` was set. On a machine that runs Agent Teams as its *default*, that disabled the hook permanently — the background review could never fire. Split the guard: the **concrete** hazard (a linked/secondary worktree, where the index may hold another agent's staged work) remains an **unconditional** skip; the bare Agent Teams **flag** is now overridable with an explicit `CROSS_REVIEW_ALLOW_AGENT_TEAMS=1` (you thereby accept that an in-process parallel agent's staged change could ride along in the egressed diff). Safe-by-default is preserved; Agent-Teams-by-default users can now opt the hook back on. PATCH — no API/count change.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.34.2](https://img.shields.io/badge/Version-1.34.2-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.3](https://img.shields.io/badge/Version-1.34.3-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.34.2](https://img.shields.io/badge/Version-1.34.2-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.3](https://img.shields.io/badge/Version-1.34.3-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/hooks/cross-review-precommit.sh
+++ b/hooks/cross-review-precommit.sh
@@ -142,10 +142,19 @@ def append(notes: str, text: str) -> None:
 
 def run_engine(cmd: list, promptf: str):
     """Return (stdout, ok). ok=False on missing CLI, non-zero exit, timeout, or
-    empty output — all treated as 'engine unavailable'."""
+    empty output — all treated as 'engine unavailable'.
+
+    cmd[0] is resolved to its FULL path via shutil.which. This is required on
+    Windows, where npm installs `codex`/`gemini` as `.CMD` shims that
+    CreateProcess cannot launch by bare name (subprocess.run(['codex', ...])
+    raises FileNotFoundError); the resolved `...\\codex.CMD` path runs fine."""
+    exe = shutil.which(cmd[0])
+    if not exe:
+        return "", False
     try:
         with open(promptf, "r", encoding="utf-8") as f:
-            res = subprocess.run(cmd, stdin=f, capture_output=True, text=True, timeout=120)
+            res = subprocess.run([exe] + cmd[1:], stdin=f,
+                                 capture_output=True, text=True, timeout=120)
         out = (res.stdout or "").strip()
         return out, (res.returncode == 0 and bool(out))
     except Exception:
@@ -158,7 +167,9 @@ def run_worker(promptf: str, notes: str) -> None:
         "gemini" if shutil.which("gemini") else "none")
 
     if engine == "codex":
-        out, ok = run_engine(["codex", "exec", "-"], promptf)
+        # --skip-git-repo-check: codex exec otherwise refuses outside a dir it
+        # already "trusts", which a fresh clone / CI checkout is not.
+        out, ok = run_engine(["codex", "exec", "--skip-git-repo-check", "-"], promptf)
         if ok:
             append(notes, "## Findings (engine: codex)\n\n%s\n" % out)
             _cleanup(promptf)


### PR DESCRIPTION
PATCH. run_engine invoked codex by bare name; on Windows npm installs codex/gemini as .CMD shims CreateProcess cannot launch by bare name (FileNotFoundError), so it degraded to 'unavailable' even with codex on PATH. Now resolves via shutil.which() and invokes the full path; no-op on POSIX. Also codex exec --skip-git-repo-check. Fail-open unchanged. meta_review PASSED, all CI green, unit 10/10. v1.34.2 -> 1.34.3.