### PR TITLE
fix(cross-review): cli-adapters hardened by live chain probe (v1.41.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.41.0",
+      "version": "1.41.1",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 22 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric.",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.41.1] - 2026-07-02
+
+### Fixed
+
+- **`skills/cross-review/references/cli-adapters.md` — hardened by a live end-to-end probe of the degradation chain.** (1) The argv fallback (`codex exec "$PROMPT"`) now carries an explicit `ARG_MAX` warning — on a ~3.7k-line diff it dies with "Argument list too long" (rc=126, reproduced live); for big diffs the recipe is stdin from a file (`codex exec - < "$PROMPT_FILE"`). (2) Documented two real "unavailable" shapes with their handling: a startup config error (`unknown variant 'priority'` in `service_tier` after a CLI version change — one retry with `codex -c 'service_tier="flex"' exec …`, then degrade) and a cloud handshake timeout (`timed out waiting for cloud requirements after 15s` — no retry, fall through). The pre-commit hook (`cross-review-precommit.sh`) was already stdin-based and needs no change. Docs-only; no code or count change.
+
 ## [1.41.0] - 2026-07-02
 
 **Scope control & verified completion: WIP=1, the state surface reaches the session, VCR is measured, and a soft activation gate watches the scope.** Closes the four findings of the /advisor check against the scope-control principle (WIP=1 / explicit completion evidence / externalized scope surface / VCR).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.41.0](https://img.shields.io/badge/Version-1.41.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.41.1](https://img.shields.io/badge/Version-1.41.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.41.0](https://img.shields.io/badge/Version-1.41.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.41.1](https://img.shields.io/badge/Version-1.41.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/skills/cross-review/references/cli-adapters.md
+++ b/skills/cross-review/references/cli-adapters.md
@@ -70,7 +70,21 @@ fi
 ```
 
 If `codex exec -` (stdin) is not supported on the installed version, pass the
-prompt as an argument: `timeout 120 codex exec "$PROMPT"`.
+prompt as an argument: `timeout 120 codex exec "$PROMPT"` — but ONLY for small
+diffs: an argument hits the OS `ARG_MAX` limit on large diffs ("Argument list
+too long", rc=126, verified live on a ~3.7k-line diff 2026-07-02). For anything
+big, keep stdin and redirect from a file instead of a variable:
+`timeout 120 codex exec - < "$PROMPT_FILE"`.
+
+Two more "unavailable" shapes seen in the wild (both = degrade, don't block):
+
+- **Config error on startup** — e.g. `Error loading config.toml: unknown variant
+  'priority', expected 'fast' or 'flex'` in `service_tier` after a CLI up/downgrade.
+  Worth ONE retry with an inline override (`codex -c 'service_tier="flex"' exec …`);
+  if that also fails, treat as unavailable and tell the user their
+  `~/.codex/config.toml` needs fixing.
+- **Cloud handshake timeout** — `timed out waiting for cloud requirements after 15s`
+  (network/VPN). No retry loop; fall through the chain.
 
 ## 4. Google Gemini CLI
 


### PR DESCRIPTION
Docs-only patch из живого end-to-end прогона цепочки cross-review (2026-07-02):

- argv-fallback (codex exec "$PROMPT") умирает на ARG_MAX при ~3.7k-строчном диффе (rc=126, воспроизведено) — рецепт для больших диффов: stdin из файла (codex exec - < file).
- Задокументированы два реальных unavailable-кейса: config-error (unknown variant 'priority' в service_tier после смены версии CLI — один ретрай с -c override, затем деградация) и cloud handshake timeout (без ретраев, fall through).
- Хук cross-review-precommit.sh уже был stdin-based — без изменений.

Verified: registration/counts 9/9, meta_review PASSED. PATCH: одна содержательная правка + version bump 1.41.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)