### PR TITLE
feat(methodology): auto-detect brownfield profile by repo maturity (v1.36.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.36.0] - 2026-07-01
+
+**Brownfield profile is now auto-detected — no per-project marker required.** Follow-up to v1.35.0: `itd-profile` no longer needs a hand-placed marker in each project. `hooks/check-skills.sh` resolves it from repo maturity, with an explicit marker overriding in either direction.
+
+### Changed
+
+- **`hooks/check-skills.sh` — `itd-profile` auto-detection.** Resolution order: (1) an explicit `itd-profile: brownfield|greenfield` (or `<!-- itd:… -->`) in the project's `CLAUDE.md` wins in either direction; (2) otherwise auto-detect by repo maturity — an established git history (`git rev-list --count HEAD` ≥ `ITD_BROWNFIELD_MIN_COMMITS`, default 25) is brownfield, a fresh/empty project (fewer commits, or no git) is greenfield. A mature repo (e.g. a 900-commit line-of-business app) becomes brownfield with zero configuration; a new project keeps the greenfield pipeline. The git call runs only when a greenfield hint actually fired, so ordinary prompts pay nothing.
+- **`hooks/check-skills.sh` — suppression matches a hint's primary skill.** A greenfield hint is filtered by its own `/skill` (the one after `используй`), never by a greenfield skill merely referenced in the prose — fixes the `/adopt` hint (which mentions `/blueprint`) being wrongly suppressed on a brownfield project (latent since v1.35.0, exposed by auto-detection).
+
+### Added
+
+- `tests/verify_brownfield_and_gate.py` — 5 new cases for auto-detection (mature repo → brownfield, fresh repo → greenfield, explicit greenfield/brownfield override, non-git dir → greenfield); 24/24 total.
+
+Escape hatch: a mature repo that still wants the greenfield pipeline for a big new feature sets `itd-profile: greenfield`. See `docs/project-profiles.md`. MINOR — backward-compatible; explicit v1.35.0 markers keep working.
+
 ## [1.35.0] - 2026-07-01
 
 **Methodology fits brownfield feature-work, not just greenfield builds — plus two false-positive fixes to the skill gate.** Five opt-in/additive changes that make the methodology effective on a mature existing codebase (feature/maintenance work, where the project's own `CLAUDE.md` is the real source of truth) without weakening the greenfield pipeline, which stays the default. Motivated by an honest self-audit on a large brownfield accounting project (OneOfS payment calendar): the greenfield pipeline was ceremony there, the skill-decision line was ~90% "не нужен" noise, and keyword triggers mis-fired (the word *deploy* inside "idea to deploy"; bare *переписать* on a letter edit).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.35.0](https://img.shields.io/badge/Version-1.35.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.36.0](https://img.shields.io/badge/Version-1.36.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.35.0](https://img.shields.io/badge/Version-1.35.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.36.0](https://img.shields.io/badge/Version-1.36.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/project-profiles.md
+++ b/docs/project-profiles.md
@@ -1,4 +1,4 @@
-# Project profiles & domain markers (v1.35.0)
+# Project profiles & domain markers (v1.36.0)
 
 idea-to-deploy is greenfield-first by default (idea → discover → blueprint →
 kickstart → … → deploy). That is the right shape when you build a product from
@@ -6,46 +6,56 @@ scratch. It is the wrong shape when the work is a **feature on a mature existing
 codebase** — there the greenfield pipeline is ceremony, and the project's own
 `CLAUDE.md` is the real source of truth.
 
-These **opt-in** markers let a project tell the methodology what kind of work it
-is. They change nothing by default: a project that sets no marker behaves
-exactly as before. Only the project's own `CLAUDE.md` (or `.claude/CLAUDE.md`)
-turns them on.
+Two markers let a project tell the methodology what kind of work it is:
+
+- **`itd-profile`** (brownfield vs greenfield) is **auto-detected** by repo
+  maturity from v1.36.0, and can be **overridden** explicitly in either
+  direction. Greenfield stays the default for a fresh project.
+- **`itd-domain: data-sensitive`** is **opt-in** — set it only when the project
+  mutates irreplaceable data.
+
+Markers live in the project's own `CLAUDE.md` (or `.claude/CLAUDE.md`),
+case-insensitive, matched in the first 8 KB.
 
 ---
 
-## `itd-profile: brownfield` — opt out of the greenfield pipeline
+## `itd-profile: brownfield` / `greenfield` — pick the right pipeline
 
-**What it does.** When the current project's `CLAUDE.md` contains this marker,
-the skill-hint hook (`hooks/check-skills.sh`) suppresses greenfield-pipeline
-hints so they stop firing on day-to-day feature work:
+**What it does.** On a **brownfield** project the skill-hint hook
+(`hooks/check-skills.sh`) suppresses greenfield-pipeline hints so they stop
+firing on day-to-day feature work:
 
 `/project`, `/blueprint`, `/discover`, `/kickstart`, `/guide`, `/strategy`,
 `/market-scan`, `/autopilot`.
 
 Everything else stays active — `/task`, `/bugfix`, `/refactor`, `/test`,
 `/review`, `/doc`, `/perf`, `/session-save`, `/migrate`, `/security-audit`, …
-The review gate and feature-branch discipline are untouched (they are equally
-valuable on brownfield).
+The review gate and feature-branch discipline are untouched (equally valuable on
+brownfield). A hint is matched by its own **primary** skill (the `/skill` after
+`используй`), never by a greenfield skill merely mentioned in the prose — so the
+`/adopt` hint, which references `/blueprint`, is not suppressed.
 
-**How to enable.** Put either form anywhere in the project's `CLAUDE.md`
-(case-insensitive, matched in the first 8 KB):
+**How it is resolved (v1.36.0).**
 
-```
-<!-- itd:brownfield -->
-```
+1. **Explicit marker wins**, in either direction. Put either form anywhere in
+   the project's `CLAUDE.md`:
 
-or, inside a YAML/front-matter-ish block:
+   ```
+   <!-- itd:brownfield -->      itd-profile: brownfield
+   <!-- itd:greenfield -->      itd-profile: greenfield
+   ```
 
-```
-itd-profile: brownfield
-```
+2. **Otherwise auto-detect by repo maturity.** An established git history
+   (`git rev-list --count HEAD` ≥ `ITD_BROWNFIELD_MIN_COMMITS`, default **25**)
+   → brownfield; a fresh or empty project (fewer commits, or no git repo)
+   → greenfield. Tune the threshold with the `ITD_BROWNFIELD_MIN_COMMITS`
+   environment variable.
 
-**When to use.** The project already has a substantial `CLAUDE.md` /
-architecture and you are adding features or fixing bugs, not bootstrapping a new
-product. `/adopt` can stamp this marker when it onboards a legacy project.
-
-**When NOT to use.** A new product build — leave it unset so the greenfield
-pipeline stays available.
+**When to override.** A mature repo where you want the greenfield pipeline back
+for a big new feature → set `itd-profile: greenfield`. A brand-new project you
+want treated as brownfield immediately → set `itd-profile: brownfield` (or let
+it flip automatically once history accrues). `/adopt` can stamp `brownfield`
+when it onboards a legacy project.
 
 ---
 
@@ -85,9 +95,13 @@ approved.
 
 ## Design guarantees
 
-- **Opt-in, additive.** No marker → no behaviour change. Greenfield projects are
-  never affected by these features.
-- **Project-declared, not global.** The markers live in the project's own
-  `CLAUDE.md`; the global methodology stays greenfield-first.
+- **Safe default.** A fresh project (few commits, or no git) stays greenfield —
+  the pipeline is available exactly as before. Auto-detection only flips an
+  *established* repo to brownfield, which is where the pipeline was ceremony
+  anyway; an explicit `itd-profile: greenfield` always overrides.
+- **`data-sensitive` is opt-in.** It never activates on its own — set it
+  deliberately.
+- **Override always wins.** An explicit `itd-profile:` marker beats
+  auto-detection in either direction; the project owner has the final say.
 - **Composable.** A project can set both markers (a brownfield, data-sensitive
   system — the common case for mature line-of-business software).

--- a/hooks/check-skills.sh
+++ b/hooks/check-skills.sh
@@ -492,27 +492,53 @@ TRIGGERS = [
 
 
 def project_profile(cwd: str) -> str:
-    """Optional per-project methodology profile marker (v1.35.0).
+    """Resolve the methodology profile for the project at `cwd` (v1.36.0).
 
-    Returns 'brownfield' when the project's CLAUDE.md opts out of the greenfield
-    pipeline, else '' (default = greenfield, no behaviour change). Marker forms
-    (case-insensitive, anywhere in the first 8 KB of the file):
-        itd-profile: brownfield
-        <!-- itd:brownfield -->
-    Opt-in only: greenfield projects never set it and are unaffected.
+    Precedence:
+      1. An explicit marker in the project's CLAUDE.md wins in EITHER direction
+         (case-insensitive, first 8 KB):
+             itd-profile: brownfield  /  <!-- itd:brownfield -->  -> 'brownfield'
+             itd-profile: greenfield  /  <!-- itd:greenfield -->  -> 'greenfield'
+      2. Otherwise AUTO-DETECT by repo maturity: an established git history
+         (>= ITD_BROWNFIELD_MIN_COMMITS commits, default 25) is 'brownfield';
+         a fresh/empty project (few or no commits, or no git repo) is
+         'greenfield' — the safe default that keeps the greenfield pipeline.
+
+    Returns 'brownfield' or 'greenfield'. Only 'brownfield' suppresses the
+    greenfield-pipeline hints in the caller. A mature repo that still wants the
+    pipeline (e.g. a big new feature) sets `itd-profile: greenfield` to opt back.
     """
     import re
+    # 1. Explicit marker (either direction) — check both CLAUDE.md locations.
     try:
         for name in ("CLAUDE.md", os.path.join(".claude", "CLAUDE.md")):
             p = os.path.join(cwd, name)
             if os.path.isfile(p):
                 with open(p, encoding="utf-8", errors="ignore") as f:
                     head = f.read(8192).lower()
+                if re.search(r"itd-profile:\s*greenfield|itd:greenfield", head):
+                    return "greenfield"
                 if re.search(r"itd-profile:\s*brownfield|itd:brownfield", head):
                     return "brownfield"
     except Exception:
         pass
-    return ""
+    # 2. Auto-detect by git maturity.
+    try:
+        threshold = int(os.environ.get("ITD_BROWNFIELD_MIN_COMMITS", "25"))
+    except Exception:
+        threshold = 25
+    try:
+        import subprocess
+        out = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=cwd, capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode == 0:
+            commits = int((out.stdout or "0").strip() or "0")
+            return "brownfield" if commits >= threshold else "greenfield"
+    except Exception:
+        pass
+    return "greenfield"
 
 
 # Hints whose skill belongs to the greenfield "idea → deploy" pipeline. In a
@@ -548,12 +574,22 @@ def main() -> int:
             hints.append(hint)
             seen.add(hint)
 
-    # (v1.35.0) Brownfield profile: opt-out of the greenfield pipeline. Only the
-    # project's own CLAUDE.md marker enables this; default behaviour unchanged.
-    cwd = (payload or {}).get("cwd") or os.getcwd()
-    if project_profile(cwd) == "brownfield":
-        hints = [h for h in hints
-                 if not any(s in h for s in _GREENFIELD_SKILLS)]
+    # (v1.36.0) Brownfield profile: suppress greenfield-pipeline hints on a
+    # mature/existing codebase. Auto-detected by repo maturity, overridable by an
+    # explicit marker (see project_profile). Match a hint by its OWN (primary)
+    # skill — the first "/skill" token, i.e. the one after "используй" — never by
+    # a greenfield skill merely mentioned in the prose (e.g. the /adopt hint
+    # references /blueprint). Resolve only when a greenfield hint actually fired,
+    # to avoid the git call on ordinary prompts.
+    def _primary_skill(h):
+        m = re.search(r"/([a-z][a-z-]+)", h)
+        return "/" + m.group(1) if m else ""
+
+    if any(_primary_skill(h) in _GREENFIELD_SKILLS for h in hints):
+        cwd = (payload or {}).get("cwd") or os.getcwd()
+        if project_profile(cwd) == "brownfield":
+            hints = [h for h in hints
+                     if _primary_skill(h) not in _GREENFIELD_SKILLS]
 
     if not hints:
         return 0

--- a/tests/verify_brownfield_and_gate.py
+++ b/tests/verify_brownfield_and_gate.py
@@ -99,6 +99,51 @@ except Exception as ex:  # noqa
     print("   error:", ex)
 
 
+# --- check-skills.sh: brownfield AUTO-DETECT by git maturity (v1.36.0) -----
+import subprocess as _sp
+
+
+def _git_project(n_commits, marker=None):
+    d = tempfile.mkdtemp(prefix="itd-git-")
+    env = dict(os.environ, GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@t",
+               GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@t")
+    _sp.run(["git", "init", "-q"], cwd=d, env=env, check=True)
+    if marker is not None:
+        with open(os.path.join(d, "CLAUDE.md"), "w", encoding="utf-8") as f:
+            f.write("# p\n%s\n" % marker)
+    for i in range(n_commits):
+        _sp.run(["git", "commit", "-q", "--allow-empty", "-m", "c%d" % i],
+                cwd=d, env=env, check=True)
+    return d
+
+
+try:
+    THR = {"ITD_BROWNFIELD_MIN_COMMITS": "3"}
+
+    def _gf(cwd):  # greenfield-prompt hints for a project at cwd (threshold=3)
+        return _run(CHECK_SKILLS, {"prompt": GREENFIELD_PROMPT, "cwd": cwd},
+                    cwd=cwd, env=THR)[1]
+
+    mature = _git_project(4)
+    check("auto: mature git repo (no marker) -> /project suppressed",
+          "/project" not in _gf(mature))
+    fresh = _git_project(1)
+    check("auto: fresh git repo (< threshold) -> /project fires",
+          "/project" in _gf(fresh))
+    override = _git_project(4, marker="itd-profile: greenfield")
+    check("override: mature repo + itd-profile: greenfield -> /project fires",
+          "/project" in _gf(override))
+    nongit = tempfile.mkdtemp(prefix="itd-nogit-")
+    check("auto: non-git dir -> greenfield default -> /project fires",
+          "/project" in _gf(nongit))
+    mkbf = _git_project(1, marker="<!-- itd:brownfield -->")
+    check("override: fresh repo + brownfield marker -> /project suppressed",
+          "/project" not in _gf(mkbf))
+except Exception as ex:  # noqa
+    check("auto-detect block ran without error", False)
+    print("   error:", ex)
+
+
 # --- check-tool-skill.sh: read-only vs mutating ---------------------------
 def tool_out(cmd):
     return _run(CHECK_TOOL, {"tool_name": "Bash", "tool_input": {"command": cmd}})


### PR DESCRIPTION
## What & why

Follow-up to #94 (v1.35.0). The brownfield profile needed a **hand-placed marker per project** — this makes it **auto-detected** so a mature repo gets it with zero configuration, while keeping an explicit override in either direction.

## Changes

- **Auto-detect `itd-profile`** (`hooks/check-skills.sh`). Resolution order:
  1. explicit `itd-profile: brownfield|greenfield` (or `<!-- itd:… -->`) in the project's `CLAUDE.md` wins in either direction;
  2. otherwise auto-detect by git maturity — `git rev-list --count HEAD ≥ ITD_BROWNFIELD_MIN_COMMITS` (default **25**) → brownfield; a fresh / no-git project → greenfield (safe default, keeps the pipeline).

  A 900-commit line-of-business app becomes brownfield with no config; a new project stays greenfield. The git call runs **only** when a greenfield hint actually fired, so ordinary prompts pay nothing.
- **Primary-skill suppression fix.** A greenfield hint is filtered by its own `/skill` (the one after `используй`), never by a greenfield skill merely mentioned in the prose — fixes the `/adopt` hint (which references `/blueprint`) being wrongly suppressed on a brownfield project (latent since v1.35.0, surfaced by auto-detection and caught by the test).
- `docs/project-profiles.md` — document auto-detection + the `itd-profile: greenfield` escape hatch.

## Tests

- `tests/verify_brownfield_and_gate.py` — **24/24** (+5 auto-detect cases: mature→brownfield, fresh→greenfield, explicit greenfield/brownfield override, non-git→greenfield)
- `tests/verify_skill_enforcement.py` — 10/10 (drift-guard intact)
- `tests/meta_review.py` — PASSED · `py_compile` — clean

Version 1.35.0 → **1.36.0** (MINOR, backward-compatible — explicit v1.35.0 markers keep working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
