### PR TITLE
docs(harness-map): version label v1.37.0 -> v1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`docs/HARNESS_ENGINEERING_MAP.md` — version label bumped v1.37.0 → v1.38.0.** An independent audit flagged the map self-stamping v1.37.0 while `plugin.json` was v1.38.0. The asserted counts (38 skills / 10 agents / 20 hooks / 2 gates) were already correct (v1.38.0 changed only `sync-to-active.sh`, not counts/registration) — this aligns the label with reality. Docs-only.
+
 ### Added
 
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.

--- a/docs/HARNESS_ENGINEERING_MAP.md
+++ b/docs/HARNESS_ENGINEERING_MAP.md
@@ -1,7 +1,7 @@
 # Harness Engineering Map: idea-to-deploy ↔ Харнес-инженерия
 
 > Дата: 2026-07-01 (обновлено; исходная карта — 2026-06-22)
-> Версия idea-to-deploy: **v1.37.0** (карта H1–H5 составлена по v1.21.0; §3/§4/§8 сверены с v1.37.0)
+> Версия idea-to-deploy: **v1.38.0** (карта H1–H5 составлена по v1.21.0; §3/§4/§8 сверены с v1.37.0–v1.38.0 — счётчики/регистрация не менялись в v1.38.0)
 > Источник: [Harness Engineering (walkinglabs)](https://walkinglabs.github.io/learn-harness-engineering/ru/)
 > Цель: проверить, в полной ли мере методология отражает философию, 5 принципов и инструменты харнес-инженерии; артикулировать gap'ы; зафиксировать осознанные out-of-scope решения.
 
@@ -32,7 +32,7 @@
 
 Статусы: ✅ **покрыто** (явная реализация с контрактом) · ◐ **частично** (gap артикулирован в §5) · ❌ **gap** (не реализовано и не замещено).
 
-Проверка — чтением `main` (v1.37.0): **38 skills, 10 subagents, 20 hooks, 2 Quality Gates**, слой контрактов `.itd/` (`docs/templates/itd/`), session-memory, 3 уровня качества (structural / snapshot / behavioural), бинарные rubric'и `/review` · `/security-audit` · `/deps-audit`. С v1.37.0 канонический набор регистрации (`scripts/sync-to-active.sh`) включает always-on хуки само-коррекции и наблюдаемости (`careful`, `stuck-detection`, `crash-recovery`, `execution-trace`, `context-aware`) — ранее они лежали в `~/.claude/hooks/`, но не были зарегистрированы; `freeze` остаётся opt-in.
+Проверка — чтением `main` (v1.38.0): **38 skills, 10 subagents, 20 hooks, 2 Quality Gates**, слой контрактов `.itd/` (`docs/templates/itd/`), session-memory, 3 уровня качества (structural / snapshot / behavioural), бинарные rubric'и `/review` · `/security-audit` · `/deps-audit`. С v1.37.0 канонический набор регистрации (`scripts/sync-to-active.sh`) включает always-on хуки само-коррекции и наблюдаемости (`careful`, `stuck-detection`, `crash-recovery`, `execution-trace`, `context-aware`) — ранее они лежали в `~/.claude/hooks/`, но не были зарегистрированы; `freeze` остаётся opt-in.
 
 ## 4. Таблица соответствия
 


### PR DESCRIPTION
Independent-audit cosmetic fix: harness map self-stamped v1.37.0 while plugin.json is v1.38.0. Counts (38/10/20/2) already correct — aligns label with reality. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)