### PR TITLE
feat(methodology): v1.50.0 — Fable 5 release A: snippets + harness best-effort invariant

### DIFF
--- a/.github/workflows/windows-verify.yml
+++ b/.github/workflows/windows-verify.yml
@@ -40,6 +40,8 @@ jobs:
         run: python tests/verify_hook_depth.py
       - name: Narration-final detector functional tests (SubagentStop)
         run: python tests/verify_narration_final.py
+      - name: Fable 5 release-A snippet pack (v1.50.0)
+        run: python tests/verify_fable_snippets.py
       - name: Fixture contracts — all fixtures by status (Phase-2)
         run: python tests/verify_snapshot.py --all
       - name: Registration & count drift-guards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.50.0] - 2026-07-05
+
+**Fable 5 adoption, release A — vendor-canonical snippets + the harness best-effort invariant.** External signal (model-generation change), routed through /advisor (ROI panel) + red-team stress-test on 2026-07-05: four zero-risk snippet adoptions from Anthropic's official Fable 5 migration guidance, plus the cross-cutting invariant the red team demanded as a precondition for every later harness-feature adoption (releases B/C/D stay in the backlog, gated on retro evidence).
+
+### Added
+
+- **`docs/templates/global-claude-md.md` — Always #7 «Grounded progress claims».** Vendor-canonical snippet: every progress claim must be auditable against a tool result from the session; unverified work is declared as such. Global — applies to all skills, not just `/goal` (which already lived by it via the ОТК-verifier).
+- **`docs/templates/global-claude-md.md` — «Harness-native features — best-effort invariant» section** (inside the ITD:BEGIN/END managed block, so it rolls out with sync). Two rules: (1) a harness-native feature may transport a methodology contract, never be it — no gate/`verified`/handoff depends on a specific tool-call, contracts stay vendor-neutral; (2) egress goes through the cross-review-grade scrubber + human confirmation, durable-state mutation follows the data-sensitive gate, background harness agents are read-only reporters. This is the red-team's cross-cutting blocker, now standing policy.
+- **`skills/goal/SKILL.md` — autonomous-run reminder (Step 2)** for headless/AFK unit driving: proceed on reversible in-scope actions without asking, self-check the last paragraph for narration-finals before ending a turn. Prevention-side twin of `hooks/narration-final.sh` (which stays as the postfactum detector); data-sensitive boundary explicitly preserved.
+- **`skills/_shared/helpers.md` §8 «Delegation Intent Template».** Every subagent spawn carries three intent lines (what larger task, for whom, what the result unblocks) — Fable 5-era models measurably improve with intent context; plus two companion rules: prescriptive WHEN-triggers for tools/skills, and the report-back contract (outcome first, evidence attached, «Не успел проверить» tail).
+- **`tests/verify_fable_snippets.py` — 28 structural checks**, wired into windows-verify CI. Positional, not substring-only: grounded-claims must be a numbered item inside `## Always`; the invariant section must sit inside the managed ITD block (sync only propagates that block); the goal reminder must live between Step 2 and Step 3; caveman's Fable note must precede Auto-Clarity and keep lite as default.
+
+### Changed
+
+- **`skills/caveman/SKILL.md` — Fable 5-class note in Intensity.** On Fable 5-era models, `full`/`ultra`/`wenyan-*` stay acceptable for working inter-tool-call messages but never for the final summary of a long task (vendor guidance bans arrow chains / invented abbreviations there — fighting the training degrades quality). Final summary auto-drops to `lite`, treated as an Auto-Clarity case.
+
+### Decided (not implemented — backlog with triggers)
+
+- Release C (review pack: coverage-first finder + refute-verifier + vendor-neutral JSON verdict contract) — next unit, goes through its own battle-test cycle.
+- Release B (worktree isolation for file-only `/refactor` after a hook path-assumption audit; consolidate-memory in approval-diff mode only; per-role effort tiers) — after C.
+- Release D (skill de-prescription A/B one at a time; SendMessage fix→re-review within one session, advice-only; evals for 2–3 skills with false-match history) — strictly retro-evidence-gated.
+- Rejected outright (red team): Artifact publishing of review/retro reports (secret egress), background harness agents with mutation rights, spawn_task chips as a BACKLOG.md replacement.
+
+---
+
 ## [1.49.0] - 2026-07-04
 
 **The narration-final anti-pattern gets a mechanical detector — prompt-level contracts demonstrably don't hold.** Retro signal #1 (evidence ×5): during the single v1.48.0 release review, the code-reviewer subagent ended its message on «Now check…»/«Далее проверю…» five times — AFTER the named anti-pattern was written into the agent contract in v1.47.0. Same class of fix as `handoff-readiness.sh`: computational detect, minimal intervention, never a prompt plea.

--- a/docs/templates/global-claude-md.md
+++ b/docs/templates/global-claude-md.md
@@ -31,6 +31,32 @@ coding from scratch:
 6. **WIP=1.** One active task/unit at a time; start the next only after the current
    one passes end-to-end verification. Don't "also refactor" B while implementing A —
    out-of-scope findings go to the backlog, not into the current diff.
+7. **Grounded progress claims.** Before reporting progress, audit each claim
+   against a tool result from this session. Only report work you can point to
+   evidence for; if something is not yet verified, say so explicitly. Report
+   outcomes faithfully: if tests fail, say so with the output; if a step was
+   skipped, say that; when something is done and verified, state it plainly
+   without hedging. (Vendor-canonical snippet, Fable 5 era — v1.50.0.)
+
+## Harness-native features — best-effort invariant (v1.50.0)
+
+The CLI harness (Claude Code / codex / gemini) ships vendor-specific tools
+(typed tool-calls, chips, artifacts, background agents, transcript search).
+Standing rule for ALL of them:
+
+- **Best-effort layer only.** A harness-native feature may TRANSPORT a
+  methodology contract, never BE the contract. No gate, no `verified`
+  transition, no handoff may depend on the presence of a specific tool-call —
+  the contract stays vendor-neutral (text/JSON in the transcript, files in the
+  repo), so it survives a vendor or version switch. A harness feature silently
+  disappearing must degrade to the neutral path, not to a false "all green".
+- **Egress + mutation guard.** Anything that leaves the machine (web publish,
+  artifact upload, transcript mining to an external model) goes through the
+  cross-review-grade secret scrubber AND explicit human confirmation. Anything
+  that mutates durable state (prod data, `MEMORY.md`, ledgers) from a harness
+  feature follows the data-sensitive gate: read-only diff → human approve →
+  apply. Background/scheduled harness agents are read-only reporters; they
+  never commit, push, or edit files unattended.
 
 ## Skill decision (visible line + trigger map)
 

--- a/skills/_shared/helpers.md
+++ b/skills/_shared/helpers.md
@@ -174,3 +174,31 @@ Rules for large tool outputs (logs, HTTP responses, `cat` of big files, wide `gr
 
 The soft hook `hooks/context-budget.sh` nudges when a command is likely to dump a large
 unbounded output. It is a reminder, never a block — judgment stays with the skill.
+
+## 8. Delegation Intent Template (v1.50.0)
+
+> Fable 5-era models perform measurably better when they understand the intent
+> behind a request — they connect the task to relevant context instead of
+> inferring intent on their own. This matters most for delegated subagents,
+> which see none of the parent conversation.
+
+When spawning ANY subagent (architect, code-reviewer, test-generator, Explore,
+researcher, …), the prompt MUST carry three intent lines before the request:
+
+```
+Я работаю над [большая задача] для [кто потребитель результата].
+Результат нужен, чтобы [что он разблокирует / как будет использован].
+С учётом этого: [конкретный запрос к субагенту].
+```
+
+Two companion rules:
+
+- **Prescriptive triggers, not capability lists.** When the subagent gets
+  tools/скиллы, say WHEN to use each ("зови `/test`, когда меняешь
+  исполняемый код; НЕ зови для чистых доков"), not merely that they exist —
+  trigger conditions in the instruction give measurable lift on should-call
+  rate (vendor guidance, Opus 4.7+/Fable 5).
+- **Report-back contract.** Tell the subagent its final message is a return
+  value, not a user-facing chat: outcome first, evidence attached,
+  «Не успел проверить: …» tail when applicable (pairs with
+  `hooks/narration-final.sh`).

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -102,6 +102,19 @@ Example — "Explain database connection pooling."
 - full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
 - ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
 
+### Fable 5-class models — final summaries stay readable (v1.50.0)
+
+On Fable 5-era models (Fable 5 / Opus 4.8+), vendor guidance explicitly bans
+arrow chains, hyphen-stacked compounds and invented abbreviations in FINAL
+summaries — «readability matters more; the way to keep output short is to be
+selective about what you include, not to compress the writing into fragments».
+Fighting that training with `ultra`/`wenyan-*` degrades quality. Rule:
+
+- **lite** — safe everywhere, stays the default.
+- **full/ultra/wenyan-\*** — acceptable for working inter-tool-call messages;
+  do NOT apply to the final summary of a long task. The final summary drops to
+  **lite** automatically (treat this as an Auto-Clarity case).
+
 ## Auto-Clarity
 
 Drop caveman (write normal prose) when brevity would hide risk or breed

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -135,6 +135,26 @@ python3 scripts/validate_state.py "$PROJECT_ROOT/.itd-memory/GOAL.json" 2>/dev/n
    смена состояния); в его срез вставь вывод
    `python3 "$GT/itd_goal_report.py"`.
 
+#### Автономный прогон (headless / AFK / долгий юнит) — anti-early-stop (v1.50.0)
+
+Когда юниты гонятся без пользователя у руля (headless-запуск, AFK-блок,
+долгий одиночный юнит), добавь себе в рабочий контекст напоминание
+(vendor-canonical снипет Fable 5-эры):
+
+> You are operating autonomously. The user is not watching in real time and
+> cannot answer questions mid-task, so asking "Want me to…?" / "Shall I…?"
+> will block the work. For reversible actions that follow from the original
+> request, proceed without asking. Before ending your turn, check your last
+> paragraph: if it is a plan, an analysis, a question, or a promise about work
+> you have not done ("I'll…", "далее проверю…"), do that work now with tool
+> calls. End your turn only when the unit is verified or you are blocked on
+> input only the user can provide.
+
+Это профилактика того же класса дефекта, который `hooks/narration-final.sh`
+ловит постфактум (нарратив-финал). Границы не отменяются: необратимые /
+data-sensitive действия по-прежнему требуют человека — автономность
+распространяется только на обратимые шаги внутри скоупа юнита.
+
 ### Step 3: Закрытие цели
 
 Все юниты `verified`/`skipped` → покажи финальный срез (юниты + evidence),

--- a/tests/verify_fable_snippets.py
+++ b/tests/verify_fable_snippets.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Functional checks for the v1.50.0 Fable 5 release-A snippet pack.
+
+Pins the four vendor-canonical snippets + the cross-cutting harness invariant
+(advisor/red-team decision 2026-07-05, release A of the Fable 5 adoption plan):
+
+  #1 docs/templates/global-claude-md.md — "Grounded progress claims" is a
+     numbered item INSIDE the "## Always" list, and the "Harness-native
+     features — best-effort invariant" section exists INSIDE the
+     ITD:BEGIN/ITD:END managed block (sync propagates only that block).
+  #2 skills/goal/SKILL.md — the autonomous-run reminder lives between
+     Step 2 and Step 3 (it is a unit-driving aid, not goal-closure text) and
+     keeps the boundary caveat (data-sensitive still needs a human).
+  #3 skills/_shared/helpers.md — §8 delegation intent template with the
+     three intent lines and both companion rules (prescriptive triggers,
+     report-back contract).
+  #4 skills/caveman/SKILL.md — Fable 5 note sits in the Intensity area
+     BEFORE Auto-Clarity; lite stays the default; ultra/wenyan are scoped to
+     working messages, never final summaries.
+
+Checks are positional/structural where possible — a snippet pasted into the
+wrong section must FAIL, not pass on mere substring presence.
+
+Self-contained:  python3 tests/verify_fable_snippets.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def flat(s: str) -> str:
+    """Collapse whitespace/newlines/quote-prefixes so phrase checks survive
+    markdown line-wrapping ("…your last\n> paragraph…")."""
+    return re.sub(r"\s+", " ", s.replace("\n> ", " ").replace("\n", " "))
+
+
+# ---------------------------------------------------------------- #1 global
+g = read("docs/templates/global-claude-md.md")
+
+# The real markers are HTML comments; the header prose also MENTIONS the
+# marker names, so match the comment form, not the bare word.
+begin, end = g.find("<!-- ITD:BEGIN"), g.find("<!-- ITD:END")
+check("global: single managed block, BEGIN before END",
+      begin != -1 and end != -1 and begin < end
+      and g.count("<!-- ITD:BEGIN") == 1 and g.count("<!-- ITD:END") == 1)
+
+always = re.search(r"## Always\n(.*?)\n## ", g, re.S)
+check("global: Always section found", always is not None)
+always_body = always.group(1) if always else ""
+check("global: grounded-claims is a numbered Always item",
+      re.search(r"^\d+\. \*\*Grounded progress claims\.\*\*", always_body, re.M)
+      is not None,
+      "item must live inside ## Always, numbered like the other rules")
+check("global: grounded-claims keeps the evidence wording",
+      "audit each claim" in always_body and "tool result" in always_body
+      and "Report" in always_body)
+
+inv = re.search(r"## Harness-native features — best-effort invariant.*?(?=\n## |\Z)",
+                g, re.S)
+check("global: harness-invariant section exists", inv is not None)
+inv_body = inv.group(0) if inv else ""
+check("global: invariant — transport, never the contract",
+      "TRANSPORT" in inv_body and "never BE the contract" in inv_body)
+check("global: invariant — vendor-neutral contract named",
+      "vendor-neutral" in inv_body)
+check("global: invariant — no gate/verified/handoff on a tool-call",
+      "gate" in inv_body and "`verified`" in inv_body and "handoff" in inv_body)
+check("global: invariant — egress via scrubber + human",
+      "scrubber" in inv_body and "human confirmation" in inv_body)
+check("global: invariant — background agents read-only",
+      "read-only reporters" in inv_body)
+check("global: invariant section is INSIDE the managed block",
+      inv is not None and begin < g.find("## Harness-native features") < end,
+      "sync-to-active.sh only propagates the ITD:BEGIN/END block")
+
+# ------------------------------------------------------------------ #2 goal
+goal = read("skills/goal/SKILL.md")
+
+s2 = goal.find("### Step 2:")
+s3 = goal.find("### Step 3:")
+auto = goal.find("#### Автономный прогон")
+check("goal: autonomous reminder present", auto != -1)
+check("goal: reminder sits between Step 2 and Step 3",
+      s2 != -1 and s3 != -1 and s2 < auto < s3,
+      "must be part of unit-driving (Step 2), not goal closure")
+auto_body = flat(goal[auto:s3]) if (auto != -1 and s3 != -1) else ""
+check("goal: reminder — operating autonomously wording",
+      "operating autonomously" in auto_body)
+check("goal: reminder — last-paragraph self-check",
+      "check your last paragraph" in auto_body)
+check("goal: reminder — pairs with narration-final hook",
+      "narration-final.sh" in auto_body)
+check("goal: reminder — data-sensitive boundary preserved",
+      "data-sensitive" in auto_body and "человека" in auto_body,
+      "autonomy must not override the human gate on irreversible ops")
+
+# --------------------------------------------------------------- #3 helpers
+h = read("skills/_shared/helpers.md")
+
+sec8 = re.search(r"## 8\. Delegation Intent Template.*", h, re.S)
+check("helpers: §8 delegation intent template exists", sec8 is not None)
+h8 = flat(sec8.group(0)) if sec8 else ""
+check("helpers: §8 — three intent lines in the fenced template",
+      "Я работаю над" in h8 and "Результат нужен" in h8
+      and "С учётом этого" in h8)
+check("helpers: §8 — prescriptive triggers rule",
+      "Prescriptive triggers" in h8 and "WHEN" in h8)
+check("helpers: §8 — report-back contract rule",
+      "Report-back contract" in h8 and "return value" in h8)
+check("helpers: §8 — pairs with narration-final hook",
+      "narration-final.sh" in h8)
+check("helpers: §7 context budget untouched above §8",
+      h.find("## 7. Context Budget") != -1
+      and h.find("## 7. Context Budget") < h.find("## 8. Delegation Intent"))
+
+# --------------------------------------------------------------- #4 caveman
+c = read("skills/caveman/SKILL.md")
+
+note = c.find("### Fable 5-class models")
+intensity = c.find("## Intensity")
+autoclar = c.find("## Auto-Clarity")
+check("caveman: Fable 5 note present", note != -1)
+check("caveman: note sits in Intensity area, before Auto-Clarity",
+      intensity != -1 and autoclar != -1 and intensity < note < autoclar)
+note_body = c[note:autoclar] if (note != -1 and autoclar != -1) else ""
+check("caveman: note — lite stays the default",
+      "lite" in note_body and "default" in note_body)
+check("caveman: note — ultra scoped to working messages, not final summaries",
+      "inter-tool-call" in note_body and "final summary" in note_body)
+check("caveman: note — routed through Auto-Clarity semantics",
+      "Auto-Clarity" in note_body)
+
+# ------------------------------------------------------- #5 CI registration
+ci = read(".github/workflows/windows-verify.yml")
+check("ci: verify_fable_snippets registered in windows-verify",
+      "tests/verify_fable_snippets.py" in ci,
+      "review finding v1.50.0: the test must guard its own CI registration")
+
+# ------------------------------------------------------------------- result
+print(f"\n{PASSED} passed, {FAILED} failed")
+sys.exit(1 if FAILED else 0)


### PR DESCRIPTION
Release A of the Fable 5 adoption plan (advisor ROI + red-team, 2026-07-05).

**Added**: Always #7 grounded progress claims; harness best-effort invariant section (managed block); /goal autonomous-run reminder; helpers §8 delegation intent template; tests/verify_fable_snippets.py (29 positional checks, CI-wired, self-registration guard).
**Changed**: /caveman — ultra/wenyan never for final summaries on Fable 5-class models.
**Decided (backlog)**: releases B/C/D with triggers; rejected: Artifact reports, mutating background agents, spawn_task-as-backlog.

Verification: 29/29 new + full local CI battery green (132 checks, snapshot 24/24, 40 skill profiles, meta_review PASSED). /review verdict: PASSED (5 nice-to-have; finding #1 fixed in-diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)