### PR TITLE
feat(sync): platform-aware hook registration (Windows sync from WSL) v1.38.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
 
+## [1.38.0] - 2026-07-01
+
+**`sync-to-active.sh` is now platform-aware — a Windows `~/.claude` can be synced from WSL, no more hand-editing.** Closes the last piece of the v1.37.0 audit's "default-on Win+WSL" gap: the sync script previously emitted only bare `~/.claude/hooks/X.sh` commands (correct on WSL, which runs them via shebang), so the Windows install had to be hand-maintained — Windows invokes `.sh` hooks through `python.exe`, not a shebang.
+
+### Changed
+
+- **`scripts/sync-to-active.sh` — platform-aware hook-command emission.** On a Windows target each `~/.claude/hooks/X.sh` is rewritten to `"<python.exe>" -X utf8 "<C:/…/.claude>/hooks/X.sh"`. Target detection: auto (Git-Bash / MSYS / Cygwin host) or explicit `ITD_TARGET_OS=windows` (for the WSL → `/mnt/c` case). The interpreter comes from `ITD_WIN_PYTHON` (or is discovered on PATH); `/mnt/c/…` and `/c/…` normalise to `C:/…`. Unix/WSL behaviour is unchanged (bare shebang paths). The foreign-key merge (SessionStart) and the ITD-only drift check both run on the platform-effective set, so re-runs are idempotent on either OS. Added a `python3`→`python` launcher fallback so the script also runs under Git-Bash. Example: `ITD_TARGET_OS=windows ITD_WIN_PYTHON="C:/…/python.exe" CLAUDE_HOME=/mnt/c/Users/<you>/.claude bash scripts/sync-to-active.sh`.
+
+Verified: Windows wrapper form + `/mnt/c`→`C:` conversion + SessionStart preserved + idempotent 2nd run; unix mode unchanged; `bash -n` clean. MINOR — additive, backward-compatible.
+
 ## [1.37.0] - 2026-07-01
 
 **Close the "orphan hook" gap — self-correction and observability hooks are now actually wired, and the two machines converge.** A 6-dimension methodology audit (effectiveness across project types, greenfield/brownfield, default-on Win+WSL, component wiring, Harness Engineering, Agentic Engineering) found that `careful`, `execution-trace`, `stuck-detection`, `crash-recovery`, and `context-aware` shipped into `~/.claude/hooks/` but were **not in the canonical registration set** — so they silently never fired, while `HARNESS_ENGINEERING_MAP.md` counted them as active (declaration ≠ reality). `careful` worked on one machine only because it had been added by hand.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.37.0](https://img.shields.io/badge/Version-1.37.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.38.0](https://img.shields.io/badge/Version-1.38.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.37.0](https://img.shields.io/badge/Version-1.37.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.38.0](https://img.shields.io/badge/Version-1.38.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/scripts/sync-to-active.sh
+++ b/scripts/sync-to-active.sh
@@ -10,6 +10,14 @@
 #   bash scripts/sync-to-active.sh           # sync all
 #   bash scripts/sync-to-active.sh --check   # dry-run, report drift only
 #
+# Windows target (v1.38.0) — sync a Windows ~/.claude from WSL, emitting
+# python.exe hook invocations instead of bare shebang paths:
+#   ITD_TARGET_OS=windows \
+#   ITD_WIN_PYTHON="C:/Users/<you>/AppData/Local/Programs/Python/Python312/python.exe" \
+#   CLAUDE_HOME=/mnt/c/Users/<you>/.claude \
+#   bash scripts/sync-to-active.sh
+# (Auto-detected as windows when run from Git-Bash/MSYS/Cygwin.)
+#
 # What it syncs:
 #   1. skills/*              → ~/.claude/skills/
 #   2. hooks/*.sh            → ~/.claude/hooks/
@@ -37,6 +45,22 @@ DRY_RUN=0
 
 if [ "${1:-}" = "--check" ]; then
   DRY_RUN=1
+fi
+
+# Python launcher: python3 on Unix/WSL, python on Git-Bash-Windows.
+if command -v python3 >/dev/null 2>&1; then PYBIN=python3
+elif command -v python  >/dev/null 2>&1; then PYBIN=python
+else PYBIN=python3; fi
+
+# Target OS (v1.38.0). On a Windows target, .sh hooks cannot run via a shebang —
+# Claude Code must invoke them through python.exe. Auto-detect a Git-Bash/MSYS/
+# Cygwin host; for the WSL → /mnt/c case set ITD_TARGET_OS=windows explicitly.
+ITD_TARGET_OS="${ITD_TARGET_OS:-}"
+if [ -z "$ITD_TARGET_OS" ]; then
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) ITD_TARGET_OS=windows ;;
+    *) ITD_TARGET_OS=unix ;;
+  esac
 fi
 
 say()   { printf "\033[1;36m▶\033[0m %s\n" "$*"; }
@@ -302,10 +326,44 @@ DESIRED_HOOKS=$(cat <<'JSON'
 JSON
 )
 
+# v1.38.0: platform-aware command form. On a Windows target, rewrite each
+# "~/.claude/hooks/X.sh" into a python.exe invocation with an absolute Windows
+# path — .sh files there have no executable shebang. Unix/WSL keeps bare paths
+# (the shebang runs them). ACTIVE (/mnt/c/... or /c/... → C:/...) is normalised;
+# the interpreter is ITD_WIN_PYTHON (required for the WSL→/mnt/c case) or is
+# discovered on PATH (Git-Bash host).
+if [ "$ITD_TARGET_OS" = "windows" ]; then
+  WIN_PY="${ITD_WIN_PYTHON:-}"
+  if [ -z "$WIN_PY" ]; then
+    _p="$(command -v python 2>/dev/null || command -v py 2>/dev/null || true)"
+    [ -n "$_p" ] && WIN_PY="$(cygpath -m "$_p" 2>/dev/null || echo "$_p")"
+  fi
+  [ -z "$WIN_PY" ] && { WIN_PY="python"; warn "ITD_WIN_PYTHON unset and python not found — using bare 'python'"; }
+  EFFECTIVE_HOOKS="$(ITD_DESIRED="$DESIRED_HOOKS" ITD_WIN_PY="$WIN_PY" ITD_ACTIVE="$ACTIVE" "$PYBIN" - <<'PYX'
+import json, os, re
+def to_win(p):
+    m = re.match(r'^/mnt/([a-zA-Z])/(.*)$', p) or re.match(r'^/([a-zA-Z])/(.*)$', p)
+    return '%s:/%s' % (m.group(1).upper(), m.group(2)) if m else p.replace('\\', '/')
+py = os.environ['ITD_WIN_PY']
+active = to_win(os.environ['ITD_ACTIVE'].rstrip('/'))
+data = json.loads(os.environ['ITD_DESIRED'])
+for ev in data.values():
+    for grp in ev:
+        for h in grp.get('hooks', []):
+            m = re.match(r'^~/\.claude/hooks/(.+)$', h['command'])
+            if m:
+                h['command'] = '"%s" -X utf8 "%s/hooks/%s"' % (py, active, m.group(1))
+print(json.dumps(data))
+PYX
+)"
+else
+  EFFECTIVE_HOOKS="$DESIRED_HOOKS"
+fi
+
 # Check if current settings.json hooks already matches desired. Compare only the
 # ITD-managed event keys — foreign keys (e.g. a SessionStart hook registered by
 # another plugin) are preserved by the merge below and must not read as "drift".
-current_hooks=$(python3 -c "
+current_hooks=$($PYBIN -c "
 import json, sys
 KEYS = ('UserPromptSubmit', 'PreToolUse', 'PostToolUse')
 try:
@@ -318,7 +376,7 @@ except Exception as e:
     sys.exit(0)
 " 2>/dev/null || echo "ERROR")
 
-desired_normalized=$(echo "$DESIRED_HOOKS" | python3 -c "
+desired_normalized=$(echo "$EFFECTIVE_HOOKS" | $PYBIN -c "
 import json, sys
 print(json.dumps(json.load(sys.stdin), sort_keys=True))
 ")
@@ -334,12 +392,12 @@ else
     ts=$(date +%Y%m%d-%H%M%S)
     bak="$SETTINGS.bak-$ts"
     cp "$SETTINGS" "$bak"
-    python3 - "$SETTINGS" <<PYEOF
+    $PYBIN - "$SETTINGS" <<PYEOF
 import json, sys
 path = sys.argv[1]
 with open(path) as f:
     data = json.load(f)
-_itd = $DESIRED_HOOKS
+_itd = $EFFECTIVE_HOOKS
 # Merge the ITD-managed event keys; preserve any foreign event keys (e.g. a
 # SessionStart hook registered by another plugin such as context-mode). ITD owns
 # UserPromptSubmit/PreToolUse/PostToolUse in full, so replacing those is correct.


### PR DESCRIPTION
## What & why

Closes the last piece of the v1.37.0 audit's **default-on Win+WSL** gap. `sync-to-active.sh` emitted only bare `~/.claude/hooks/X.sh` commands (correct on WSL, which runs them via shebang), so the **Windows** install had to be hand-maintained — Windows invokes `.sh` hooks through `python.exe`, not a shebang.

## Change

- **`scripts/sync-to-active.sh` — platform-aware command emission.** On a Windows target each `~/.claude/hooks/X.sh` → `"<python.exe>" -X utf8 "<C:/…/.claude>/hooks/X.sh"`. Detection: auto (Git-Bash/MSYS/Cygwin) or explicit `ITD_TARGET_OS=windows` (WSL → `/mnt/c`). Interpreter from `ITD_WIN_PYTHON` or PATH; `/mnt/c/…` and `/c/…` → `C:/…`. Unix/WSL unchanged. Foreign-key merge (SessionStart) + drift check operate on the platform-effective set → idempotent on either OS. `python3`→`python` launcher fallback.

Sync a Windows `~/.claude` from WSL:
```
ITD_TARGET_OS=windows ITD_WIN_PYTHON="C:/…/python.exe" \
CLAUDE_HOME=/mnt/c/Users/<you>/.claude bash scripts/sync-to-active.sh
```

## Tests

Windows wrapper form + `/mnt/c`→`C:` + SessionStart preserved + idempotent 2nd run; unix unchanged; `bash -n` clean. `verify_brownfield_and_gate` 24/24 · `verify_skill_enforcement` 10/10 · `meta_review` PASSED. 1.37.0 → **1.38.0** (MINOR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
