### PR TITLE
fix(tests): endpoint regex + act of the first live greenfield run (v1.43.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.43.0",
+      "version": "1.43.1",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.43.0",
+  "version": "1.43.1",
   "description": "Complete project lifecycle methodology — 38 skills + 10 specialized subagents + 22 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric.",
   "author": {
     "name": "HiH-DimaN",

--- a/.github/workflows/windows-verify.yml
+++ b/.github/workflows/windows-verify.yml
@@ -19,6 +19,10 @@ jobs:
   windows-verify:
     runs-on: windows-latest
     timeout-minutes: 10
+    env:
+      # The runner console is cp1252; meta_review prints emoji markers.
+      # Real Windows installs invoke hooks with `python -X utf8` — mirror that.
+      PYTHONUTF8: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.43.1] - 2026-07-03
+
+### Fixed
+
+- **`tests/verify_snapshot.py` `_API_ENDPOINT_RE`** — counts the fourth legitimate endpoint shape: method in its OWN markdown-table cell, path in the next (`| GET | /api/v1/... |`). Caught by the first live headless run of fixture-01 (the generated architecture doc's API section held 40+ endpoints in exactly this shape yet scored 0 against the `min_api_endpoints: 15` contract → false FAIL); same output re-validates 33/33 after the fix. Regression pinned by the new `tests/verify_endpoint_regex.py` (4 positive shapes + 5 negative cases: table headers, separator rows, prose with method words).
+
+### Added
+
+- **`docs/greenfield-live-run-2026-07-03.md`** — the act of the first live greenfield run: kickstart Phase 1–2 via the standard headless fixture runner (33/33, $1.02) + a headless probe of the v1.40.0 initialization phase (Phase 3 steps 1–8): `PHASE3-PROBE-DONE 6/6`, independently verified by hand (pytest 1 passed in the project venv, 13 `.itd/` contracts, `validate_state.py` OK, 2 git checkpoint commits). Operational notes: headless claude from Windows requires a login shell (`wsl.exe --exec bash -lc`); Phases 4–5 remain signal-gated ($10–25/run). Greenfield score on the audit scale: 8 → 9.
+
 ## [1.43.0] - 2026-07-03
 
 **The model council, done the ITD way: one external seat at decision points.** Answers the "council of models" request (second signal for the v1.21-rejected "adversarial debates" candidate) without building an orchestrator: role diversity already exists (10 subagents; /advisor and /blueprint 2.5 already synthesize multi-perspective output), so the only un-captured win is a genuinely DIFFERENT model family at the table. Same-model persona ensembles buy little for 3-4× tokens; a foreign model has foreign blind spots.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.43.0](https://img.shields.io/badge/Version-1.43.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.43.1](https://img.shields.io/badge/Version-1.43.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 38](https://img.shields.io/badge/Skills-38-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.43.0](https://img.shields.io/badge/Version-1.43.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.43.1](https://img.shields.io/badge/Version-1.43.1-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/greenfield-live-run-2026-07-03.md
+++ b/docs/greenfield-live-run-2026-07-03.md
@@ -1,0 +1,56 @@
+# Акт: live-прогон greenfield-пайплайна (kickstart) — 2026-07-03
+
+> Цель: закрыть остаток аудита 2026-07-02 «greenfield 8/10 — структурно полный,
+> но без боевых подтверждений». Метод: штатный headless-раннер фикстур +
+> отдельная headless-проба новой init-фазы v1.40.0. Исполнено на WSL
+> (claude CLI 2.1.186, model sonnet).
+
+## Ступень 1 — kickstart Phase 1–2 (документация), штатная фикстура
+
+- **Прогон:** `bash tests/run-fixture-headless.sh fixture-01-saas-clinic --keep-output`
+  (SaaS-клиника, Full-набор из 7 документов, pre-seeded clarifications).
+- **Результат:** все 7 документов сгенерированы; snapshot-валидация после фикса
+  валидатора — **PASSED, 33/33 проверок**. Cost: **$1.02** (equiv pay-as-you-go).
+- **Находка №1 (исправлена в этом же патче):** `tests/verify_snapshot.py`
+  `_API_ENDPOINT_RE` не считал эндпоинты в формате «метод в отдельной ячейке
+  таблицы» (`| GET | /api/v1/... |`) — легитимный и частый выход модели дал
+  0/15 и ложный FAIL. Регекс расширен четвёртой формой; тот же вывод после
+  фикса — 33/33. Дефект валидатора, не генерации.
+
+## Ступень 2 — kickstart Phase 3 (init-фаза v1.40.0), headless-проба
+
+Поверх доков ступени 1, промпт = «выполни Phase 3 шаги 1–8 из SKILL.md»
+(backend-only, SQLite вместо PG, Docker — файлы без сборки; cap $8).
+
+- **Результат агента:** `PHASE3-PROBE-DONE 6/6` — все пункты Initialization
+  Acceptance Checklist закрыты.
+- **Независимая ручная верификация (не со слов агента):**
+  - `.venv/bin/python -m pytest -q` → **1 passed** (example-тест health-роута);
+  - `.itd/` → **13 файлов** (полный контрактный слой);
+  - `scripts/validate_state.py .itd-memory/STATE.json` → **OK**
+    (`sessionState=ACTIVE`, `currentStage=SCAFFOLDING`);
+  - `git log` → **2 чекпоинт-коммита** (scaffold + .itd), `.itd*` в HEAD;
+  - `events.jsonl` создан; `pyproject/Dockerfile/compose/.env.example` на месте.
+- Т.е. вся init-фаза Anthropic-порта (ось I карты, §4.4) подтверждена боем:
+  запускаемое окружение, проверяемый тест-фреймворк, bootstrap-контракт,
+  декомпозиция (10 шагов в IMPLEMENTATION_PLAN), git-чекпоинт.
+
+## Операционные заметки (для будущих прогонов)
+
+- **№2:** headless-запуск из Windows через `wsl.exe bash script.sh` БЕЗ
+  login-shell даёт `Not logged in` у claude CLI — креды/env подтягиваются
+  только в `bash -lc`. Всегда: `wsl.exe -d <distro> --exec bash -lc '...'`.
+- **№3:** проба выполнила bootstrap с «proxy workaround» при pip install
+  (сетевая специфика машины) — checklist-пункт «bootstrap from scratch»
+  прошёл, но на чистых машинах шаг может требовать индекс-настройку pip.
+- Фикстурный вывод сохранён в `tests/fixtures/fixture-01-saas-clinic/output/`
+  (артефакт прогона; в git не входит — каталог output в .gitignore фикстур).
+
+## Вердикт
+
+Greenfield-пайплайн **live-подтверждён** на фазах 1–3 (докогенерация с
+контент-контрактами + инициализация с fail-closed чеклистом). Непокрытыми
+боем остаются Phase 4–5 (пошаговая реализация с Gate 2 и деплой) — их
+честная стоимость $10–25/прогон; гонять по сигналу (первый реальный
+greenfield-проект), не ради галочки. Оценка greenfield по линейке аудита:
+**8 → 9** (структура 10, live-покрытие 3/5 фаз).

--- a/tests/verify_endpoint_regex.py
+++ b/tests/verify_endpoint_regex.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Regression cases for verify_snapshot's _API_ENDPOINT_RE (v1.43.1).
+
+The live fixture-01 headless run (2026-07-03) produced endpoints as
+`| GET | /api/v1/... |` (method in its own table cell) and scored a false
+0/15. This suite pins all four legitimate shapes AND the negative cases the
+reviewer asked to lock down (table headers, prose with method words).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from verify_snapshot import count_api_endpoints  # noqa: E402
+
+PASS = FAIL = 0
+
+
+def check(name: str, text: str, expected: int) -> None:
+    global PASS, FAIL
+    got = count_api_endpoints(text)
+    if got == expected:
+        PASS += 1
+        print(f"PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"FAIL  {name} — expected {expected}, got {got}: {text!r}")
+
+
+# --- positive: the four legitimate shapes ------------------------------------
+check("plain line", "GET /api/v1/users\nPOST /api/v1/users", 2)
+check("backtick line", "`GET /api/v1/users`", 1)
+check("numbered table row", "| 1 | GET | /api/v1/users | list |", 1)
+check("method+path in one cell", "| GET /api/v1/users | list users |", 1)
+check("method in own cell, path next (v1.43.1)",
+      "| GET | /api/v1/auth/login | вход | all |\n"
+      "| POST | `/api/v1/auth/refresh` | обновление | all |", 2)
+check("path param braces", "| DELETE | /api/v1/patients/{id} | удалить | admin |", 1)
+
+# --- negative: must NOT count -------------------------------------------------
+check("table header", "| Метод | Путь | Описание | Роль |", 0)
+check("separator row", "|---|---|---|---|", 0)
+check("prose with method word", "The GET requests are cached for 60 seconds.", 0)
+check("method word in cell without path",
+      "| GET requests | are cached | 60s |", 0)
+check("plain text mention", "используем POST для записи", 0)
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/tests/verify_snapshot.py
+++ b/tests/verify_snapshot.py
@@ -136,9 +136,15 @@ class Report:
 _SECTION_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", re.MULTILINE)
 _API_ENDPOINT_RE = re.compile(
     r"^\s*(?:"
-    r"[`*]?\s*(?:GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+[/:\w{}\-]+"
+    # v1.43.1: the path must START with /, : or { — bare `METHOD word` is prose
+    # («GET requests are cached»), not an endpoint (regression: verify_endpoint_regex.py)
+    r"[`*]?\s*(?:GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+[`]?[/:{][/:\w{}\-]*"
     r"|\|\s*\d+\s*\|\s*(?:GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s*\|"
-    r"|\|\s*(?:GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+[/:\w{}\-]+\s*\|"
+    r"|\|\s*(?:GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+[`]?[/:{][/:\w{}\-]*\s*\|"
+    # v1.43.1: method in its OWN table cell, path in the NEXT cell —
+    # `| GET | /api/v1/auth/login | ... |` (live fixture-01 headless run
+    # 2026-07-03 generated exactly this shape and scored 0/15 endpoints)
+    r"|\|\s*[`*]?(?:GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)[`*]?\s*\|\s*[`]?[/:{]"
     r")",
     re.MULTILINE | re.IGNORECASE,
 )


### PR DESCRIPTION
## v1.43.1 — первый живой greenfield-прогон + фиксы, которые он вскрыл

### Прогон (акт: docs/greenfield-live-run-2026-07-03.md)
- **Ступень 1** — kickstart Phase 1–2 через штатный headless-раннер (fixture-01-saas-clinic, Sonnet): 7 документов, **33/33 проверок, \.02**.
- **Ступень 2** — headless-проба init-фазы v1.40.0 (Phase 3 шаги 1–8): **PHASE3-PROBE-DONE 6/6**, независимо верифицировано руками — pytest 1 passed в venv проекта, 13 контрактов .itd/, validate_state OK, 2 git-чекпоинта.
- Greenfield по линейке аудита: **8 → 9** (Phase 4–5 — signal-gated, \–25/прогон).

### Фиксы (оба вскрыты прогоном)
1. \_API_ENDPOINT_RE\: 4-я легитимная форма — метод в своей ячейке таблицы (\| GET | /api/v1/... |\); реальный док дал 0/15 → ложный FAIL.
2. Pre-existing over-match, пойманный новым негативным кейсом: \| GET requests |\ считался эндпоинтом — путь теперь обязан начинаться с \/\, \:\ или \{\.
3. Регресс закреплён \	ests/verify_endpoint_regex.py\ (6 позитивных + 5 негативных, 11/11).

### Операционные заметки в акте
- headless claude из Windows — только через \wsl.exe --exec bash -lc\ (non-login shell → «Not logged in»).

Верификация: verify_endpoint_regex 11/11; фикстура 33/33; registration 9/9; meta_review PASSED. Ревью: PASSED_WITH_WARNINGS, оба Important закрыты до коммита.

🤖 Generated with [Claude Code](https://claude.com/claude-code)