### PR TITLE
feat(methodology): v1.52.0 — release B: worktree isolation + memory approval-diff + effort tiers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.51.0",
+      "version": "1.52.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "description": "Complete project lifecycle methodology — 40 skills + 10 specialized subagents + 24 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, long-goal mode with a persistent unit ledger (GOAL.json, resumable across sessions), a telemetry-driven self-improvement retro (facts from the harness, proposals evidence-gated, merge stays human), strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric, a mechanical subagent narration-final stop-gate and a vendor-neutral verdict-contract stop-gate (SubagentStop).",
   "author": {
     "name": "HiH-DimaN",

--- a/.github/workflows/windows-verify.yml
+++ b/.github/workflows/windows-verify.yml
@@ -42,6 +42,8 @@ jobs:
         run: python tests/verify_narration_final.py
       - name: Verdict-contract validator functional tests (SubagentStop, v1.51.0)
         run: python tests/verify_verdict_contract.py
+      - name: Worktree hook-safety audit invariant (v1.52.0)
+        run: python tests/verify_worktree_hook_safety.py
       - name: Fable 5 release-A snippet pack (v1.50.0)
         run: python tests/verify_fable_snippets.py
       - name: Fixture contracts — all fixtures by status (Phase-2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.52.0] - 2026-07-05
+
+**Fable 5 adoption, release B — safety + calibration** (order A→C→B→D). Three changes: stronger isolation for large refactors, the data-sensitive gate applied to memory consolidation, and effort-tier calibration across the subagents. No new hook — the hook count stays 24.
+
+### Added
+
+- **`skills/refactor/references/worktree-isolation.md` + `/refactor` Step 0.5 — opt-in git-worktree isolation** for large, file-only refactors: do the whole refactor in a throwaway worktree, verify green there, merge back only on success — the main working tree is never touched until then. **Opt-in, not the default**; graceful fallback to the existing `freeze.sh` scope guard when a worktree can't be created (not a git repo, old git, dirty tree, user declines). Worktree isolation transports the "don't corrupt the working tree" intent — it is not the contract (harness best-effort invariant).
+- **Hook path-assumption audit (precondition, documented in the same reference).** All 24 hooks are worktree-safe: repo-root detection walks up to `.claude-plugin/plugin.json` (a worktree checks it out), and sentinels are keyed on `session_id`, not path. Two benign path-coupled cases (`execution-trace.sh` traces land in the transient worktree; `handoff-readiness.sh` may soft-nag on the dirty worktree) degrade, never break.
+- **`tests/verify_worktree_hook_safety.py` — audit invariant test**, wired into windows-verify CI. Drives the commit gate's actual `find_repo_root(start)` against a REAL git worktree (fidelity), asserting the repo root resolves from inside the worktree and from a nested dir, with a non-repo control. SKIPs gracefully if git is unavailable (falls back to a simulated checkout for the walk-up assertions).
+- **`docs/AGENT_EFFORT_TIERS.md`** — the per-role effort-tier framework (role class → effort), the durable rationale for the calibration below.
+
+### Changed
+
+- **Per-role effort tiers across the 10 subagents.** Before: almost every agent at `high` (no cost differentiation). After: verify/judge/design/deep-analysis (`code-reviewer`, `security-reviewer`, `devils-advocate`, `architect`, `perf-analyzer`, `test-generator`) stay `high`; gather/advise (`researcher` high→medium, `business-analyst` high→medium) drop to `medium`; mechanical `doc-writer` medium→low. `test-generator` stays `high` on purpose — its output gates everything else. `effort` is a per-call override via the Agent tool, so the frontmatter value is a default, not a floor.
+- **`skills/session-save/SKILL.md` — memory consolidation is now approval-diff-only.** `MEMORY.md` and the session files are durable state, so running `anthropic-skills:consolidate-memory` follows the data-sensitive gate (harness best-effort invariant): model changes read-only → show the before/after diff of which facts are dropped/merged → explicit human approval → only then write. Never a blind rewrite, never an out-of-band writer. The gate is ITD's, not optional.
+- **`plugin.json` / `marketplace.json` / README badges → 1.52.0.**
+
+### Decided (not implemented — backlog with triggers)
+
+- Release D — strictly retro-evidence-gated (skill de-prescription A/B one at a time; SendMessage fix→re-review within one session, advice-only; evals for 2–3 skills with false-match history).
+- Drift-guard hardening (from the C review): `verify_registration_and_counts.py` / M-C15 miss loose/spelled-out count mentions in README prose — fold into a retro fix.
+
+---
+
 ## [1.51.0] - 2026-07-05
 
 **Fable 5 adoption, release C — the review pack.** Three coupled upgrades to the review gate, taken before B/D flow through it (order A→C→B→D, decided 2026-07-05). The gate now collects findings for recall, filters them adversarially, and hands downstream a machine-readable verdict — with a mechanical stop-gate so the machine-readable part is never silently dropped. Battle-tested on this release's own review cycle.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.51.0](https://img.shields.io/badge/Version-1.51.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.52.0](https://img.shields.io/badge/Version-1.52.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.51.0](https://img.shields.io/badge/Version-1.51.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.52.0](https://img.shields.io/badge/Version-1.52.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/agents/business-analyst.md
+++ b/agents/business-analyst.md
@@ -2,7 +2,7 @@
 name: business-analyst
 description: 'Product discovery specialist — market analysis, user personas, competitor research, feature prioritization (MoSCoW + RICE). Read-only analysis, does not write files.'
 model: opus
-effort: high
+effort: medium
 maxTurns: 20
 allowed-tools: Read Grep Glob
 report_only: true

--- a/agents/doc-writer.md
+++ b/agents/doc-writer.md
@@ -2,7 +2,7 @@
 name: doc-writer
 description: "Specialized agent for documentation generation. Creates README, API docs, inline comments, and user guides matching project style. Use when user says 'напиши документацию', 'создай README', 'обнови README', 'опиши API', 'добавь inline комментарии', 'JSDoc', 'docstrings', 'changelog', or after a non-trivial feature lands. Typically invoked from /doc skill, but can be called directly via Agent tool for documentation-only work."
 model: haiku
-effort: medium
+effort: low
 maxTurns: 10
 allowed-tools: Read Grep Glob
 ---

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -2,7 +2,7 @@
 name: researcher
 description: 'Research specialist for market, technical, and documentation questions that change product, architecture, dependency, or integration decisions. Read-only — gathers evidence and returns recommendations, does not write files.'
 model: sonnet
-effort: high
+effort: medium
 maxTurns: 15
 allowed-tools: Read Grep Glob
 report_only: true

--- a/docs/AGENT_EFFORT_TIERS.md
+++ b/docs/AGENT_EFFORT_TIERS.md
@@ -1,0 +1,37 @@
+# Per-role effort tiers for the subagents (v1.52.0)
+
+Each agent in `agents/*.md` carries an `effort` value in its frontmatter — the reasoning-budget dial, **orthogonal to `model`**. Before v1.52.0 most agents sat at `high` (8 of 10; `doc-writer` and `ux-reviewer` were already `medium`): little cost differentiation, and cheap gather/mechanical roles burned nearly the same budget as the hard verify/judge ones. Release B calibrates them by role class.
+
+## The principle
+
+- **`high`** — hard verify / judge / design / deep analysis. The output gates quality or requires holding a lot of structure in mind at once; a wrong answer is expensive downstream, so spend the budget.
+- **`medium`** — gather / advise / review-with-evidence. Reads and synthesizes, but does not itself gate code or hold a whole design.
+- **`low`** — mechanical transformation. The shape of the answer is largely determined by the input.
+
+When in doubt, err one tier **up** for anything whose output feeds a gate (tests, security, review). `effort` is independent of `model`: a `haiku`+`low` role is cheap on both axes; an `opus`+`medium` role is a strong model on a bounded task.
+
+## The table
+
+| Agent | Role class | model | effort |
+|---|---|---|---|
+| `code-reviewer` | verify (gates quality) | sonnet | **high** |
+| `security-reviewer` | verify (gates security) | opus | **high** |
+| `devils-advocate` | judge (adversarial) | opus | **high** |
+| `architect` | design (deep structure) | opus | **high** |
+| `perf-analyzer` | deep analysis | sonnet | **high** |
+| `test-generator` | generate (feeds a gate) | sonnet | **high** |
+| `researcher` | gather / recommend | sonnet | medium |
+| `business-analyst` | gather / advise | opus | medium |
+| `ux-reviewer` | review-with-evidence | sonnet | medium |
+| `doc-writer` | mechanical write | haiku | **low** |
+
+Rationale for the v1.52.0 changes (the rest were already correct):
+
+- `doc-writer` **medium → low** — writing shaped by the code it documents; the least open-ended role.
+- `researcher` **high → medium** — gathers evidence and recommends; read-only, does not gate code.
+- `business-analyst` **high → medium** — market/persona/competitor analysis; advisory, read-only.
+- `test-generator` stays **high** on purpose — it is generative, but its output is the test suite that gates everything else, so under-thinking there is a false green.
+
+## Per-call override
+
+The frontmatter value is the sensible default, not a hard floor. The Agent tool's `effort` option (and a workflow's `agent(..., {effort})`) takes precedence for a single dispatch — bump a normally-`medium` role to `high` for one unusually hard task, or drop a `high` role to `low` for a trivial one.

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   side_effect: local-write
   explicit_invocation: false
   author: HiH-DimaN
-  version: 1.3.1
+  version: 1.4.0
   category: code-quality
   tags: [refactoring, clean-code, readability]
 ---
@@ -49,6 +49,21 @@ echo "/path/to/refactor/directory" | tee "/tmp/claude-freeze-${CLAUDE_SESSION_ID
 ```
 
 This prevents accidental edits outside the refactoring scope. The freeze is cleared when the skill completes. If the refactoring legitimately requires changes outside the frozen scope (e.g., updating callers), the freeze hook will warn and ask for confirmation.
+
+### Step 0.5: Optional worktree isolation for a large file-only refactor (v1.4.0)
+
+For a **large, file-only** refactor (multi-file rename / extract / move, no behaviour change), you may upgrade from the soft freeze to hard **git-worktree isolation**: do the whole refactor in a throwaway worktree, verify green there, and merge back only on success — the main working tree is never touched until then. This is **opt-in**, not the default.
+
+Use it when the user asks for an isolated/worktree refactor, or offer it for a large file-only job. For a small in-place edit, the Step 0 freeze is enough — do not spin a worktree for a two-line change.
+
+**Read `references/worktree-isolation.md`** for the full procedure and the hook path-assumption audit (all 24 hooks are worktree-safe — repo-root detection finds `.claude-plugin/plugin.json` in the worktree, sentinels are session-scoped). The shape:
+
+1. Preconditions (git repo, worktree-capable git, ideally a clean tree). If ANY fails → **fall back to the Step 0 freeze path and say why in one line**. Never hard-fail the refactor because a worktree could not be created (harness best-effort invariant — worktree isolation transports the intent, it is not the contract).
+2. `git worktree add <path> -b refactor/<name>` off HEAD; make ALL edits against paths under the worktree.
+3. Run the project's tests **inside the worktree** (the green baseline is the gate). On green, **commit inside the worktree** (`git -C <wt> add -A && git -C <wt> commit`) — that commit is what step 4 merges back; without it the merge is a silent no-op that loses the work.
+4. On green → `git merge --ff-only` (or `--no-ff`) the branch into the working branch, then `git worktree remove` + delete the branch. **If the merge conflicts** (the working branch diverged and overlaps), `git merge --abort` and drop to the freeze path, keeping the branch/worktree so the verified work is not lost. On red (nothing committed) → `git worktree remove --force` and discard; the main tree stays pristine.
+
+Behaviour-changing refactors are out of scope for this mode (they need `/test` first, Rule 2) — worktree isolation is only for structure-preserving, file-only work.
 
 ### Step 1: Analyze
 Read the code, understand its purpose and ALL callers/usages.

--- a/skills/refactor/references/worktree-isolation.md
+++ b/skills/refactor/references/worktree-isolation.md
@@ -1,0 +1,67 @@
+# Worktree isolation for file-only refactors (v1.52.0)
+
+A **file-only** refactor — pure structural moves with no behaviour change (rename, extract, split, dedupe across files) — is the safest candidate for *stronger-than-freeze* isolation: do the whole thing in a throwaway `git worktree`, verify green there, and only merge back to the working branch on success. The main working tree is never touched until a verified merge, so a botched refactor costs a `git worktree remove`, not a `git reset`.
+
+This is an **opt-in** upgrade to the default `freeze.sh` scope guard (soft, warns on out-of-scope edits). It is NOT a new contract: worktree isolation is a harness/git convenience that TRANSPORTS the "don't corrupt the working tree" intent — it must degrade gracefully to the freeze path when unavailable (harness best-effort invariant, global CLAUDE.md).
+
+## Hook path-assumption audit (precondition — all 24 hooks are worktree-safe)
+
+Running a skill with `cwd` inside a linked worktree was audited against every hook in `hooks/`. Result: **no hook blocks, misfires, or corrupts state in a worktree.** Two reasons cover the whole set:
+
+1. **Repo-root detection walks up to `.claude-plugin/plugin.json`, which a worktree checks out.** `careful.sh`, `check-commit-completeness.sh`, and `check-skill-completeness.sh` find the methodology root by walking parent dirs for `.claude-plugin/plugin.json`. A `git worktree` is a full working-tree checkout of a commit, so that file is present at the worktree root — detection resolves exactly as in the main tree. The commit gates parse `git diff --cached`, which operates on the worktree's own index; they fire identically. (`check-skills.sh` uses a **different** lookup — `project_profile(cwd)` reads `cwd/CLAUDE.md` for `itd-profile:` markers and falls back to `git rev-list --count HEAD`; it does NOT walk up for plugin.json. It is still worktree-safe: `CLAUDE.md` is checked out at the worktree root, and a worktree shares the repo history so `git rev-list` returns the same count — same profile as the main tree, via a different mechanism.)
+
+2. **Sentinels are keyed on `session_id`, not on path.** `/tmp/claude-{review,dod,freeze,skill-check,cost,checkpoint}-<session>` are session-scoped. Changing `cwd` into a worktree does not change `CLAUDE_SESSION_ID`, so the `/review`, DoD, freeze, cost, and crash-recovery sentinels are all still found. The commit gates unblock across the worktree boundary as expected.
+
+**Two benign path-coupled cases** (degrade, never break):
+
+- `execution-trace.sh` writes `<cwd>/.claude/traces/session-<id>.jsonl`. In a worktree that lands under the worktree dir and is discarded on `git worktree remove`. Pure debug telemetry — losing an ephemeral trace is harmless; `.claude/` is gitignored so it never enters a commit.
+- `handoff-readiness.sh` keys its rate-limit sentinel on an md5 of `cwd`, and nags (soft `systemMessage`) on a dirty tree with no fresh `session_*.md`. In a mid-refactor worktree the tree IS dirty, so it may soft-nag, and the worktree gets its own rate-limit bucket. Soft-only, never blocks — an acceptable, transient nudge.
+
+Each plugin.json-walk-up hook carries its OWN copy of the detection (not shared code): `careful.sh` walks up via `os.getcwd()` (`find_methodology_repo`), while `check-commit-completeness.sh` and `check-skill-completeness.sh` walk up via a path argument (`find_repo_root(start)`). `tests/verify_worktree_hook_safety.py` drives **both** path-arg copies against a real worktree (so a future divergence in either fails the test); `careful.sh`'s copy is the same walk-up logic on `os.getcwd()` and is covered by the audit, not the path-arg test.
+
+No hook needed a code change for worktree safety; this audit is the durable record that the precondition holds.
+
+## Procedure (opt-in)
+
+Use this for a **large, file-only** refactor (multi-file rename/extract/move). For a small in-place edit the default `freeze.sh` (Step 0) is enough — don't spin a worktree for a two-line change.
+
+```bash
+# 0. Preconditions — if ANY fails, fall back to the freeze path (Step 0) and say why.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "not a git repo → freeze fallback"; }
+# a reasonably clean tree is preferred so the merge-back is a clean fast-forward
+git diff --quiet && git diff --cached --quiet || echo "warning: dirty tree — prefer stashing or use freeze fallback"
+
+# 1. Create an isolated worktree on a throwaway branch off HEAD.
+WT="$(git rev-parse --show-toplevel)/../.itd-refactor-wt-$$"
+BR="refactor/$$-$(date +%s)"       # $$ (pid) avoids a same-second collision; date via shell is fine here (not a workflow script)
+git worktree add "$WT" -b "$BR" >/dev/null
+
+# 2. Do ALL refactor edits against paths under "$WT". Run the project's tests THERE,
+#    then COMMIT inside the worktree — the commit is what step 3a merges back.
+#    If tests are RED, do NOT commit — go straight to 3b.
+( cd "$WT" && pytest -q ) || { echo "tests red → go to 3b (discard)"; }   # project's green baseline
+git -C "$WT" add -A && git -C "$WT" commit -qm "refactor: <describe the change>"
+
+# 3a. On GREEN (committed above) — merge the verified branch into the working branch.
+if git merge --ff-only "$BR" 2>/dev/null || git merge --no-ff "$BR"; then
+  git worktree remove "$WT" && git branch -d "$BR"        # merged cleanly → clean up
+else
+  # Working branch diverged AND overlaps the refactor textually → conflict.
+  # Do NOT leave the tree mid-merge; abort and drop to the Step 0 freeze path.
+  # Keep the branch + worktree so the verified work is not lost.
+  git merge --abort
+  echo "merge conflict → freeze fallback. Verified work kept on branch $BR (worktree $WT); resolve manually, then: git worktree remove \"$WT\""
+fi
+
+# 3b. On RED (tests failed, nothing committed) — discard; the main tree was never touched:
+git worktree remove --force "$WT" && git branch -D "$BR"
+```
+
+### Rules
+
+- **Opt-in, never default.** Trigger it when the user asks for worktree/isolated refactor, or offer it for a large file-only job. The default remains the freeze hook.
+- **Graceful fallback is mandatory.** Not a git repo, git too old for worktrees, a dirty tree the user won't stash, or the user declines → drop to Step 0 (`freeze.sh`) and note the downgrade in one line. Never hard-fail the refactor because a worktree could not be created.
+- **Verify, then COMMIT, inside the worktree before merge.** The green test run in step 2 is the gate; on green you MUST commit inside the worktree (step 2) — step 3a merges that commit, and without it `git merge` is a silent no-op that discards the work and breaks the `git worktree remove` cleanup. A red run means `3b` (discard, nothing committed), and the working tree stays pristine.
+- **Merge-time fallback too.** The graceful-fallback rule covers not just preconditions but the merge: if `3a`'s `--no-ff` hits a conflict, `git merge --abort` and drop to the Step 0 freeze path — never leave the working tree mid-merge. The verified branch is preserved for manual resolution.
+- **Behaviour-changing refactors are out of scope for this mode.** If tests must be rewritten (behaviour changed), it is not a file-only refactor — use the normal in-place flow with `/test` first (Rule 2).
+- **The worktree is transient.** Do not leave `.itd-refactor-wt-*` dirs around; step 3 always removes them. `git worktree prune` cleans up any orphan from a crashed session.

--- a/skills/session-save/SKILL.md
+++ b/skills/session-save/SKILL.md
@@ -163,11 +163,18 @@ Add a line to `MEMORY.md` in the same memory directory:
 
 If `MEMORY.md` doesn't exist, create it with the first entry.
 
-> **Memory hygiene (periodic).** When `MEMORY.md` or the memory dir grows large or
-> accumulates duplicate/stale facts, run the `anthropic-skills:consolidate-memory` skill
-> to merge duplicates, fix stale entries, and prune the index — keep it in-session and
-> reviewed, never an out-of-band writer (ADR-001 async-memory note). idea-to-deploy does
-> not build its own consolidation engine; it delegates to that skill.
+> **Memory hygiene (periodic) — approval-diff mode only (v1.52.0).** When `MEMORY.md`
+> or the memory dir grows large or accumulates duplicate/stale facts, run the
+> `anthropic-skills:consolidate-memory` skill to merge duplicates, fix stale entries,
+> and prune the index. `MEMORY.md` and the session files are **durable state** — the
+> consolidation follows the data-sensitive gate (global CLAUDE.md, harness best-effort
+> invariant): **model the changes read-only first → show the before/after diff → get
+> explicit human approval → only then write.** Never a blind rewrite, never an
+> out-of-band/async writer (ADR-001 async-memory note): a merge that silently drops a
+> fact is worse than a slightly stale index. Concretely — before applying, surface the
+> proposed deletions/merges as a diff (which facts are being removed or rewritten, and
+> why), and wait for the user's go. idea-to-deploy does not build its own consolidation
+> engine; it delegates to that skill, but the approval-diff gate is ITD's, not optional.
 
 ### Step 4.5: Write active-session lockfile (v1.5.0)
 

--- a/tests/verify_worktree_hook_safety.py
+++ b/tests/verify_worktree_hook_safety.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Audit invariant for v1.52.0 release B, part 1: the enforcement hooks are
+worktree-safe.
+
+The load-bearing claim behind opt-in worktree isolation for /refactor
+(skills/refactor/references/worktree-isolation.md) is that a hook running from
+inside a linked `git worktree` resolves the methodology repo root the same way
+it does in the main tree — because a worktree checks out the same commit, so
+`.claude-plugin/plugin.json` is present at the worktree root and the walk-up
+detection finds it. That detection is what the commit gates
+(check-skill-completeness / check-commit-completeness) use to decide whether to
+fire; if it broke in a worktree, a /refactor commit from the worktree would slip
+past the gates.
+
+This test drives `find_repo_root(start)` — the exact walk-up function the commit
+gates use — directly (deterministic, no subprocess/stdin/env noise), against a
+REAL git worktree (fidelity: proves the worktree actually checks out
+plugin.json):
+  * find_repo_root(worktree root)        == worktree root   ← the claim
+  * find_repo_root(worktree/nested/dir)  == worktree root   ← from deep inside
+  * find_repo_root(plain non-repo dir)   is None            ← control
+
+The git-worktree creation SKIPs (exit 0) if git is unavailable; the walk-up
+assertions still run against a simulated checkout (a dir with plugin.json) so
+the invariant is covered even on a runner without git.
+
+Self-contained, stdlib only, cross-platform. Run:
+  python3 tests/verify_worktree_hook_safety.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+# Every hook that resolves the methodology root by walking parents for
+# .claude-plugin/plugin.json carries its OWN copy of find_repo_root (not shared
+# code), so a future edit to one could diverge. Drive each independently — the
+# audit's walk-up claim covers all of them, not one representative. (careful.sh
+# uses the same walk-up but via os.getcwd() with no path argument, so it is not
+# in this path-arg set; its logic is identical and CLAUDE-md/cwd-based, covered
+# by the audit doc's note.)
+HOOKS = [
+    ROOT / "hooks" / "check-skill-completeness.sh",
+    ROOT / "hooks" / "check-commit-completeness.sh",
+]
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def load_find_repo_root(hook: Path):
+    """Import find_repo_root from the .sh-that-is-python hook (meta_review
+    pattern): copy to a .py so importlib will load it, then grab the symbol."""
+    tmp = Path(tempfile.gettempdir()) / f"_wt_import_{uuid.uuid4().hex[:8]}.py"
+    shutil.copy(hook, tmp)
+    try:
+        spec = importlib.util.spec_from_file_location("_csc_mod", tmp)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore
+        return mod.find_repo_root
+    finally:
+        try:
+            tmp.unlink()
+        except Exception:
+            pass
+
+
+def git(args, cwd) -> subprocess.CompletedProcess:
+    env = {**os.environ,
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    return subprocess.run(["git", *args], cwd=str(cwd), env=env,
+                          capture_output=True, text=True, timeout=60)
+
+
+def make_checkout(base: Path) -> tuple[Path, bool]:
+    """Return (checkout_root, is_real_worktree). Prefer a real git worktree;
+    fall back to a simulated checkout (plain dir with plugin.json) when git is
+    unavailable — find_repo_root only cares about the plugin.json marker."""
+    def seed_marker(root: Path) -> None:
+        (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+        (root / ".claude-plugin" / "plugin.json").write_text(
+            '{"name": "idea-to-deploy"}', encoding="utf-8")
+
+    if shutil.which("git"):
+        repo = base / "repo"
+        repo.mkdir()
+        if git(["init", "-q"], repo).returncode == 0:
+            seed_marker(repo)
+            git(["add", "-A"], repo)
+            if git(["commit", "-qm", "init"], repo).returncode == 0:
+                wt = base / "wt"
+                if git(["worktree", "add", "-q", str(wt)], repo).returncode == 0:
+                    return wt, True
+    # Fallback: simulated checkout.
+    sim = base / "sim"
+    seed_marker(sim)
+    return sim, False
+
+
+def main() -> int:
+    base = Path(tempfile.mkdtemp(prefix="wt-safety-"))
+    try:
+        wt, real = make_checkout(base)
+        print(("using REAL git worktree" if real
+               else "git unavailable — using simulated checkout") + f": {wt}\n")
+
+        check("worktree/checkout contains .claude-plugin/plugin.json",
+              (wt / ".claude-plugin" / "plugin.json").is_file())
+
+        nested = wt / "src" / "deep"
+        nested.mkdir(parents=True)
+        plain = base / "plain"
+        plain.mkdir()
+
+        # Drive EACH plugin.json-walk-up hook's own find_repo_root — the audit
+        # claim covers all of them, so a per-hook copy that diverged must fail.
+        for hook in HOOKS:
+            find_repo_root = load_find_repo_root(hook)
+            tag = hook.name
+            check(f"[{tag}] CLAIM: find_repo_root(worktree root) resolves to "
+                  "the worktree root (repo detected from the worktree)",
+                  find_repo_root(wt) == wt, f"got {find_repo_root(wt)}")
+            check(f"[{tag}] find_repo_root from a nested dir inside the worktree "
+                  "resolves to the worktree root",
+                  find_repo_root(nested) == wt, f"got {find_repo_root(nested)}")
+            check(f"[{tag}] control: find_repo_root(non-repo dir) is None",
+                  find_repo_root(plain) is None, f"got {find_repo_root(plain)}")
+
+        if real:
+            git(["worktree", "remove", "--force", str(wt)], base / "repo")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+    print("\n%d passed, %d failed" % (PASSED, FAILED))
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Release B** of the Fable 5 adoption (order A→C→B→D). Three changes: stronger isolation for large refactors, the data-sensitive gate applied to memory consolidation, and per-role effort calibration. **No new hook — the count stays 24.**

## What changed

**Part 1 — opt-in worktree isolation for `/refactor` + hook path-assumption audit**
- `skills/refactor/references/worktree-isolation.md` + `/refactor` Step 0.5: for a large **file-only** refactor, do the whole thing in a throwaway `git worktree`, verify + **commit** there, and merge back only on green — the main working tree is never touched until then. **Opt-in, not the default.** Graceful fallback to the existing `freeze.sh` guard when a worktree can't be created (not a git repo, old git, dirty tree, user declines), and a merge-time `git merge --abort` → freeze fallback on conflict (worktree isolation transports the intent, it is not the contract — harness best-effort invariant).
- **Hook audit (documented, same reference):** all 24 hooks are worktree-safe — repo-root detection walks up to `.claude-plugin/plugin.json` (a worktree checks it out), sentinels are keyed on `session_id` not path. Two benign path-coupled cases degrade, never break.
- `tests/verify_worktree_hook_safety.py`: drives the commit gates' actual `find_repo_root` from **both** `check-skill-completeness.sh` and `check-commit-completeness.sh` against a REAL git worktree; wired into windows-verify CI. SKIPs gracefully without git.

**Part 2 — consolidate-memory approval-diff only** (`skills/session-save/SKILL.md`): `MEMORY.md` and session files are durable state, so running `anthropic-skills:consolidate-memory` follows the data-sensitive gate — model read-only → before/after diff → explicit human approval → only then write. Never a blind rewrite.

**Part 3 — per-role effort tiers** (`docs/AGENT_EFFORT_TIERS.md`): verify/judge/design/deep-analysis roles stay `high`; `researcher`/`business-analyst` high→medium (gather/advise); `doc-writer` medium→low (mechanical). `test-generator` stays `high` on purpose — its output gates the rest. `effort` is a per-call override, so the frontmatter is a default, not a floor.

## Acceptance (battle-test on its own review cycle)

The new C review pipeline (coverage-first + refute + JSON verdict) reviewed this diff and **earned its keep on a different change**: first pass **BLOCKED** — it caught a real **Critical** in the worktree procedure (no `git commit` inside the worktree before the merge → `git merge --ff-only` is a silent no-op that discards the refactor AND breaks the `git worktree remove` cleanup; reproduced live) plus two Important (no `--no-ff` conflict recovery; audit over-described `check-skills.sh`'s mechanism + the test drove 1 of the named hooks). All fixed — the Critical fix validated end-to-end (refactor lands on the branch, cleanup succeeds), the test extended to both commit-gate copies (7/7), and a **fresh re-review returned PASSED**.

Local gate suite green: worktree 7/7, registration 40/10/24, skill-profiles OK, **meta_review PASSED**, + all other CI tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
