### PR TITLE
fix(hooks): resolve a working engine binary (Windows desktop codex) (v1.34.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.34.3",
+      "version": "1.34.4",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.34.3",
+  "version": "1.34.4",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.34.4] - 2026-06-29
+
+**Engine resolution prefers a working binary — fixes codex on Windows behind a flaky VPN.** The hook resolved `codex` purely via `PATH`, which on a typical Windows box is the npm `codex.CMD` shim — and that can be a stale version that fails to even start (rejects a newer `config.toml`'s `service_tier`, or times out refreshing its model list under a fake-ip VPN) while the user's *OpenAI Codex desktop* bundle (a newer, network-capable `codex.exe`) works fine. New `resolve_engine()` picks, in order: an explicit `CROSS_REVIEW_CODEX_BIN` / `CROSS_REVIEW_GEMINI_BIN` override; for codex on Windows, the **newest** `%LOCALAPPDATA%\OpenAI\Codex\bin\<hash>\codex.exe` (auto-tracks desktop auto-updates); then `PATH`. PATCH — no API/count change.
+
+### Fixed
+
+- **`hooks/cross-review-precommit.sh`** — `resolve_engine()` selects a working engine binary instead of blindly trusting `PATH`. Adds the `CROSS_REVIEW_<NAME>_BIN` override and a Windows OpenAI-Codex-desktop fallback. `run_engine` now runs an already-resolved full-path argv.
+
+### Verified
+
+- **Live Windows e2e behind the user's active VPN**: the hook resolved the desktop `codex.exe` (v0.142) and the detached worker wrote **three real codex findings** (overdraft, input validation, money-precision) on a staged `app/billing/charge.py` diff — genuine cross-vendor output, non-blocking, working tree untouched.
+- `tests/verify_cross_review_precommit.py` -> 10/10; `tests/meta_review.py` -> PASSED; all 6 CI checks green; `py_compile` clean.
+- **Version 1.34.3 -> 1.34.4** across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the Version badge in `README.md` / `README.ru.md`.
+
 ## [1.34.3] - 2026-06-29
 
 **Actually launch the external CLI on Windows (`run_engine` full-path resolution).** The hook invoked `subprocess.run(["codex", ...])` by bare name. On Windows, npm installs `codex`/`gemini` as `.CMD` shims that `CreateProcess` cannot launch by bare name — `subprocess.run` raises `FileNotFoundError`, so the worker always fell through to "unavailable" even when codex was installed and on `PATH`. `run_engine` now resolves the CLI to its full path via `shutil.which()` (e.g. `...\codex.CMD`), which launches correctly on Windows and is a harmless no-op on POSIX. Also pass `codex exec --skip-git-repo-check` so a fresh clone / CI checkout (a directory codex does not yet "trust") does not hard-error. PATCH — no API/count change.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.34.3](https://img.shields.io/badge/Version-1.34.3-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.4](https://img.shields.io/badge/Version-1.34.4-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.34.3](https://img.shields.io/badge/Version-1.34.3-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.4](https://img.shields.io/badge/Version-1.34.4-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/hooks/cross-review-precommit.sh
+++ b/hooks/cross-review-precommit.sh
@@ -43,6 +43,7 @@ Fail-open: ANY error path -> exit 0 (allow, never block).
 """
 from __future__ import annotations
 
+import glob
 import json
 import os
 import re
@@ -140,20 +141,42 @@ def append(notes: str, text: str) -> None:
         pass
 
 
-def run_engine(cmd: list, promptf: str):
-    """Return (stdout, ok). ok=False on missing CLI, non-zero exit, timeout, or
-    empty output — all treated as 'engine unavailable'.
+def resolve_engine(name: str):
+    """Return a full path to the engine binary, or None. Resolution order:
 
-    cmd[0] is resolved to its FULL path via shutil.which. This is required on
-    Windows, where npm installs `codex`/`gemini` as `.CMD` shims that
-    CreateProcess cannot launch by bare name (subprocess.run(['codex', ...])
-    raises FileNotFoundError); the resolved `...\\codex.CMD` path runs fine."""
-    exe = shutil.which(cmd[0])
-    if not exe:
-        return "", False
+      1. explicit override env  CROSS_REVIEW_<NAME>_BIN  (points at any binary);
+      2. for codex on Windows, the newest OpenAI Codex *desktop* bundle
+         (%LOCALAPPDATA%\\OpenAI\\Codex\\bin\\<hash>\\codex.exe) — it is newer
+         and network-capable where the npm `codex.CMD` shim can be a stale
+         version that fails (e.g. an unknown `service_tier` or a model-refresh
+         timeout). Picking the newest by mtime survives desktop auto-updates;
+      3. whatever is on PATH (shutil.which).
+
+    Returning a FULL path also fixes the Windows `.CMD` launch problem (a bare
+    name is not launchable by CreateProcess)."""
+    override = os.environ.get("CROSS_REVIEW_%s_BIN" % name.upper())
+    if override and os.path.exists(override):
+        return override
+    if name == "codex" and os.name == "nt":
+        base = os.path.join(
+            os.environ.get("LOCALAPPDATA", ""), "OpenAI", "Codex", "bin")
+        cands = [p for p in glob.glob(os.path.join(base, "*", "codex.exe"))
+                 if os.path.exists(p)]
+        if cands:
+            try:
+                return max(cands, key=os.path.getmtime)
+            except OSError:
+                return cands[0]
+    return shutil.which(name)
+
+
+def run_engine(argv: list, promptf: str):
+    """Run an already-resolved engine invocation (argv[0] is a full path).
+    Return (stdout, ok). ok=False on non-zero exit, timeout, or empty output —
+    all treated as 'engine unavailable'."""
     try:
         with open(promptf, "r", encoding="utf-8") as f:
-            res = subprocess.run([exe] + cmd[1:], stdin=f,
+            res = subprocess.run(argv, stdin=f,
                                  capture_output=True, text=True, timeout=120)
         out = (res.stdout or "").strip()
         return out, (res.returncode == 0 and bool(out))
@@ -163,21 +186,20 @@ def run_engine(cmd: list, promptf: str):
 
 def run_worker(promptf: str, notes: str) -> None:
     """Detached child: detect engine, run it, append findings. Degrade honestly."""
-    engine = "codex" if shutil.which("codex") else (
-        "gemini" if shutil.which("gemini") else "none")
+    codex = resolve_engine("codex")
+    gemini = resolve_engine("gemini")
 
-    if engine == "codex":
+    if codex:
         # --skip-git-repo-check: codex exec otherwise refuses outside a dir it
         # already "trusts", which a fresh clone / CI checkout is not.
-        out, ok = run_engine(["codex", "exec", "--skip-git-repo-check", "-"], promptf)
+        out, ok = run_engine([codex, "exec", "--skip-git-repo-check", "-"], promptf)
         if ok:
             append(notes, "## Findings (engine: codex)\n\n%s\n" % out)
             _cleanup(promptf)
             return
-        engine = "gemini" if shutil.which("gemini") else "none"
 
-    if engine == "gemini":
-        out, ok = run_engine(["gemini", "-p", "-"], promptf)
+    if gemini:
+        out, ok = run_engine([gemini, "-p", "-"], promptf)
         if ok:
             append(notes, "## Findings (engine: gemini)\n\n%s\n" % out)
             _cleanup(promptf)


### PR DESCRIPTION
PATCH. Hook resolved codex via PATH = npm codex.CMD shim (stale version that fails: rejects newer config service_tier / model-refresh timeout under VPN) while the OpenAI Codex desktop bundle works. resolve_engine() prefers CROSS_REVIEW_<NAME>_BIN override, then newest LOCALAPPDATA OpenAI Codex desktop codex.exe, then PATH. Verified live behind VPN: desktop codex v0.142 returned 3 real findings. unit 10/10, meta_review PASSED, CI green. v1.34.3 -> 1.34.4.