### PR TITLE
feat(methodology): v1.53.0 — first live /retro cycle implemented (P1-P4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.52.0",
+      "version": "1.53.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "description": "Complete project lifecycle methodology — 40 skills + 10 specialized subagents + 24 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, long-goal mode with a persistent unit ledger (GOAL.json, resumable across sessions), a telemetry-driven self-improvement retro (facts from the harness, proposals evidence-gated, merge stays human), strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric, a mechanical subagent narration-final stop-gate and a vendor-neutral verdict-contract stop-gate (SubagentStop).",
   "author": {
     "name": "HiH-DimaN",

--- a/.github/workflows/windows-verify.yml
+++ b/.github/workflows/windows-verify.yml
@@ -44,6 +44,8 @@ jobs:
         run: python tests/verify_verdict_contract.py
       - name: Worktree hook-safety audit invariant (v1.52.0)
         run: python tests/verify_worktree_hook_safety.py
+      - name: M-C15 spelled hook-count parser (retro P2, v1.53.0)
+        run: python tests/verify_hook_count_words.py
       - name: Fable 5 release-A snippet pack (v1.50.0)
         run: python tests/verify_fable_snippets.py
       - name: Fixture contracts — all fixtures by status (Phase-2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.53.0] - 2026-07-05
+
+**The first live `/retro` cycle, implemented.** `/retro` ran over the harness telemetry (SKILL_BYPASS ledger, cost, VCR) plus this session's external signals (real review findings, a reviewer stall, drift-guard holes) and produced `docs/retros/RETRO-2026-07-05.md`. The human accepted all four evidence-backed candidates; this release implements them. No new hook/agent — counts stay 40/10/24.
+
+### Changed
+
+- **P1 — `check-tool-skill.sh` read-only Bash exemption now fires for `wsl -e`.** Evidence: **691 SKILL_BYPASS records this session, all Bash**, reasons dominated by read-only/verification/staging. Reading the code (not memory) refined the fix: the read-only allowlist + `wsl … bash -lc` unwrap already existed (v1.35.0/v1.47.0), but the unwrap regex only matched the long `--exec` — the far more common short `-e` form (`wsl -e bash -lc …`) never unwrapped, so a whole session of read-only recon produced ceremony bypasses. Added `-e` to the unwrap; mutations inside `wsl -e` stay gated (verified). Test: `verify_v147_fixes.py` (+3 cases).
+- **P2 — M-C15 hook-count check now parses teens + twenties (compounds).** Evidence: «семнадцать хуков» (17) sat stale in README.ru through v1.49/v1.50 (parser knew only 1-9), and «двадцать четыре хука» was misread as «четыре»=4, a false BLOCK in v1.51.0. The spelled-number parser (`num_ru`/`num_en`, now module-level in `meta_review.py`) covers 1..39 with compound parsing. New regression test `tests/verify_hook_count_words.py`, wired into CI. Residual (documented, no evidence yet): loose non-adjacent forms like «их N хуков» stay uncovered — over-match risk too high without a second signal.
+- **P3 — `narration-final.sh` widened (cautiously, pruned to evidence).** Evidence: a reviewer ended on «Now I have full coverage. Time to refute my own findings before reporting.» — the narration was in the LAST sentence, not the paragraph start, so start-only matching missed it. Added the `time to …` opener, the single evidenced verb `refute` (+ RU `опроверг`), and a last-sentence probe. The review of this very release flagged an over-widening in the first draft: `report`/`finalize`/`summarize`/`wrap` double as user-facing instructions («Now report back to the team», «Now wrap up») and false-blocked benign non-review finals — pruned to the evidenced minimum, re-expand only on a second concrete incident. Safety nets: the verdict-marker exemption (a review that issued its verdict is never blocked) + the ≤2 ping cap; `verify_narration_final.py` adds positive + false-block-guard cases (+7, including the pruned-verb guards).
+
+### Added
+
+- **P4 — helper rule: re-verify after BLOCKED with a fresh narrow agent, not a resume** (`skills/_shared/helpers.md` §8). Evidence: a resumed re-check stalled (600s watchdog) while a fresh narrow agent returned PASSED in 84s. A fresh agent starts thin (cheaper, less stall-prone) and its verdict is independent of the finder's reasoning.
+- **`docs/retros/RETRO-2026-07-05.md`** — the retro report (scan as-is + the evidence-ranked candidate table + the human decision).
+
+### Decided (not implemented — backlog with triggers)
+
+- Release D — strictly retro-evidence-gated (skill de-prescription A/B one at a time; SendMessage fix→re-review within one session, advice-only; evals for 2-3 skills with false-match history).
+
+---
+
 ## [1.52.0] - 2026-07-05
 
 **Fable 5 adoption, release B — safety + calibration** (order A→C→B→D). Three changes: stronger isolation for large refactors, the data-sensitive gate applied to memory consolidation, and effort-tier calibration across the subagents. No new hook — the hook count stays 24.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.52.0](https://img.shields.io/badge/Version-1.52.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.53.0](https://img.shields.io/badge/Version-1.53.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.52.0](https://img.shields.io/badge/Version-1.52.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.53.0](https://img.shields.io/badge/Version-1.53.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/retros/RETRO-2026-07-05.md
+++ b/docs/retros/RETRO-2026-07-05.md
@@ -1,0 +1,53 @@
+# RETRO 2026-07-05 — после релизов Fable 5 A→C→B (v1.50–v1.52)
+
+`/retro` цикл: **FACTS** (скрипт) → **PROPOSALS** (модель, evidence-gated) → **MERGE** (человек, штатный конвейер). Этот отчёт НЕ правит методологию; кандидаты идут в бэклог, реализация — отдельными релизами.
+
+## Step 1 — FACTS (скан as-is)
+
+Команда: `python itd_retro_scan.py C:/Users/Дмитрий/AI/OneOfS_tmp` (Windows-python — леджеры сессии писались под Windows-tempdir).
+
+```
+## Retro scan — факты из телеметрии (без интерпретации)
+
+Проектов с `.itd-memory`: 1 (workspace: C:\Users\Дмитрий\AI\OneOfS_tmp)
+VCR глобально: 0.0 (0/1 юнитов), регрессий: 0, проваленных верификаций: 0
+Проекты с VCR<1.0: OneOfS_tmp
+
+SKILL_BYPASS: всего 691, по инструментам: Bash×691
+Последние причины bypass: release B verification / staging for review /
+  review-fix cycle / fix verification / validating Critical fix / read-only
+  status audit / /retro FACTS step (все Bash, все read-only/verification/staging)
+
+Cost-леджеры: 560 сессий, 1 440 900 токенов, ~$43.23
+
+| Проект | Юниты (verified/activated) | VCR | Регрессии | Незакрытые гейты |
+| OneOfS_tmp | 0/1 | 0.0 | 0 | — |
+```
+
+**Внешние сигналы (read-only, из session_2026-07-05_{1,2,3}.md + ревью-циклов):**
+- C-пайплайн (coverage-first + refute + JSON-вердикт) на диффе релиза B поймал реальный **Critical** (worktree-процедура без `git commit` перед merge = silent no-op, теряет рефакторинг) — воспроизведён ревьюером live; BLOCKED→fix→PASSED.
+- Ревьюер-субагент порождал **нарратив-финал** 3× за A/C/B. `narration-final.sh` поймал «Let me check…» (C), но НЕ «Now I have full coverage. Time to refute…» (B) — вариант вне узкого триггера.
+- Ревьюер-субагент **застрял** на re-check (watchdog 600s); митигация — свежий узкий агент (PASSED 84s).
+- **Дыра дрифт-гарда:** `README.ru.md` жил с «семнадцать хуков» (17) и «их 23» сквозь v1.49/v1.50 — `verify_registration_and_counts` + M-C15 не ловят loose/прописью счётчики. M-C15 к тому же частично парсит слова («четыре»=4) → «двадцать четыре хука» дало ложный BLOCK в C.
+- `verdict-contract.sh` (релиз C) подтверждён live end-to-end (probe): харнес перечитывает settings.json без рестарта.
+
+## Step 2 — PROPOSALS (каждое с evidence; merge за человеком)
+
+| # | Сигнал (из Step 1) | Предложение | Effort | Риск / чем прибьём | Статус |
+|---|---|---|---|---|---|
+| P1 | SKILL_BYPASS **691, все Bash**, причины — read-only/verification/staging | `check-tool-skill.sh`: не наговаривать skill-решение на **консервативный read-only Bash-allowlist** (git status\|log\|diff\|show, ls, cat, grep/rg, `python tests/*`, wc). Соответствует правилу global CLAUDE.md «Read-only Bash не нужен skill-line» | S | Проэкземптить Bash, который ДОЛЖЕН был звать скилл → allowlist держать узким, покрыть `verify_skill_enforcement.py` | **кандидат** (повторяющийся, кросс-сессионный) |
+| P2 | README.ru stale 17/23 сквозь 2 релиза + M-C15 «четыре»=4 → ложный BLOCK (2 evidence) | Расширить count-гард (`verify_registration_and_counts.py` + M-C15): матчить `\d+\s+(hooks?\|хук\w*)` и `(hooks?\|хук\w*)\s*\(…\d+`; числа-слова — либо полная нормализация, либо линт «счётчик хуков только цифрой» | M | Over-match чисел в прозе → ложные фейлы; заскоупить на hook/skill/agent-count контексты + negative-тесты | **кандидат** (боевой: ложный BLOCK + stale sync) |
+| P3 | Нарратив-финал «Time to refute…» не пойман (1 вариант-инцидент; «reviewers narration-final» ×3 суммарно) | Осторожно расширить `NARRATION_RE` на «Time to <verb>» / «Now I …+review-verb», под ping-cap + расширенные negative-кейсы | S | Ложный блок = целый лишний ход субагента; ВЫСОКАЯ чувствительность | **бэклог-нота** — ждать 2-го evidence ИМЕННО этого варианта до расширения (signal-gated) |
+| P4 | Re-check ревьюера застрял (watchdog 600s), fresh narrow агент — PASSED 84s | Правило в `skills/_shared/helpers.md`: для re-verify после BLOCKED — **свежий узкий агент**, не резюм длинного зависшего транскрипта | S | ~0 (advice-only) | **бэклог-нота** (1 инцидент) |
+
+**Наблюдения (НЕ предложения — анти-Гудхарт):**
+- VCR 0.0 (0/1) — артефакт **abandoned**-цели «Календарь Этап 1», не провал верификации (регрессий 0, проваленных верификаций 0). VCR конфлейтит «abandoned» и «failed» — телеметрия-неточность; кода-фикс НЕ предлагаю (иначе — правка собственной метрики).
+- **Позитив (зафиксировать):** C-пакет (coverage-first+refute+JSON) окупился — поймал реальный Critical на чужом диффе с первого прохода. Фикс не нужен, это валидация релиза C.
+
+## Step 3 — решение за человеком
+
+Топ-кандидаты в бэклог следующего релиза (D или отдельный fix-релиз): **P1** (read-only Bash exemption) и **P2** (count-гард). P3/P4 — бэклог-ноты (signal-gated, ждут 2-го evidence / advice-only). Что берём — решает пользователь. Самозапуск реализации `/retro` не делает.
+
+## Решение пользователя + реализация (v1.53.0)
+
+Пользователь: **чиним все 4 сейчас, одним релизом** (v1.53.0). При реализации P1 уточнён чтением кода (не по памяти): read-only Bash-allowlist в `check-tool-skill.sh` УЖЕ существовал (v1.35.0) + unwrap `wsl … bash -lc` (v1.47.0), но unwrap-регекс ловил только длинный `--exec`, а НЕ короткий `-e` (`wsl -e bash -lc …` — моя форма всю сессию) → exemption не срабатывал → 691 ceremony-bypass. Реальный P1-фикс = добавить `-e` в unwrap (не «добавить allowlist»). Хороший пример принципа «прогони скан / читай код, не доверяй памяти».

--- a/hooks/check-tool-skill.sh
+++ b/hooks/check-tool-skill.sh
@@ -234,14 +234,18 @@ def is_readonly_bash(payload: dict) -> bool:
     if not cmd.strip():
         return False
     import re
-    # v1.47.0 (retro 2026-07-04, finding #2): unwrap `wsl.exe [-d X] [--exec]
+    # v1.47.0 (retro 2026-07-04, finding #2): unwrap `wsl.exe [-d X] [--exec|-e]
     # bash -lc "<inner>"` and judge the INNER command — on a Windows+WSL setup
     # every repo command travels in this wrapper, so the exemption never fired
     # and read-only recon produced hundreds of ceremony SKILL_BYPASS records
     # (628 in the ledger, top reason «read-only lookup»).
+    # v1.53.0 (retro 2026-07-05, P1): also unwrap the SHORT `-e` form of --exec.
+    # v1.47.0 only matched the long `--exec`, but `wsl -e bash -lc …` is the far
+    # more common spelling — it never unwrapped, so a whole session of read-only
+    # recon produced 691 ceremony SKILL_BYPASS records (all Bash) in the ledger.
     for _ in range(3):  # nested wrappers are theoretical; bound the loop
         m = re.match(
-            r"""^\s*wsl(?:\.exe)?\s+(?:-d\s+\S+\s+)?(?:--exec\s+)?
+            r"""^\s*wsl(?:\.exe)?\s+(?:-d\s+\S+\s+)?(?:(?:--exec|-e)\s+)?
                 bash\s+-l?c\s+(["'])(.*)\1\s*$""",
             cmd.strip(), re.VERBOSE | re.DOTALL,
         )

--- a/hooks/narration-final.sh
+++ b/hooks/narration-final.sh
@@ -63,13 +63,24 @@ MAX_PINGS_DEFAULT = 2
 # almost certainly content, not an announcement — stay silent on those.
 MAX_FINAL_PARA_LEN = 400
 
-# Opener at the very start of the final paragraph + a check-verb within the
-# next couple of words. Kept deliberately narrow: a false BLOCK costs a whole
-# extra subagent turn, a false pass costs one manual ping.
+# Opener at the very start of the final paragraph (or its LAST sentence) + a
+# check/deliverable-verb within the next couple of words. Kept deliberately
+# narrow: a false BLOCK costs a whole extra subagent turn, a false pass costs
+# one manual ping.
+# v1.53.0 (retro 2026-07-05, P3): added the "time to …" opener and the SINGLE
+# evidenced verb refute (+ RU опроверг), and the match now also probes the LAST
+# sentence of the final paragraph. Evidence: a reviewer ended on «Now I have
+# full coverage. Time to refute my own findings before reporting.» — the
+# narration sits in the last sentence, not the paragraph start, so start-only
+# matching missed it. Deliberately NOT added: report/finalize/summarize/wrap —
+# they double as user-facing instructions («Now report back to the team», «Now
+# wrap up») and would false-block non-review subagents (review-flagged, pruned
+# to the evidenced minimum; re-expand only on a second concrete incident).
 NARRATION_RE = re.compile(
-    r"^(?:now|next|let'?s|let\s+me|далее|теперь|сейчас)[,\s]+(?:[\w-]+[\s,]+){0,2}?"
-    r"(?:check|verify|test|re-?run|run|search|look|inspect|"
-    r"провер|перепровер|запус|посмотр|глян|поищ|протест)",
+    r"^(?:now|next|let'?s|let\s+me|time\s+to|далее|теперь|сейчас)[,\s]+"
+    r"(?:[\w-]+[\s,]+){0,2}?"
+    r"(?:check|verify|test|re-?run|run|search|look|inspect|refute|"
+    r"провер|перепровер|запус|посмотр|глян|поищ|протест|опроверг)",
     re.IGNORECASE,
 )
 
@@ -206,8 +217,14 @@ def main() -> int:
     if not para or len(para) > MAX_FINAL_PARA_LEN:
         return 0
     # Strip markdown emphasis so «**Далее** проверю…» still matches.
-    probe = re.sub(r"[*_`]+", " ", para).lstrip("#>–—•- \t")
-    if not NARRATION_RE.match(probe.strip()):
+    probe = re.sub(r"[*_`]+", " ", para).lstrip("#>–—•- \t").strip()
+    # Probe the paragraph start AND its last sentence: narration often trails a
+    # status sentence («Now I have coverage. Time to refute …»), which the
+    # start-only match missed (v1.53.0 P3). The verdict-marker exemption above
+    # is the real safety net — a review that issued its verdict is never here.
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", probe) if s.strip()]
+    last = sentences[-1] if sentences else ""
+    if not (NARRATION_RE.match(probe) or NARRATION_RE.match(last)):
         return 0
     if not take_ping_slot(key, env_int("ITD_NARRATION_MAX_PINGS", MAX_PINGS_DEFAULT)):
         return 0

--- a/skills/_shared/helpers.md
+++ b/skills/_shared/helpers.md
@@ -202,3 +202,13 @@ Two companion rules:
   value, not a user-facing chat: outcome first, evidence attached,
   «Не успел проверить: …» tail when applicable (pairs with
   `hooks/narration-final.sh`).
+- **Re-verify after BLOCKED with a FRESH narrow agent, not a resume (v1.53.0,
+  retro 2026-07-05, P4).** When a review returns BLOCKED and you fix the
+  findings, confirm the fix by dispatching a NEW subagent scoped to just the
+  changed points — do not resume the original long transcript. Evidence: a
+  resumed re-check stalled (600s watchdog, no progress) while a fresh narrow
+  agent returned PASSED in 84s. A fresh agent starts from a thin context (cheaper,
+  less stall-prone) and its verdict is independent of the finder's prior
+  reasoning — the same fresh-context property the refute pass relies on. Pass the
+  specific findings + fixed file paths by value; keep the scope to "is each prior
+  finding resolved + any new defect introduced," not a from-scratch re-review.

--- a/tests/meta_review.py
+++ b/tests/meta_review.py
@@ -42,6 +42,77 @@ from pathlib import Path
 
 
 # --------------------------------------------------------------------------
+# Spelled-number parsing for the M-C15 hook-count check (module-level so the
+# regression test can import it). v1.53.0 (retro 2026-07-05, P2): teens +
+# twenties WITH compound parsing — «двадцать четыре» = 24 (not «четыре» = 4,
+# the v1.51.0 false-BLOCK), «семнадцать» = 17 (was uncovered, let a stale
+# README.ru count survive v1.49/v1.50). Counts are small, so 1..39 suffices.
+# --------------------------------------------------------------------------
+_RU_UNIT = {
+    "один": 1, "одного": 1, "одно": 1, "одна": 1,
+    "два": 2, "двух": 2, "две": 2, "три": 3, "трёх": 3, "трех": 3,
+    "четыре": 4, "четырёх": 4, "четырех": 4, "пять": 5, "пяти": 5,
+    "шесть": 6, "шести": 6, "семь": 7, "семи": 7,
+    "восемь": 8, "восьми": 8, "девять": 9, "девяти": 9,
+}
+_RU_TEEN = {
+    "десять": 10, "одиннадцать": 11, "двенадцать": 12, "тринадцать": 13,
+    "четырнадцать": 14, "пятнадцать": 15, "шестнадцать": 16,
+    "семнадцать": 17, "восемнадцать": 18, "девятнадцать": 19,
+}
+_RU_TENS = {"двадцать": 20, "тридцать": 30}
+_EN_UNIT = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+            "six": 6, "seven": 7, "eight": 8, "nine": 9}
+_EN_TEEN = {"ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13,
+            "fourteen": 14, "fifteen": 15, "sixteen": 16,
+            "seventeen": 17, "eighteen": 18, "nineteen": 19}
+_EN_TENS = {"twenty": 20, "thirty": 30}
+
+
+def num_ru(phrase: str):
+    """Russian spelled number → int (1..39, compounds), else None."""
+    parts = phrase.lower().split()
+    if len(parts) == 2 and parts[0] in _RU_TENS and parts[1] in _RU_UNIT:
+        return _RU_TENS[parts[0]] + _RU_UNIT[parts[1]]
+    w = parts[0] if parts else ""
+    return _RU_TENS.get(w) or _RU_TEEN.get(w) or _RU_UNIT.get(w)
+
+
+def num_en(phrase: str):
+    """English spelled number → int (1..39, hyphenated compounds), else None."""
+    parts = re.split(r"[\s-]+", phrase.lower())
+    if len(parts) == 2 and parts[0] in _EN_TENS and parts[1] in _EN_UNIT:
+        return _EN_TENS[parts[0]] + _EN_UNIT[parts[1]]
+    w = parts[0] if parts else ""
+    return _EN_TENS.get(w) or _EN_TEEN.get(w) or _EN_UNIT.get(w)
+
+
+# Spelled-number-word regexes (module-level so verify_hook_count_words.py can
+# pin the over-match guard). Each REQUIRES a hook-word right after the number,
+# so «двадцать четыре часа» / «twenty-four hours» (24 HOURS, not hooks) never
+# matches — the guard that keeps the count check from firing on unrelated
+# numbers. The tens alternative is FIRST so a compound «двадцать четыре» /
+# "twenty-four" matches the whole thing, not bare «четыре»/"four".
+HOOK_EN_WORD_RE = re.compile(
+    r"\b((?:twenty|thirty)(?:[\s-]+(?:one|two|three|four|five|six|"
+    r"seven|eight|nine))?|ten|eleven|twelve|thirteen|fourteen|fifteen|"
+    r"sixteen|seventeen|eighteen|nineteen|one|two|three|four|five|six|"
+    r"seven|eight|nine)\s+"
+    r"(?:hooks?|enforcement\s+scripts?|hook\b)",
+    re.IGNORECASE,
+)
+HOOK_RU_WORD_RE = re.compile(
+    r"\b((?:двадцать|тридцать)(?:\s+(?:один|два|две|три|четыре|пять|"
+    r"шесть|семь|восемь|девять))?|десять|одиннадцать|двенадцать|"
+    r"тринадцать|четырнадцать|пятнадцать|шестнадцать|семнадцать|"
+    r"восемнадцать|девятнадцать|один|одного|одна|одно|два|двух|две|три|"
+    r"трёх|трех|четыре|четырёх|четырех|пять|пяти|шесть|шести|семь|семи|"
+    r"восемь|восьми|девять|девяти)\s+(?:хук\w*|скрипт\w*)",
+    re.IGNORECASE,
+)
+
+
+# --------------------------------------------------------------------------
 # Configuration
 # --------------------------------------------------------------------------
 
@@ -640,23 +711,8 @@ def run_rubric(repo: Path) -> Report:
             repo / "CONTRIBUTING.md",
         ]
 
-        # English number words 1-9
-        en_words = {
-            "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
-            "six": 6, "seven": 7, "eight": 8, "nine": 9,
-        }
-        # Russian number words (root forms) 1-9
-        ru_words = {
-            "один": 1, "одного": 1, "одно": 1, "одна": 1,
-            "два": 2, "двух": 2, "две": 2,
-            "три": 3, "трёх": 3, "трех": 3,
-            "четыре": 4, "четырёх": 4, "четырех": 4,
-            "пять": 5, "пяти": 5,
-            "шесть": 6, "шести": 6,
-            "семь": 7, "семи": 7,
-            "восемь": 8, "восьми": 8,
-            "девять": 9, "девяти": 9,
-        }
+        # Number words are parsed by module-level num_ru / num_en (v1.53.0,
+        # retro P2 — importable by tests/verify_hook_count_words.py).
 
         # Hook context words: must appear on the same line as the count
         hook_ctx = re.compile(
@@ -671,20 +727,10 @@ def run_rubric(repo: Path) -> Report:
             r"(?<!\S)(\d+)\s+(?:hooks?|скрипт\w*|hook\b|хук\w*)",
             re.IGNORECASE,
         )
-        # English word + hooks
-        hook_en_word_re = re.compile(
-            r"\b(one|two|three|four|five|six|seven|eight|nine)\s+"
-            r"(?:hooks?|enforcement\s+scripts?|hook\b)",
-            re.IGNORECASE,
-        )
-        # Russian word + хук/скрипт
-        hook_ru_word_re = re.compile(
-            r"\b(один|одного|одна|одно|два|двух|две|"
-            r"три|трёх|трех|четыре|четырёх|четырех|"
-            r"пять|пяти|шесть|шести|семь|семи|восемь|восьми|девять|девяти)\s+"
-            r"(?:хук\w*|скрипт\w*)",
-            re.IGNORECASE,
-        )
+        # Spelled-number-word regexes live at module level (HOOK_EN_WORD_RE /
+        # HOOK_RU_WORD_RE) so the over-match guard is pinned by the test.
+        hook_en_word_re = HOOK_EN_WORD_RE
+        hook_ru_word_re = HOOK_RU_WORD_RE
         # "All N hooks" / "Все N хуков" — covered by hook_num_re
 
         for doc in hook_count_doc_paths:
@@ -713,18 +759,18 @@ def run_rubric(repo: Path) -> Report:
                             f"{rel}:{lineno}: '{m.group(0)}' but actual hook count is {actual_hooks_n}",
                         )
 
-                # Pattern B: English number word "four hooks"
+                # Pattern B: English number word "four hooks" / "twenty-four hooks"
                 for m in hook_en_word_re.finditer(line):
-                    n = en_words.get(m.group(1).lower())
+                    n = num_en(m.group(1))
                     if n is not None and n != actual_hooks_n:
                         r.crit(
                             "M-C15",
                             f"{rel}:{lineno}: '{m.group(0)}' (={n}) but actual hook count is {actual_hooks_n}",
                         )
 
-                # Pattern C: Russian number word "четыре хука"
+                # Pattern C: Russian number word "четыре хука" / "двадцать четыре хука"
                 for m in hook_ru_word_re.finditer(line):
-                    n = ru_words.get(m.group(1).lower())
+                    n = num_ru(m.group(1))
                     if n is not None and n != actual_hooks_n:
                         r.crit(
                             "M-C15",

--- a/tests/verify_hook_count_words.py
+++ b/tests/verify_hook_count_words.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Regression pin for the M-C15 spelled-number parser (v1.53.0, retro P2).
+
+M-C15 (in meta_review.py) checks that hook counts written in prose match the
+real hook count. Two live incidents motivated widening its number vocabulary:
+  * «семнадцать хуков» (17) sat stale in README.ru through v1.49/v1.50 — the
+    old parser only knew 1-9, so a teen count slipped past the guard;
+  * «двадцать четыре хука» was misread as «четыре» = 4 (compound not handled),
+    producing a false BLOCK in v1.51.0.
+
+This test drives the module-level `num_ru` / `num_en` parsers directly, pinning
+teen + twenties + compound behaviour and the "not a hook context" guard.
+
+Self-contained, stdlib only. Run: python3 tests/verify_hook_count_words.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+spec = importlib.util.spec_from_file_location("_mr", ROOT / "tests" / "meta_review.py")
+mr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mr)  # type: ignore
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def main() -> int:
+    # Russian
+    ru = [
+        ("семнадцать", 17),      # incident A: the teen that slipped stale
+        ("двадцать четыре", 24),  # incident B: compound (was misread as 4)
+        ("двадцать", 20),
+        ("двадцать один", 21),
+        ("четыре", 4),
+        ("девять", 9),
+        ("тридцать", 30),
+        ("десять", 10),
+        ("девятнадцать", 19),
+    ]
+    for phrase, exp in ru:
+        check(f"num_ru('{phrase}') == {exp}", mr.num_ru(phrase) == exp,
+              f"got {mr.num_ru(phrase)}")
+    check("num_ru('банан') is None (not a number)", mr.num_ru("банан") is None)
+
+    # English
+    en = [
+        ("seventeen", 17),
+        ("twenty-four", 24),   # hyphenated compound
+        ("twenty four", 24),   # spaced compound
+        ("twenty", 20),
+        ("four", 4),
+        ("thirty", 30),
+        ("nineteen", 19),
+    ]
+    for phrase, exp in en:
+        check(f"num_en('{phrase}') == {exp}", mr.num_en(phrase) == exp,
+              f"got {mr.num_en(phrase)}")
+    check("num_en('banana') is None (not a number)", mr.num_en("banana") is None)
+
+    # Over-match guard: the word-regexes REQUIRE a hook-word after the number,
+    # so a spelled number followed by any other noun (hours/часа) never fires
+    # the count check. This is the guard that keeps M-C15 from flagging
+    # «двадцать четыре часа» / "twenty-four hours" as a stale hook count.
+    check("RU regex matches «двадцать четыре хука»",
+          mr.HOOK_RU_WORD_RE.search("итого двадцать четыре хука в наборе") is not None)
+    check("RU regex GUARD: «двадцать четыре часа» does NOT match (24 hours)",
+          mr.HOOK_RU_WORD_RE.search("прошло двадцать четыре часа") is None)
+    check("EN regex matches 'twenty-four hooks'",
+          mr.HOOK_EN_WORD_RE.search("there are twenty-four hooks now") is not None)
+    check("EN regex GUARD: 'twenty-four hours' does NOT match (24 hours)",
+          mr.HOOK_EN_WORD_RE.search("waited twenty-four hours") is None)
+
+    print("\n%d passed, %d failed" % (PASSED, FAILED))
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/verify_narration_final.py
+++ b/tests/verify_narration_final.py
@@ -130,6 +130,28 @@ NARR_MID_VERDICT = ("Now check the edge cases — done, results below.\n\n"
 NE_USPEL_TAIL = ("Разобрал 3 из 5 файлов, замечаний нет.\n\n"
                  "Не успел проверить: hooks/careful.sh, tests/meta_review.py.")
 LONG_CONTENT_PARA = ("Summary of the change.\n\nNow check " + "x" * 450)
+# v1.53.0 (retro 2026-07-05, P3): narration in the LAST sentence after a status
+# sentence, and the "time to …" opener + refute/wrap verbs.
+NARR_LAST_SENTENCE = ("I read all four files and cross-checked the hooks.\n\n"
+                      "Now I have full coverage. Time to refute my own findings "
+                      "before reporting.")
+NARR_RU_OPROVERG = ("Собрал находки по всем частям.\n\n"
+                    "Теперь опровергну каждую перед отчётом.")
+# Guards for the P3 prune: report/wrap/finalize double as user-facing
+# instructions and must NOT false-block (pruned to the evidenced `refute` only).
+GUARD_REPORT_BACK = ("Всё готово, изменения внесены.\n\n"
+                     "Now report back to the team with the results.")
+GUARD_WRAP_UP = ("Задача выполнена, тесты зелёные.\n\n"
+                 "Now wrap up: no further action needed.")
+GUARD_FINALIZE = ("Правки внесены во все три файла.\n\n"
+                  "Now finalize the docs and hand off.")
+# Guard: a content final whose last sentence is NOT an opener+verb → silent.
+CONTENT_LAST_SENTENCE = ("Разобрал дифф, вопросов нет.\n\n"
+                         "Все три части согласованы между собой. Отчёт выше "
+                         "покрывает найденное.")
+# Guard: verdict present + a "time to refute" sentence → verdict exemption wins.
+VERDICT_WITH_TIMETO = ("Time to refute the last finding — done.\n\n"
+                       "Вердикт: PASSED — все находки опровергнуты или закрыты.")
 
 
 def main() -> int:
@@ -143,8 +165,30 @@ def main() -> int:
     p = run_hook(make_layout(NARR_BOLD, "agent-direct"))
     check("markdown-bold narration opener still blocks", blocked(p),
           p.stdout[:200])
+    # v1.53.0 P3: last-sentence narration + "time to …" opener + refute/wrap verbs
+    p = run_hook(make_layout(NARR_LAST_SENTENCE, "agent-direct"))
+    check("P3: narration in last sentence («… Time to refute …») blocks",
+          blocked(p), p.stdout[:200])
+    p = run_hook(make_layout(NARR_RU_OPROVERG, "main-fallback"))
+    check("P3: «Теперь опровергну …» blocks", blocked(p), p.stdout[:200])
 
     # --- negatives: a verdict-final is NEVER blocked ------------------------
+    p = run_hook(make_layout(CONTENT_LAST_SENTENCE, "agent-direct"))
+    check("P3 guard: content last sentence (no opener+verb) stays silent",
+          not blocked(p), p.stdout[:200])
+    p = run_hook(make_layout(VERDICT_WITH_TIMETO, "agent-direct"))
+    check("P3 guard: verdict present + «time to refute» stays silent",
+          not blocked(p), p.stdout[:200])
+    # P3 prune guards: report/wrap/finalize are user-facing instructions, silent.
+    p = run_hook(make_layout(GUARD_REPORT_BACK, "agent-direct"))
+    check("P3 prune: «Now report back to the team» stays silent (not narration)",
+          not blocked(p), p.stdout[:200])
+    p = run_hook(make_layout(GUARD_WRAP_UP, "agent-direct"))
+    check("P3 prune: «Now wrap up: no further action» stays silent",
+          not blocked(p), p.stdout[:200])
+    p = run_hook(make_layout(GUARD_FINALIZE, "agent-direct"))
+    check("P3 prune: «Now finalize the docs» stays silent",
+          not blocked(p), p.stdout[:200])
     p = run_hook(make_layout(VERDICT_FINAL, "agent-direct"))
     check("verdict-final stays silent", not blocked(p), p.stdout[:200])
     p = run_hook(make_layout(NARR_MID_VERDICT, "agent-direct"))

--- a/tests/verify_v147_fixes.py
+++ b/tests/verify_v147_fixes.py
@@ -100,6 +100,13 @@ def main() -> int:
           not ro(bash('wsl.exe -d Ubuntu-24.04 --exec bash -lc "git push origin main"')))
     check("#2 wsl-wrapped inner redirect still gated",
           not ro(bash('wsl.exe --exec bash -lc "git log > /tmp/x"')))
+    # v1.53.0 (retro 2026-07-05, P1): the SHORT `-e` form of --exec must unwrap too.
+    check("#2 wsl -e (short exec) read-only exempted",
+          ro(bash("wsl -e bash -lc 'cd /repo && git status --short'")))
+    check("#2 wsl -d X -e (short exec) read-only exempted",
+          ro(bash("wsl -d Ubuntu-24.04 -e bash -lc 'git log --oneline -5'")))
+    check("#2 wsl -e mutation still gated",
+          not ro(bash("wsl -e bash -lc 'git commit -m x'")))
     check("#2 gh pr checks exempted", ro(bash("gh pr checks 108")))
     check("#2 gh pr merge still gated", not ro(bash("gh pr merge 108 --squash")))
     check("#2 cd && read-only exempted", ro(bash("cd /x && git status")))


### PR DESCRIPTION
**The first live `/retro` cycle, implemented.** `/retro` ran over the harness telemetry (**691 Bash SKILL_BYPASS this session**, cost, VCR) plus this session's external signals (real review findings, a reviewer stall, drift-guard holes), wrote `docs/retros/RETRO-2026-07-05.md`, and the human accepted all four evidence-backed candidates. This PR implements them. **No new hook/agent — counts stay 40/10/24.**

## The four fixes (each with its evidence)

**P1 — `check-tool-skill.sh` read-only exemption now fires for `wsl -e`.** Reading the code (not memory) refined the proposal: the read-only allowlist + `wsl … bash -lc` unwrap already existed (v1.35.0/v1.47.0), but the unwrap regex only matched the long `--exec` — the far more common short `-e` (`wsl -e bash -lc …`) never unwrapped, so a whole session of read-only recon produced **691 ceremony bypasses**. Added `-e`; mutations inside `wsl -e` stay gated (verified). +3 cases in `verify_v147_fixes.py`.

**P2 — M-C15 hook-count check parses teens + twenties (compounds).** «семнадцать хуков» (17) sat stale in README.ru through v1.49/v1.50 (parser knew only 1-9); «двадцать четыре хука» was misread as «четыре»=4, a false BLOCK in v1.51.0. `num_ru`/`num_en` (module-level in `meta_review.py`) now cover 1..39 with compounds. The over-match guard (a number needs a hook-word right after it, so «двадцать четыре часа»/"twenty-four hours" never fires) is pinned. New test `verify_hook_count_words.py`, wired into CI.

**P3 — `narration-final.sh` widened, then pruned to evidence.** A reviewer ended on «Now I have full coverage. Time to refute my own findings before reporting.» — the narration was in the LAST sentence, so start-only matching missed it. Added the `time to …` opener, the verb `refute` (+ RU `опроверг`), and a last-sentence probe. **This release's own review caught an over-widening in the first draft**: `report`/`finalize`/`summarize`/`wrap` double as user-facing instructions («Now report back to the team», «Now wrap up») and false-blocked benign non-review finals — pruned to the evidenced minimum. Safety nets: the verdict-marker exemption + ≤2 ping cap; +7 guard cases.

**P4 — helper rule: re-verify after BLOCKED with a fresh narrow agent, not a resume** (`skills/_shared/helpers.md` §8). A resumed re-check stalled (600s watchdog) while a fresh narrow agent returned PASSED in 84s.

## Acceptance (battle-test on its own review cycle)

The C review pipeline reviewed this diff and **earned its keep again**: it flagged the P3 over-widening as a real false-block (with concrete benign-final examples), which was pruned + guarded; a **fresh narrow re-review returned PASSED**, and its one Minor (the over-match guard wasn't regression-pinned) was closed too. The P4 rule (fresh narrow agent for re-verify) was applied live in this very cycle.

Local gate suite: **19 suites ALL-GREEN**, meta_review PASSED (0 critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
