### PR TITLE
feat(methodology): wire always-on hooks + merge-safe sync + harness-map v1.37.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.36.0",
+      "version": "1.37.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.37.0] - 2026-07-01
+
+**Close the "orphan hook" gap — self-correction and observability hooks are now actually wired, and the two machines converge.** A 6-dimension methodology audit (effectiveness across project types, greenfield/brownfield, default-on Win+WSL, component wiring, Harness Engineering, Agentic Engineering) found that `careful`, `execution-trace`, `stuck-detection`, `crash-recovery`, and `context-aware` shipped into `~/.claude/hooks/` but were **not in the canonical registration set** — so they silently never fired, while `HARNESS_ENGINEERING_MAP.md` counted them as active (declaration ≠ reality). `careful` worked on one machine only because it had been added by hand.
+
+### Changed
+
+- **`scripts/sync-to-active.sh` — canonical hook registration now includes the always-on self-correction / observability / guardrail hooks.** Added to `DESIRED_HOOKS`: `context-aware` (UserPromptSubmit), `execution-trace` (PreToolUse `*`), `careful` (PreToolUse `Bash`), `stuck-detection` + `crash-recovery` (PostToolUse `*`). `freeze` stays opt-in by design. Registered ITD hooks 14 → 19 (of 20 files).
+- **`scripts/sync-to-active.sh` — the settings.json patch is now a MERGE, not a full replace.** It updates only the ITD-managed event keys (UserPromptSubmit / PreToolUse / PostToolUse) and **preserves foreign event keys** (e.g. a SessionStart hook registered by another plugin such as context-mode), which the old full-replace silently clobbered. The drift check compares only the ITD keys, so a foreign key no longer reads as perpetual drift.
+- **`docs/HARNESS_ENGINEERING_MAP.md` — updated to v1.37.0.** Counts 33→38 skills / 16→20 hooks; `careful` reclassified opt-in → always-on; the 4 previously-missing hooks (`pii-egress-guard`, `record-agent-skill`, `risk-score`, `cross-review-precommit`) added to §8.2; §8.3 recount 7→8 blocking / 9→12 soft; a v1.37.0 note records the declaration↔reality fix.
+
+### Added
+
+- **`docs/project-profiles.md` — "Recommended skill sets by scenario" matrix + complexity axis.** Formalizes project-kind/complexity → skill-set, removing the last heuristic gap for point 1 of the audit (projects of different kind/complexity).
+
+Deploy-time config facts fixed outside the repo (per-machine): WSL was missing `careful` + `CAREFUL_MODE=1` and both machines' `settings.json` diverged — resolved by re-syncing both to the new canonical set + adding the env var on WSL. MINOR — additive registration + docs; no skill/agent count change.
+
 ## [1.36.0] - 2026-07-01
 
 **Brownfield profile is now auto-detected — no per-project marker required.** Follow-up to v1.35.0: `itd-profile` no longer needs a hand-placed marker in each project. `hooks/check-skills.sh` resolves it from repo maturity, with an explicit marker overriding in either direction.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.36.0](https://img.shields.io/badge/Version-1.36.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.37.0](https://img.shields.io/badge/Version-1.37.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.36.0](https://img.shields.io/badge/Version-1.36.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.37.0](https://img.shields.io/badge/Version-1.37.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/HARNESS_ENGINEERING_MAP.md
+++ b/docs/HARNESS_ENGINEERING_MAP.md
@@ -1,7 +1,7 @@
 # Harness Engineering Map: idea-to-deploy ↔ Харнес-инженерия
 
-> Дата: 2026-06-22
-> Версия idea-to-deploy: **v1.21.0** (`main` = `1e95ddb`)
+> Дата: 2026-07-01 (обновлено; исходная карта — 2026-06-22)
+> Версия idea-to-deploy: **v1.37.0** (карта H1–H5 составлена по v1.21.0; §3/§4/§8 сверены с v1.37.0)
 > Источник: [Harness Engineering (walkinglabs)](https://walkinglabs.github.io/learn-harness-engineering/ru/)
 > Цель: проверить, в полной ли мере методология отражает философию, 5 принципов и инструменты харнес-инженерии; артикулировать gap'ы; зафиксировать осознанные out-of-scope решения.
 
@@ -32,7 +32,7 @@
 
 Статусы: ✅ **покрыто** (явная реализация с контрактом) · ◐ **частично** (gap артикулирован в §5) · ❌ **gap** (не реализовано и не замещено).
 
-Проверка — чтением `main` (`1e95ddb`, v1.21.0): **33 skills, 10 subagents, 16 hooks, 2 Quality Gates**, слой контрактов `.itd/` (`docs/templates/itd/`), session-memory, 3 уровня качества (structural / snapshot / behavioural), бинарные rubric'и `/review` · `/security-audit` · `/deps-audit`.
+Проверка — чтением `main` (v1.37.0): **38 skills, 10 subagents, 20 hooks, 2 Quality Gates**, слой контрактов `.itd/` (`docs/templates/itd/`), session-memory, 3 уровня качества (structural / snapshot / behavioural), бинарные rubric'и `/review` · `/security-audit` · `/deps-audit`. С v1.37.0 канонический набор регистрации (`scripts/sync-to-active.sh`) включает always-on хуки само-коррекции и наблюдаемости (`careful`, `stuck-detection`, `crash-recovery`, `execution-trace`, `context-aware`) — ранее они лежали в `~/.claude/hooks/`, но не были зарегистрированы; `freeze` остаётся opt-in.
 
 ## 4. Таблица соответствия
 
@@ -40,7 +40,7 @@
 
 | Тезис курса | Статус | Воплощение |
 |---|:---:|---|
-| **«Harness важнее, чем умная модель»** — замкнутая система с явными правилами и границами | ✅ | **Дословно центральный тезис методологии**: 33 skills + 10 agents + 16 hooks + 2 Quality Gates + слой контрактов `.itd/` поверх Claude Code. Codegen — следствие harness'а (ср. `K11`) |
+| **«Harness важнее, чем умная модель»** — замкнутая система с явными правилами и границами | ✅ | **Дословно центральный тезис методологии**: 38 skills + 10 agents + 20 hooks + 2 Quality Gates + слой контрактов `.itd/` поверх Claude Code. Codegen — следствие harness'а (ср. `K11`) |
 | **Харнес-инженерия как output** — методология не только *сама* харнес, но и *учит строить* харнес продукта пользователя | ✅ (v1.32.0–v1.33.0) | **Два слоя.** *Operating*: ITD = харнес над Claude Code. *Output* (порты Day-3/5): врезки проектируют харнес агента пользователя — память/контекст (`/blueprint` Step 1.6, `/security-audit` `MEM-1..7`), eval-петли (`/test`, `/harden` `EVAL-1`), Zero-Trust guardrails (`/harden` `ZT-1`, semantic gating = ASK). ADR-001: учим+аудируем, не движок |
 
 ### 4.2. 5 ключевых принципов
@@ -132,14 +132,14 @@
 
 Центральный принцип PFO: **computational — для блокирующих инвариантов, inferential — для семантики.** Жёсткий блок (`deny`) должен быть чисто вычислительным; если проверка требует семантического суждения — она обязана быть мягкой (hint), а не `deny`, иначе в гейт входит недетерминизм.
 
-### 8.1. Все 16 хуков по квадрантам
+### 8.1. Все 20 хуков по квадрантам
 
 | | **Computational** (детерминированный) | **Inferential** (интерпретирует модель) |
 |---|---|---|
-| **Feedforward** (до действия) | **Жёсткие guardrail'ы (все blocking):** `check-tool-skill` · `check-commit-completeness` · `check-review-before-commit` · `check-dod-before-commit` · `check-skill-completeness` · `freeze`* · `careful`* | **Формирование контекста (soft):** `check-skills` · `context-aware` · `pre-flight-check` · `session-open-diagnostic` · `context-budget` |
-| **Feedback** (после действия) | **Наблюдаемость (soft):** `cost-tracker` · `execution-trace`** | **Само-коррекция (soft):** `stuck-detection` · `crash-recovery` |
+| **Feedforward** (до действия) | **Жёсткие guardrail'ы (все blocking):** `check-tool-skill` · `check-commit-completeness` · `check-review-before-commit` · `check-dod-before-commit` · `check-skill-completeness` · `pii-egress-guard` · `careful` · `freeze`* | **Формирование контекста (soft):** `check-skills` · `context-aware` · `pre-flight-check` · `session-open-diagnostic` · `context-budget` |
+| **Feedback** (после действия) | **Наблюдаемость / учёт (soft):** `cost-tracker` · `execution-trace`** · `record-agent-skill` · `risk-score` · `cross-review-precommit` (fail-open) | **Само-коррекция (soft):** `stuck-detection` · `crash-recovery` |
 
-`*` opt-in (активны только при наличии trigger-файла). `**` `execution-trace` — тайминг PreToolUse, но роль наблюдательная (пишет JSONL-трейс, zero-context, никогда не блокирует) → отнесён к feedback по роли, а не по событию.
+`*` `freeze` — opt-in (активен только при активном scope-lock). `careful` с v1.37.0 в каноническом наборе (always-on). `**` `execution-trace` — тайминг PreToolUse, но роль наблюдательная (пишет JSONL-трейс, zero-context, никогда не блокирует) → отнесён к feedback по роли, а не по событию.
 
 ### 8.2. Подробно по хукам
 
@@ -151,7 +151,8 @@
 | `check-dod-before-commit.sh` | PreToolUse | feedforward | computational | **blocking** — `deny` commit'а с риск-сигналом (миграция/деньги/новый код без теста) без нужного скилла |
 | `check-skill-completeness.sh` | PreToolUse | feedforward | computational | **blocking** — `deny` записи SKILL.md без artefacts (был PostToolUse-баг в v1.5.0 → исправлен в v1.5.1) |
 | `freeze.sh` | PreToolUse | feedforward | computational | **blocking** (opt-in) — `deny` правок замороженных файлов |
-| `careful.sh` | PreToolUse | feedforward | computational | **blocking** (opt-in) — режим повышенной осторожности (`ask`/`deny`) |
+| `careful.sh` | PreToolUse | feedforward | computational | **blocking** (v1.37.0 always-on) — детект деструктивных команд (`rm -rf`, `DROP TABLE`, `git push --force`) → `ask`/`deny` |
+| `pii-egress-guard.sh` | PreToolUse (Bash\|WebFetch) | feedforward | computational | **blocking** — `deny`/`exit 2` при попытке отправить PII/секреты вовне |
 | `check-skills.sh` | UserPromptSubmit | feedforward | inferential | soft — инжектит skill-hint; маршрут выбирает модель |
 | `context-aware.sh` | UserPromptSubmit | feedforward | inferential | soft — инжектит проектный контекст |
 | `pre-flight-check.sh` | UserPromptSubmit | feedforward | inferential | soft — git-статус + `MEMORY.md` в контекст для resume |
@@ -161,13 +162,18 @@
 | `execution-trace.sh` | PreToolUse | feedback | computational | soft — observability: JSONL-трейс tool-call'ов, zero-context |
 | `stuck-detection.sh` | PostToolUse | feedback | inferential | soft — детект застревания → напоминание сменить подход |
 | `crash-recovery.sh` | PostToolUse | feedback | inferential | soft — recovery-контекст после краша для возобновления |
+| `record-agent-skill.sh` | PostToolUse (Task\|Agent) | feedback | computational | soft — пишет skill-sentinel, когда review/test/security делегированы субагенту (чтобы commit-гейты это засчитали) |
+| `risk-score.sh` | PostToolUse | feedback | computational | soft — оценка риск-сигнала действия (не блокирует) |
+| `cross-review-precommit.sh` | PreToolUse (Bash) | feedback | computational | soft (**fail-open**) — диспетчеризует независимый cross-vendor review диффа перед commit; аддитивно к `/review`, не гейт |
 
 ### 8.3. Что показывает линза
 
-- **Все 7 блокирующих хуков — computational × feedforward.** Методология **нигде** не вешает жёсткий `deny` на inferential-суждение модели — ровно принцип PFO «computational для блокирующих инвариантов». Гейт детерминирован: блокирует git-состояние/счётчик/наличие файла, а не «мнение» модели.
-- **9 soft-хуков** распределены: 5 формируют контекст (inferential feedforward), 2 наблюдают (computational feedback), 2 помогают само-коррекции (inferential feedback). Ни один не претендует на жёсткий блок — потому что их сигнал семантический.
+- **Все 8 блокирующих хуков — computational × feedforward.** Методология **нигде** не вешает жёсткий `deny` на inferential-суждение модели — ровно принцип PFO «computational для блокирующих инвариантов». Гейт детерминирован: блокирует git-состояние/счётчик/наличие файла/детект PII, а не «мнение» модели.
+- **12 soft-хуков** распределены: 5 формируют контекст (inferential feedforward), 5 наблюдают/учитывают (computational feedback), 2 помогают само-коррекции (inferential feedback). Ни один не претендует на жёсткий блок — потому что их сигнал семантический.
 - **Правило дизайна для будущих хуков (следствие):** новый хук, который должен *блокировать*, обязан быть computational; если проверка по сути требует семантического суждения — она должна быть мягким hint'ом (как `check-skills` или `context-budget`), а не `deny`. Inferential-блок = недетерминированный гейт, что противоречит H1/H3.
 
 ---
 
 **Обновление документа.** При изменении числа скиллов/хуков, закрытии gap'а или изменении принципов курса — обновлять §4, §6 и §8 (классификацию). Если gap закрывается — статус → ✅ с пометкой о версии-релизе.
+
+> **v1.37.0.** Устранён разрыв «декларация ↔ реальность»: хуки наблюдаемости и само-коррекции (`execution-trace`, `stuck-detection`, `crash-recovery`, `context-aware`) и guardrail `careful` физически лежали в `~/.claude/hooks/`, но **не были в наборе регистрации** `scripts/sync-to-active.sh` → де-факто молчали, хотя §8.1 числил их активными. Теперь они в каноническом наборе (always-on), а sync **мержит** ITD-события, сохраняя чужие (напр. SessionStart другого плагина). H5-наблюдаемость и Agentic-само-коррекция стали фактически, а не на бумаге. `freeze` остаётся opt-in по дизайну.

--- a/docs/project-profiles.md
+++ b/docs/project-profiles.md
@@ -105,3 +105,35 @@ approved.
   auto-detection in either direction; the project owner has the final say.
 - **Composable.** A project can set both markers (a brownfield, data-sensitive
   system — the common case for mature line-of-business software).
+
+---
+
+## Recommended skill sets by scenario (v1.37.0)
+
+The profile picks *which pipeline* fits; this matrix maps the **scenario** to the
+skills that carry it. It removes the last of the "the model guesses" heuristic
+for point-1 (projects of different kind/complexity). Use it as guidance, not a
+hard gate — the skill-hint hook still routes per prompt.
+
+| Scenario | Recommended skills (in order) |
+|---|---|
+| **New product from an idea** (greenfield) | `/discover` → `/blueprint` → `/kickstart` → `/review` → `/test` → `/harden` → `/deploy` |
+| **New feature on an existing codebase** (brownfield) | `/task` → (`/bugfix` \| `/refactor` \| `/perf`) → `/test` → `/review` → `/session-save` |
+| **Bug fix** | `/bugfix` (root-cause gate) → `/test` (regression) → `/review` |
+| **Refactor / tech debt** | `/refactor` → `/test` → `/review`; `/deps-audit` if dependencies |
+| **Data-sensitive change** (`itd-domain: data-sensitive`) | model read-only first → `/task` → `/migrate` (backup + rollback) → `/review`; **never** mutate prod from an ad-hoc command |
+| **Security-critical** (auth / payments / secrets) | `/security-audit` + security-guidance plugin → `/review` |
+| **Legacy onboarding** | `/adopt` → `/strategy` or `/blueprint` |
+| **Advisory / "analyze, don't code"** | `/advisor` (or `/grill-me` to stress-test a decision) — read-only |
+| **Docs** | `/doc` |
+| **Trivial / small script** | minimal — `Скилл: не нужен` (or `SKILL_BYPASS`); no ceremony |
+
+**Complexity axis (how much ceremony):**
+
+- **Trivial** (one-liner, throwaway script) → skip the pipeline; declare `не нужен`.
+- **Small** (single-file feature/fix) → the relevant single skill + `/review`.
+- **Medium** (multi-file feature) → `/task` router + `/test` + `/review` + `/session-save`.
+- **Large** (new product / subsystem) → the full greenfield or brownfield chain above.
+
+Always-on regardless of size: the review gate before a multi-file commit, tests
+for new source, and a session checkpoint at meaningful state changes.

--- a/scripts/sync-to-active.sh
+++ b/scripts/sync-to-active.sh
@@ -239,7 +239,8 @@ DESIRED_HOOKS=$(cat <<'JSON'
       "hooks": [
         { "type": "command", "command": "~/.claude/hooks/session-open-diagnostic.sh", "timeout": 5 },
         { "type": "command", "command": "~/.claude/hooks/pre-flight-check.sh",        "timeout": 5 },
-        { "type": "command", "command": "~/.claude/hooks/check-skills.sh",            "timeout": 5 }
+        { "type": "command", "command": "~/.claude/hooks/check-skills.sh",            "timeout": 5 },
+        { "type": "command", "command": "~/.claude/hooks/context-aware.sh",           "timeout": 5 }
       ]
     }
   ],
@@ -251,13 +252,20 @@ DESIRED_HOOKS=$(cat <<'JSON'
       ]
     },
     {
+      "matcher": "*",
+      "hooks": [
+        { "type": "command", "command": "~/.claude/hooks/execution-trace.sh", "timeout": 5 }
+      ]
+    },
+    {
       "matcher": "Bash",
       "hooks": [
         { "type": "command", "command": "~/.claude/hooks/check-commit-completeness.sh",   "timeout": 5 },
         { "type": "command", "command": "~/.claude/hooks/check-review-before-commit.sh",  "timeout": 5 },
         { "type": "command", "command": "~/.claude/hooks/check-dod-before-commit.sh",     "timeout": 5 },
         { "type": "command", "command": "~/.claude/hooks/cross-review-precommit.sh",      "timeout": 5 },
-        { "type": "command", "command": "~/.claude/hooks/context-budget.sh",              "timeout": 5 }
+        { "type": "command", "command": "~/.claude/hooks/context-budget.sh",              "timeout": 5 },
+        { "type": "command", "command": "~/.claude/hooks/careful.sh",                     "timeout": 5 }
       ]
     },
     {
@@ -283,8 +291,10 @@ DESIRED_HOOKS=$(cat <<'JSON'
     {
       "matcher": "*",
       "hooks": [
-        { "type": "command", "command": "~/.claude/hooks/cost-tracker.sh", "timeout": 5 },
-        { "type": "command", "command": "~/.claude/hooks/risk-score.sh",   "timeout": 5 }
+        { "type": "command", "command": "~/.claude/hooks/cost-tracker.sh",      "timeout": 5 },
+        { "type": "command", "command": "~/.claude/hooks/risk-score.sh",        "timeout": 5 },
+        { "type": "command", "command": "~/.claude/hooks/stuck-detection.sh",   "timeout": 5 },
+        { "type": "command", "command": "~/.claude/hooks/crash-recovery.sh",    "timeout": 5 }
       ]
     }
   ]
@@ -292,13 +302,17 @@ DESIRED_HOOKS=$(cat <<'JSON'
 JSON
 )
 
-# Check if current settings.json hooks already matches desired
+# Check if current settings.json hooks already matches desired. Compare only the
+# ITD-managed event keys — foreign keys (e.g. a SessionStart hook registered by
+# another plugin) are preserved by the merge below and must not read as "drift".
 current_hooks=$(python3 -c "
 import json, sys
+KEYS = ('UserPromptSubmit', 'PreToolUse', 'PostToolUse')
 try:
     with open('$SETTINGS') as f:
         data = json.load(f)
-    print(json.dumps(data.get('hooks', {}), sort_keys=True))
+    h = data.get('hooks', {})
+    print(json.dumps({k: h.get(k) for k in KEYS}, sort_keys=True))
 except Exception as e:
     print('ERROR:' + str(e))
     sys.exit(0)
@@ -325,7 +339,13 @@ import json, sys
 path = sys.argv[1]
 with open(path) as f:
     data = json.load(f)
-data['hooks'] = $DESIRED_HOOKS
+_itd = $DESIRED_HOOKS
+# Merge the ITD-managed event keys; preserve any foreign event keys (e.g. a
+# SessionStart hook registered by another plugin such as context-mode). ITD owns
+# UserPromptSubmit/PreToolUse/PostToolUse in full, so replacing those is correct.
+data.setdefault('hooks', {})
+for _k, _v in _itd.items():
+    data['hooks'][_k] = _v
 with open(path, 'w') as f:
     json.dump(data, f, indent=2, ensure_ascii=False)
     f.write('\n')


### PR DESCRIPTION
## What & why

Output of an **evidence-based 6-dimension audit** of the methodology (effectiveness across project types, greenfield/brownfield, default-on Win+WSL, component wiring, Harness Engineering, Agentic Engineering). The audit found the weakest point was **component wiring**: `careful`, `execution-trace`, `stuck-detection`, `crash-recovery`, `context-aware` shipped into `~/.claude/hooks/` but were **never in the canonical registration set** — so they silently didn't fire, while `HARNESS_ENGINEERING_MAP.md` counted them as active (declaration ≠ reality). `careful` "worked" on one machine only because it had been added by hand.

## Changes

- **`scripts/sync-to-active.sh` — register the always-on hooks.** `DESIRED_HOOKS` now includes `context-aware` (UserPromptSubmit), `execution-trace` (PreToolUse `*`), `careful` (PreToolUse `Bash`), `stuck-detection` + `crash-recovery` (PostToolUse `*`). `freeze` stays opt-in. Registered ITD hooks 14 → 19 (of 20 files).
- **`scripts/sync-to-active.sh` — merge, not replace.** The settings.json patch now updates only the ITD-managed event keys and **preserves foreign event keys** (e.g. a SessionStart hook from another plugin such as context-mode) that the old full-replace silently clobbered. Drift check compares only ITD keys. **Sandbox-verified**: foreign `SessionStart` + `theme` preserved, all 5 new hooks registered.
- **`docs/HARNESS_ENGINEERING_MAP.md` → v1.37.0.** 33→38 skills / 16→20 hooks; `careful` opt-in → always-on; the 4 previously-missing hooks (`pii-egress-guard`, `record-agent-skill`, `risk-score`, `cross-review-precommit`) added to §8.2; §8.3 recount 7→8 blocking / 9→12 soft; a v1.37.0 note records the declaration↔reality fix.
- **`docs/project-profiles.md` — scenario → skill-set matrix + complexity axis.** Closes the point-1 heuristic gap (projects of different kind/complexity).

## Tests

- `tests/verify_brownfield_and_gate.py` — 24/24 · `tests/verify_skill_enforcement.py` — 10/10 · `tests/meta_review.py` — PASSED · `sync-to-active.sh` `bash -n` clean · merge sandbox-test green.

Version 1.36.0 → **1.37.0** (MINOR — additive registration + docs; no skill/agent count change).

Deploy-time (per-machine, not in repo): WSL was missing `careful` + `CAREFUL_MODE=1` and the two machines' `settings.json` diverged — resolved by re-syncing both to this new canonical set + adding the env var on WSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
