### PR TITLE
fix(hooks): reach Windows desktop codex from WSL via /mnt interop (v1.34.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.34.4",
+      "version": "1.34.5",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.34.4",
+  "version": "1.34.5",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.34.5] - 2026-06-29
+
+**Real cross-vendor review from inside WSL — reach the Windows Codex desktop binary over /mnt interop.** The standalone codex CLI inside WSL can be broken behind a fake-ip VPN (model-refresh timeout / Node crash), so a WSL-launched Claude Code session degraded cross-review to the native fallback. `resolve_engine` now, on WSL/Linux, also discovers the OpenAI Codex *desktop* `codex.exe` via the Windows mount (`/mnt/<drive>/Users/*/AppData/Local/OpenAI/Codex/bin/*/codex.exe`) and runs it through WSL interop — it executes as a Windows process and therefore uses the working Windows network stack. On a plain Linux box (no Windows mount) the glob matches nothing and resolution falls through to `PATH`, so nothing changes there. PATCH — no API/count change.
+
+### Fixed
+
+- **`hooks/cross-review-precommit.sh`** — `resolve_engine` gains a WSL→Windows-desktop-codex path (newest by mtime, survives desktop auto-updates), extracted a `_newest()` helper. The standalone CLI being unusable under a VPN no longer means "no cross-vendor review" in WSL.
+- **`tests/verify_cross_review_precommit.py`** — inject a dummy engine via `CROSS_REVIEW_{CODEX,GEMINI}_BIN=/bin/false` so the detached worker never fires a real (paid) call during testing now that resolution can find a real binary off `PATH`.
+- **Version 1.34.4 -> 1.34.5** across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the Version badge in `README.md` / `README.ru.md`.
+
+### Verified
+
+- **Live WSL run behind the user's active VPN**: `resolve_engine("codex")` resolved the Windows desktop `codex.exe` via `/mnt`, and `run_engine` returned **three real codex findings** (overdraft, input validation, money-precision) on a buggy `charge()` diff in 42.9s — the same module path the detached worker uses. (The full dispatch→detached-worker→notes chain was separately verified on Windows in v1.34.4.)
+- `tests/verify_cross_review_precommit.py` -> 10/10 (deterministic, no external call); `tests/meta_review.py` -> PASSED; all 6 CI checks green; `py_compile` clean.
+
 ## [1.34.4] - 2026-06-29
 
 **Engine resolution prefers a working binary — fixes codex on Windows behind a flaky VPN.** The hook resolved `codex` purely via `PATH`, which on a typical Windows box is the npm `codex.CMD` shim — and that can be a stale version that fails to even start (rejects a newer `config.toml`'s `service_tier`, or times out refreshing its model list under a fake-ip VPN) while the user's *OpenAI Codex desktop* bundle (a newer, network-capable `codex.exe`) works fine. New `resolve_engine()` picks, in order: an explicit `CROSS_REVIEW_CODEX_BIN` / `CROSS_REVIEW_GEMINI_BIN` override; for codex on Windows, the **newest** `%LOCALAPPDATA%\OpenAI\Codex\bin\<hash>\codex.exe` (auto-tracks desktop auto-updates); then `PATH`. PATCH — no API/count change.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.34.4](https://img.shields.io/badge/Version-1.34.4-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.5](https://img.shields.io/badge/Version-1.34.5-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.34.4](https://img.shields.io/badge/Version-1.34.4-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.34.5](https://img.shields.io/badge/Version-1.34.5-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/hooks/cross-review-precommit.sh
+++ b/hooks/cross-review-precommit.sh
@@ -141,32 +141,48 @@ def append(notes: str, text: str) -> None:
         pass
 
 
+def _newest(paths):
+    paths = [p for p in paths if os.path.exists(p)]
+    if not paths:
+        return None
+    try:
+        return max(paths, key=os.path.getmtime)
+    except OSError:
+        return paths[0]
+
+
 def resolve_engine(name: str):
     """Return a full path to the engine binary, or None. Resolution order:
 
       1. explicit override env  CROSS_REVIEW_<NAME>_BIN  (points at any binary);
-      2. for codex on Windows, the newest OpenAI Codex *desktop* bundle
-         (%LOCALAPPDATA%\\OpenAI\\Codex\\bin\\<hash>\\codex.exe) — it is newer
-         and network-capable where the npm `codex.CMD` shim can be a stale
-         version that fails (e.g. an unknown `service_tier` or a model-refresh
-         timeout). Picking the newest by mtime survives desktop auto-updates;
+      2. for codex, the newest OpenAI Codex *desktop* bundle — it is newer and
+         network-capable where the standalone CLI can fail (unknown `service_tier`,
+         or a model-refresh timeout behind a fake-ip VPN):
+           - on Windows: %LOCALAPPDATA%\\OpenAI\\Codex\\bin\\<hash>\\codex.exe;
+           - on WSL/Linux: the same Windows binary via /mnt interop
+             (/mnt/<drive>/Users/*/AppData/Local/OpenAI/Codex/bin/*/codex.exe).
+             It runs as a Windows process, so it uses the working Windows network
+             stack — the standalone WSL codex CLI may be broken under the VPN.
+         Picking the newest by mtime survives desktop auto-updates;
       3. whatever is on PATH (shutil.which).
 
     Returning a FULL path also fixes the Windows `.CMD` launch problem (a bare
-    name is not launchable by CreateProcess)."""
+    name is not launchable by CreateProcess). On a plain Linux box (no Windows
+    mount) the /mnt glob matches nothing and we fall straight through to PATH."""
     override = os.environ.get("CROSS_REVIEW_%s_BIN" % name.upper())
     if override and os.path.exists(override):
         return override
-    if name == "codex" and os.name == "nt":
-        base = os.path.join(
-            os.environ.get("LOCALAPPDATA", ""), "OpenAI", "Codex", "bin")
-        cands = [p for p in glob.glob(os.path.join(base, "*", "codex.exe"))
-                 if os.path.exists(p)]
-        if cands:
-            try:
-                return max(cands, key=os.path.getmtime)
-            except OSError:
-                return cands[0]
+    if name == "codex":
+        if os.name == "nt":
+            base = os.path.join(
+                os.environ.get("LOCALAPPDATA", ""), "OpenAI", "Codex", "bin")
+            found = _newest(glob.glob(os.path.join(base, "*", "codex.exe")))
+        else:
+            # WSL interop: reach the Windows desktop codex.exe across drive mounts.
+            found = _newest(glob.glob(
+                "/mnt/*/Users/*/AppData/Local/OpenAI/Codex/bin/*/codex.exe"))
+        if found:
+            return found
     return shutil.which(name)
 
 

--- a/tests/verify_cross_review_precommit.py
+++ b/tests/verify_cross_review_precommit.py
@@ -60,6 +60,12 @@ def run_hook(repo, command="git commit -m x", env_overrides=None):
         "PATH": SAFE_PATH,
         "HOME": os.environ.get("HOME", repo),
         "TMPDIR": tempfile.mkdtemp(prefix="xreview-tmp-"),
+        # Inject a dummy engine via the override so the detached worker never
+        # fires a real (paid) external call during testing — /bin/false exists
+        # and exits non-zero, so run_engine reports "unavailable" deterministically
+        # (and resolve_engine never reaches its desktop/PATH discovery).
+        "CROSS_REVIEW_CODEX_BIN": "/bin/false",
+        "CROSS_REVIEW_GEMINI_BIN": "/bin/false",
     }
     if env_overrides:
         env.update(env_overrides)


### PR DESCRIPTION
PATCH. WSL standalone codex CLI broken behind fake-ip VPN -> resolve_engine now discovers OpenAI Codex desktop codex.exe via /mnt interop (runs as Windows process -> working network). Plain Linux falls through to PATH. Verified live in WSL: 3 real findings on a buggy charge() diff (42.9s). unit 10/10, meta_review PASSED, CI green. v1.34.4 -> 1.34.5.