### PR TITLE
feat(methodology): CLAUDE.md sync + registration/count drift-guards (v1.39.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 20 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **`docs/HARNESS_ENGINEERING_MAP.md` — version label bumped v1.37.0 → v1.38.0.** An independent audit flagged the map self-stamping v1.37.0 while `plugin.json` was v1.38.0. The asserted counts (38 skills / 10 agents / 20 hooks / 2 gates) were already correct (v1.38.0 changed only `sync-to-active.sh`, not counts/registration) — this aligns the label with reality. Docs-only.
-
 ### Added
 
 - **`docs/HARNESS_ENGINEERING_MAP.md` §4.1/§6 — two-layer framing.** Records that ITD realizes harness engineering on two layers: *operating* (ITD is itself a harness over Claude Code) and *output* (the Day-3/5 ports added врезки that teach/audit building the harness of the user's own product — memory/context, eval loops, zero-trust guardrails). Docs-only; no code or count change.
 - **`docs/competitive-analysis.md` §9 — external validation via the Google whitepaper *The New SDLC With Vibe Coding*** (Osmani, Saboo, Kartakis, 2026). Maps the paper's framework (structure > vibes, skills as dynamic context, hooks as guardrails, tests + evals, harness engineering, the "last 20%", model routing, context engineering as OpEx lever) onto concrete idea-to-deploy mechanisms — positioning the methodology as the plugin-form realization of the new SDLC, with the v1.31.0 enrichments closing the previously-honest gaps. Marketing/positioning only; no code or count change.
+
+## [1.39.0] - 2026-07-01
+
+**CLAUDE.md methodology block now syncs across machines, and two drift-guards lock the wins in place.** Closes the audit's most valuable remaining items (points 3/4/5 — the ones worth chasing); points 1/2/6 are deliberate design tradeoffs (advisory complexity routing, commit-count brownfield detect, opt-in `.itd/` contracts) where forcing "10/10" would reduce effectiveness, so they're left as-is.
+
+### Added
+
+- **`docs/templates/global-claude-md.md` + `sync-to-active.sh` Step 5/5 — the global CLAUDE.md methodology block now syncs (point 3).** The repo owns the MANDATORY methodology block between `<!-- ITD:BEGIN -->`/`<!-- ITD:END -->` markers; sync replaces ONLY that marked region in the active `~/.claude/CLAUDE.md`, preserving everything outside (personal sections like token-efficiency prefs). Backup + dry-run aware + idempotent. Closes the "CLAUDE.md can silently drift between machines" gap — both installs are now kept in lockstep by the same mechanism as skills/hooks.
+- **`tests/verify_registration_and_counts.py` — two drift-guards (points 4 + 5).** (4) Every hook file must be in the canonical registration set (`DESIRED_HOOKS`) OR the explicit opt-in allowlist (`freeze`) — turns the exact v1.37.0 root-cause (hooks shipped but silently unregistered) into a failing test. (5) The skill/agent/hook counts asserted in `plugin.json`, `marketplace.json`, `HARNESS_ENGINEERING_MAP.md`, and the CLAUDE.md template must all equal the actual on-disk counts — stops stale "34 skills / 16 hooks"-style docs.
+
+### Fixed
+
+- **`docs/HARNESS_ENGINEERING_MAP.md` — version label v1.37.0 → v1.38.0.** Independent audit flagged the map self-stamping v1.37.0 while `plugin.json` was v1.38.0; counts already correct, label aligned. Docs-only.
+
+### Changed
+
+- **`sync-to-active.sh` — step count 4 → 5**; backup cleanup now also prunes `CLAUDE.md.bak-*`.
+
+Verified: Step 5 sandbox (up-to-date / update / prepend / create — personal section preserved in every case); `verify_registration_and_counts` 9/9; `verify_brownfield_and_gate` 24/24; `verify_skill_enforcement` 10/10; `meta_review` PASSED; `bash -n` clean. MINOR — additive.
 
 ## [1.38.0] - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.38.0](https://img.shields.io/badge/Version-1.38.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.39.0](https://img.shields.io/badge/Version-1.39.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.38.0](https://img.shields.io/badge/Version-1.38.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.39.0](https://img.shields.io/badge/Version-1.39.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/templates/global-claude-md.md
+++ b/docs/templates/global-claude-md.md
@@ -1,0 +1,89 @@
+<!-- ITD:BEGIN methodology — managed by scripts/sync-to-active.sh. Edit THIS repo file, not the deployed ~/.claude/CLAUDE.md; sync propagates the block between the ITD:BEGIN/ITD:END markers to every machine and preserves everything outside them (personal sections). -->
+# Global development methodology — idea-to-deploy (MANDATORY)
+
+This machine uses the **idea-to-deploy** methodology for ALL software development,
+in **every project — new or existing** — unless the user explicitly says
+"skip the methodology" (or gives a `SKILL_BYPASS: <reason>`) for that specific task.
+
+This file is a standing user instruction. It overrides ad-hoc / improvised coding.
+
+## Core routing rule
+
+Before writing or changing code, route the work through the methodology instead of
+coding from scratch:
+
+- **New project, or a new feature from an idea** → start with `/project` (the router)
+  or the `discover → blueprint → kickstart` pipeline. Ask clarifying questions first,
+  produce a plan, and **wait for the user's approval before building.**
+- **Existing / legacy project not yet onboarded** → run `/adopt` first to map it,
+  then proceed with the methodology.
+- **Day-to-day task on an existing project** → start with `/task` to route to the
+  right skill (bugfix, refactor, perf, test, review, deps-audit, security-audit,
+  infra, harden, migrate, deploy, …).
+
+## Always
+
+1. **Plan before code.** Show the plan and wait for approval on any non-trivial work.
+2. **Test every change.** Write/extend tests and run them after each step.
+3. **Review before commit.** Run `/review`; never commit unreviewed multi-file changes.
+4. **Document & persist.** Record decisions; run `/session-save` when wrapping up a session.
+5. **Prefer the methodology's skills/agents** over improvising your own ad-hoc process.
+
+## Skill decision (visible line + trigger map)
+
+On every substantive request, the FIRST line of the response declares the skill
+decision: `Скилл: /<name>` (then call it via the Skill tool before any
+Read/Edit/Bash/Write) or `Скилл: не нужен — <reason>`. Silently skipping is not
+allowed; an explicit refusal with a reason IS a valid decision (the enforcement
+hook treats it so — see `SKILL_BYPASS`).
+
+Trigger → skill (apply as a rule, not a hint):
+
+- New product/feature from an idea → `/project` (or `/discover` → `/blueprint`).
+- Advisory / consulting / "analyze, don't code" → `/advisor`.
+- Stress-test a plan/design/architecture before committing → `/grill-me`.
+- Product discovery (market, personas, competitors) → `/discover`.
+- Meeting / interview prep, drafting questions → `/advisor` (or `/grill-me`).
+- Existing-project task → `/task` (routes to bugfix/refactor/test/perf/…).
+- End of a working session → `/session-save` (always, before wrapping up).
+
+When several fit, pick the most specific; when none fit, say so in the decision line.
+Pure mechanics (file generation, browser ops) and tight back-and-forth wording
+iterations are legitimate `Скилл: не нужен` cases — name the reason, don't pretend.
+
+## Bypass
+
+The only way to skip the methodology for a task is an explicit user instruction
+("skip the methodology" / "just do it directly") or an explicit `SKILL_BYPASS: <reason>`.
+Absent that, apply the methodology — when in doubt, apply it.
+
+> Methodology source (canonical): WSL repo `idea-to-deploy`
+> (`/home/hihol/projects/idea-to-deploy`), published as plugin
+> `hihol-labs/idea-to-deploy`. 38 skills + 10 agents + 20 hooks.
+
+## Project profiles & markers (v1.35.0)
+
+A project can declare an **opt-in** profile in its own `CLAUDE.md`; unset = default
+behaviour. See `docs/project-profiles.md` in the methodology repo.
+
+- **`itd-profile: brownfield`** (or `<!-- itd:brownfield -->`) — feature/maintenance
+  on a mature existing codebase. The skill-hint hook suppresses greenfield-pipeline
+  skills (`/project`, `/blueprint`, `/discover`, `/kickstart`, `/guide`, `/strategy`,
+  `/market-scan`, `/autopilot`); `/task`, `/bugfix`, `/refactor`, `/review`, `/test`,
+  `/migrate`, … stay active. On such a project the project's own `CLAUDE.md` is the
+  real source of truth — do not force the greenfield pipeline.
+- **`itd-domain: data-sensitive`** (or `<!-- itd:data-sensitive -->`) — the project
+  mutates production / financial / irreplaceable data. **Gate:** model the change
+  read-only first, show before/after, get explicit confirmation, then mutate. Never
+  run a data-mutating op (prod write, mass re-post, destructive migration, money
+  movement) straight from an ad-hoc command.
+
+**Memory is the continuity backbone.** Checkpoint via `/session-save` on every
+meaningful state change (subphase / roadmap item done, migration applied, before a
+risky or irreversible op, after an external artifact is sent) — cheap incremental
+checkpoints, not one big end-of-session save.
+
+**Read-only Bash does not need a skill line.** Pure inspection (ls/cat/grep/find/
+git status|log|diff) is exempt from the skill-decision gate; declare the skill only
+before a mutation or a genuine new task.
+<!-- ITD:END methodology -->

--- a/scripts/sync-to-active.sh
+++ b/scripts/sync-to-active.sh
@@ -86,9 +86,9 @@ if [ "$DRY_RUN" = "1" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# Step 1/4: Sync skills
+# Step 1/5: Sync skills
 # -----------------------------------------------------------------------------
-say "Step 1/4: skills/"
+say "Step 1/5: skills/"
 mkdir -p "$ACTIVE/skills"
 
 added=0
@@ -131,9 +131,9 @@ done
 ok "skills: +$added added, ~$updated updated, =$unchanged unchanged"
 
 # -----------------------------------------------------------------------------
-# Step 2/4: Sync hooks
+# Step 2/5: Sync hooks
 # -----------------------------------------------------------------------------
-say "Step 2/4: hooks/"
+say "Step 2/5: hooks/"
 mkdir -p "$ACTIVE/hooks"
 
 h_added=0
@@ -175,7 +175,7 @@ done
 ok "hooks: +$h_added added, ~$h_updated updated, =$h_unchanged unchanged"
 
 # -----------------------------------------------------------------------------
-# Step 3/4: Sync agents/*.md (subagents)
+# Step 3/5: Sync agents/*.md (subagents)
 # -----------------------------------------------------------------------------
 # Gap #9 (v1.13.1): sync-to-active.sh originally copied skills/ and hooks/
 # but NOT agents/, so updates to subagent instructions (e.g. the v1.13.0
@@ -186,7 +186,7 @@ ok "hooks: +$h_added added, ~$h_updated updated, =$h_unchanged unchanged"
 # Numbering note (v1.13.2): originally this was "Step 2.5/3" because agents/
 # was added after the 3-step layout was fixed. v1.13.2 renumbered to the
 # honest 1/4..4/4 scheme so that `--check` dry-run output matches reality.
-say "Step 3/4: agents/"
+say "Step 3/5: agents/"
 mkdir -p "$ACTIVE/agents"
 
 a_added=0
@@ -228,9 +228,9 @@ fi
 ok "agents: +$a_added added, ~$a_updated updated, =$a_unchanged unchanged"
 
 # -----------------------------------------------------------------------------
-# Step 4/4: Patch settings.json "hooks" section
+# Step 4/5: Patch settings.json "hooks" section
 # -----------------------------------------------------------------------------
-say "Step 4/4: settings.json hooks registration"
+say "Step 4/5: settings.json hooks registration"
 
 SETTINGS="$ACTIVE/settings.json"
 
@@ -412,14 +412,68 @@ PYEOF
   fi
 fi
 
+# -----------------------------------------------------------------------------
+# Step 5/5: Sync the ITD methodology block into ~/.claude/CLAUDE.md (v1.39.0)
+# -----------------------------------------------------------------------------
+# The global CLAUDE.md carries the MANDATORY methodology instruction plus
+# personal sections (e.g. token-efficiency prefs). To keep the methodology block
+# in lockstep across machines WITHOUT clobbering personal content, the repo owns
+# the block (docs/templates/global-claude-md.md, between ITD:BEGIN/ITD:END
+# markers) and this step replaces ONLY that marked region in the active file.
+say "Step 5/5: CLAUDE.md methodology block"
+TPL="$REPO_ROOT/docs/templates/global-claude-md.md"
+CLAUDE_MD="$ACTIVE/CLAUDE.md"
+if [ ! -f "$TPL" ]; then
+  warn "template not found ($TPL) — skipping CLAUDE.md sync"
+else
+  _cmres="$(ITD_TPL="$TPL" ITD_CLAUDE="$CLAUDE_MD" ITD_DRY="$DRY_RUN" "$PYBIN" - <<'PYX'
+import os, sys, time, shutil
+BEGIN = "<!-- ITD:BEGIN"; END = "<!-- ITD:END methodology -->"
+tpl = open(os.environ["ITD_TPL"], encoding="utf-8").read()
+b, e = tpl.find(BEGIN), tpl.find(END)
+if b == -1 or e == -1:
+    print("ERROR:template markers missing"); sys.exit(0)
+block = tpl[b:e + len(END)]
+active = os.environ["ITD_CLAUDE"]; dry = os.environ["ITD_DRY"]
+if not os.path.exists(active):
+    action, result = "create", block + "\n"
+else:
+    cur = open(active, encoding="utf-8").read()
+    ab, ae = cur.find(BEGIN), cur.find(END)
+    if ab != -1 and ae != -1:
+        if cur[ab:ae + len(END)] == block:
+            print("UPTODATE"); sys.exit(0)
+        action, result = "update", cur[:ab] + block + cur[ae + len(END):]
+    else:
+        action, result = "prepend", block + "\n\n" + cur
+if dry == "1":
+    print("DRIFT:" + action); sys.exit(0)
+if os.path.exists(active):
+    shutil.copy(active, active + ".bak-" + time.strftime("%Y%m%d-%H%M%S"))
+with open(active, "w", encoding="utf-8") as f:
+    f.write(result)
+print("WROTE:" + action)
+PYX
+)"
+  case "$_cmres" in
+    UPTODATE) ok "CLAUDE.md methodology block already up-to-date" ;;
+    DRIFT:*)  warn "CLAUDE.md methodology block drift (${_cmres#DRIFT:}) — would sync" ;;
+    WROTE:*)  ok "CLAUDE.md methodology block synced (${_cmres#WROTE:})" ;;
+    ERROR:*)  err "CLAUDE.md sync: ${_cmres#ERROR:}" ;;
+    *)        warn "CLAUDE.md sync: unexpected result ($_cmres)" ;;
+  esac
+fi
+
 # v1.20.1 cleanup: keep the 5 most recent settings.json.bak-* files, delete
 # older ones. `sync-to-active` is run routinely, so these accumulate fast.
 if [ "$DRY_RUN" = "0" ]; then
-  mapfile -t _old_baks < <(ls -1t "$ACTIVE"/settings.json.bak-* 2>/dev/null | tail -n +6)
-  if [ "${#_old_baks[@]}" -gt 0 ]; then
-    rm -f "${_old_baks[@]}"
-    ok "backup cleanup: pruned ${#_old_baks[@]} old settings.json.bak files (kept 5 most recent)"
-  fi
+  for _glob in "settings.json.bak-" "CLAUDE.md.bak-"; do
+    mapfile -t _old_baks < <(ls -1t "$ACTIVE/$_glob"* 2>/dev/null | tail -n +6)
+    if [ "${#_old_baks[@]}" -gt 0 ]; then
+      rm -f "${_old_baks[@]}"
+      ok "backup cleanup: pruned ${#_old_baks[@]} old ${_glob}* files (kept 5 most recent)"
+    fi
+  done
 fi
 
 echo ""

--- a/tests/verify_registration_and_counts.py
+++ b/tests/verify_registration_and_counts.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Drift guards (v1.39.0) — prevent the two regressions an audit could catch:
+
+  P4  Hook registration completeness. Every hook file in hooks/ must be EITHER
+      in the canonical registration set (DESIRED_HOOKS in scripts/sync-to-active.sh)
+      OR in the explicit opt-in allowlist (freeze). This is exactly the v1.37.0
+      root-cause bug (hooks shipped but silently unregistered) turned into a test.
+
+  P5  Count consistency. The skill/agent/hook counts asserted in plugin.json,
+      marketplace.json, docs/HARNESS_ENGINEERING_MAP.md, and the global CLAUDE.md
+      template must all equal the ACTUAL counts on disk. Stops "34 skills / 16
+      hooks"-style stale docs.
+
+Self-contained. Run: python3 tests/verify_registration_and_counts.py
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Hooks that ship but are intentionally NOT registered (activated on demand).
+OPT_IN_HOOKS = {"freeze.sh"}
+
+PASS, FAIL = 0, 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print("PASS  " + name)
+    else:
+        FAIL += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def read(rel):
+    with open(os.path.join(ROOT, rel), encoding="utf-8") as f:
+        return f.read()
+
+
+# --- actual counts on disk -------------------------------------------------
+skills = [d for d in os.listdir(os.path.join(ROOT, "skills"))
+          if os.path.isfile(os.path.join(ROOT, "skills", d, "SKILL.md"))]
+agents = [f for f in os.listdir(os.path.join(ROOT, "agents")) if f.endswith(".md")]
+hook_files = [f for f in os.listdir(os.path.join(ROOT, "hooks")) if f.endswith(".sh")]
+N_SKILLS, N_AGENTS, N_HOOKS = len(skills), len(agents), len(hook_files)
+print("actual: %d skills, %d agents, %d hooks\n" % (N_SKILLS, N_AGENTS, N_HOOKS))
+
+
+# --- P4: hook registration completeness ------------------------------------
+sync = read("scripts/sync-to-active.sh")
+# Extract only the DESIRED_HOOKS heredoc so prose/other refs don't count.
+m = re.search(r"DESIRED_HOOKS=\$\(cat <<'JSON'\n(.*?)\nJSON", sync, re.DOTALL)
+check("DESIRED_HOOKS heredoc found in sync-to-active.sh", m is not None)
+registered = set(re.findall(r"~/\.claude/hooks/([a-z0-9-]+\.sh)", m.group(1))) if m else set()
+
+files = set(hook_files)
+unregistered = files - registered - OPT_IN_HOOKS
+check("every hook file is registered or explicitly opt-in", not unregistered,
+      "orphans: " + ", ".join(sorted(unregistered)))
+missing_files = registered - files
+check("every registered hook has a file", not missing_files,
+      "registered but absent: " + ", ".join(sorted(missing_files)))
+# freeze must stay out of the registered set (it is opt-in by design).
+check("opt-in hooks are NOT in the registered set",
+      not (OPT_IN_HOOKS & registered),
+      "unexpectedly registered: " + ", ".join(sorted(OPT_IN_HOOKS & registered)))
+print("  registered ITD hooks: %d" % len(registered))
+
+
+# --- P5: count consistency across manifests & docs -------------------------
+def assert_counts(label, text, pat):
+    mm = re.search(pat, text)
+    if not mm:
+        check("%s: count triple present" % label, False, "pattern not found")
+        return
+    s, a, h = int(mm.group(1)), int(mm.group(2)), int(mm.group(3))
+    check("%s counts == actual (%d/%d/%d)" % (label, N_SKILLS, N_AGENTS, N_HOOKS),
+          (s, a, h) == (N_SKILLS, N_AGENTS, N_HOOKS),
+          "doc says %d/%d/%d" % (s, a, h))
+
+
+# Optional qualifier word before "agents"/"hooks" (e.g. "specialized subagents",
+# "enforcement hooks") — the manifests phrase it slightly differently.
+MANIFEST_PAT = (r"(\d+)\s+skills\s*\+\s*(\d+)\s+(?:\w+\s+)?(?:sub)?agents"
+                r"\s*\+\s*(\d+)\s+(?:\w+\s+)?hooks")
+assert_counts("plugin.json", read(".claude-plugin/plugin.json"), MANIFEST_PAT)
+assert_counts("marketplace.json", read(".claude-plugin/marketplace.json"), MANIFEST_PAT)
+assert_counts("HARNESS_ENGINEERING_MAP.md", read("docs/HARNESS_ENGINEERING_MAP.md"),
+              r"(\d+)\s+skills,\s*(\d+)\s+subagents,\s*(\d+)\s+hooks")
+assert_counts("global-claude-md template", read("docs/templates/global-claude-md.md"),
+              r"(\d+)\s+skills\s*\+\s*(\d+)\s+agents\s*\+\s*(\d+)\s+hooks")
+
+# The template must carry the ITD:BEGIN/END markers sync relies on.
+tpl = read("docs/templates/global-claude-md.md")
+check("template has ITD:BEGIN/END markers",
+      "<!-- ITD:BEGIN" in tpl and "<!-- ITD:END methodology -->" in tpl)
+
+
+print("\n%d passed, %d failed" % (PASS, FAIL))
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## What & why

Closes the **worth-doing** items from the independent audit (points 3/4/5). Points 1/2/6 are deliberate design tradeoffs where forcing 10/10 would *reduce* effectiveness, so they're left as-is.

## Changes

- **Point 3 — CLAUDE.md syncs across machines.** New `docs/templates/global-claude-md.md` owns the MANDATORY methodology block between `<!-- ITD:BEGIN -->`/`<!-- ITD:END -->` markers. `sync-to-active.sh` **Step 5/5** replaces ONLY that marked region in the active `~/.claude/CLAUDE.md`, preserving everything outside (personal sections). Backup + dry-run + idempotent. The two installs are now kept in lockstep by the same mechanism as skills/hooks — no more silent CLAUDE.md drift.
- **Points 4+5 — drift-guards.** New `tests/verify_registration_and_counts.py`: (4) every hook file must be in the canonical registration set OR the opt-in allowlist (`freeze`) — the exact v1.37.0 root-cause (shipped-but-unregistered hooks) as a failing test; (5) the skill/agent/hook counts in `plugin.json`, `marketplace.json`, `HARNESS_ENGINEERING_MAP.md`, and the CLAUDE.md template must all equal the actual on-disk counts.
- `sync-to-active.sh` step count 4→5; backup cleanup also prunes `CLAUDE.md.bak-*`.
- `HARNESS_ENGINEERING_MAP.md` version label v1.37.0 → v1.38.0 (counts already correct).

## Tests

Step 5 sandbox (up-to-date / update / prepend / create — personal section preserved every case) · `verify_registration_and_counts` 9/9 · `verify_brownfield_and_gate` 24/24 · `verify_skill_enforcement` 10/10 · `meta_review` PASSED · `bash -n` clean.

Version 1.38.0 → **1.39.0** (MINOR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
