### PR TITLE
feat(methodology): v1.55.0 — Release D1 advisor↔blueprint de-prescription (one measured A/B)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.54.0",
+      "version": "1.55.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "description": "Complete project lifecycle methodology — 40 skills + 10 specialized subagents + 24 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, long-goal mode with a persistent unit ledger (GOAL.json, resumable across sessions), a telemetry-driven self-improvement retro (facts from the harness, proposals evidence-gated, merge stays human), strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric, a mechanical subagent narration-final stop-gate and a vendor-neutral verdict-contract stop-gate (SubagentStop).",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.55.0] - 2026-07-05
+
+**Release D1 — skill-overlap de-prescription (wave 2, strictly one A/B at a time).** The 2026-07-05 `/advisor` audit flagged conceptual overlaps between skills; Release D resolves them one *measured* A/B at a time (baseline → change → `verify_routing.py` re-measure → rollback on any accuracy drop). Of the three pairs the audit named (project↔task, blueprint↔strategy, advisor↔grill-me), the routing benchmark showed **none** as a measurable ambiguity — the router is already 100% accurate. D1 therefore targets the only overlap that *did* surface as measurable routing ambiguity, `advisor`↔`blueprint`, chosen on evidence rather than the plan's assumed pairs. No new hook/agent/skill — counts stay 40/10/24.
+
+### Changed
+
+- **`check-skills.sh` — blueprint's bare `архитект` trigger narrowed to architecture-of-a-thing.** The bare stem matched "варианты архитектуры" in the analysis-only benchmark prompt `advisor-1` ("Только анализ, без кода: сравни варианты архитектуры"), so `/blueprint` co-fired and stole `/advisor`'s routing (ambiguous). Narrowed to `архитектур\w*\s+(?:проект|приложени|систем|продукт|сервис)` — still matches the canonical "архитектура проекта" phrase (so `verify_triggers.py` stays green) and genuine design prompts, and design-verb prompts ("спроектируй архитектуру") still route via `спроектируй`; it no longer fires on "сравни варианты архитектуры". **A/B measured:** routing accuracy 100.0% → 100.0% (no degradation); ambiguous prompts 10 → 9 (`advisor-1` now routes to `/advisor` alone); `verify_triggers.py` reports no drift.
+
+---
+
 ## [1.54.0] - 2026-07-05
 
 **Release E — usability fix-pack (wave 1 of the 2026-07-05 `/advisor` effectiveness audit, grade A−).** Three evidence-backed items: E1 shrinks the biggest ceremony source (691 SKILL_BYPASS this session), E2 makes two subagent contracts honest about their tools, E3 records a keep-with-justification decision for the three "silent" hooks and closes a hook-doc gap the drift-guard never caught. No new hook/agent/skill — counts stay 40/10/24.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.54.0](https://img.shields.io/badge/Version-1.54.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.55.0](https://img.shields.io/badge/Version-1.55.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.54.0](https://img.shields.io/badge/Version-1.54.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.55.0](https://img.shields.io/badge/Version-1.55.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/hooks/check-skills.sh
+++ b/hooks/check-skills.sh
@@ -138,7 +138,15 @@ TRIGGERS = [
         "🔔 Триггер 'review' → используй /review или субагента code-reviewer.",
     ),
     (
-        r"(спланируй|архитект|blueprint|подготовь\s+документац|спроектируй|"
+        # v1.55.0 (Release D1, advisor↔blueprint de-prescription): the bare stem
+        # `архитект` matched "варианты архитектуры" in an analysis-only prompt,
+        # so blueprint stole advisor's routing (advisor-1 was ambiguous). Narrowed
+        # to architecture-OF-a-thing (project/app/system/product/service) — keeps
+        # the canonical "архитектура проекта" phrase (verify_triggers) and genuine
+        # design prompts, but no longer fires on "сравни варианты архитектуры".
+        # Design-verb prompts ("спроектируй архитектуру") still match via `спроектируй`.
+        r"(спланируй|архитектур\w*\s+(?:проект|приложени|систем|продукт|сервис)|"
+        r"blueprint|подготовь\s+документац|спроектируй|"
         r"создай\s+документацию\s+для\s+проекта|техническое\s+задание|"
         r"\bprd\b|design\s+the\s+system|system\s+design)",
         "🔔 Триггер 'планирование/архитектура' → используй /blueprint или architect.",


### PR DESCRIPTION
## Release D1 — advisor↔blueprint de-prescription (v1.55.0)

Wave 2 of the 2026-07-05 `/advisor` audit, **strictly one A/B at a time** (per directive: don't touch routing blindly). No new hook/agent/skill — counts stay **40/10/24**.

### Evidence-driven target selection
The audit named three overlap pairs (project↔task, blueprint↔strategy, advisor↔grill-me), but the routing benchmark (`verify_routing.py`) shows the router is **already 100% accurate** and **none** of those pairs surface as measurable ambiguity. The only overlap that *did* surface as measurable routing ambiguity was **advisor↔blueprint** (`advisor-1`), so D1 targets that on evidence rather than the plan's assumed pairs. (Confirmed with the user before proceeding.)

### The change
`hooks/check-skills.sh`: blueprint's bare stem `архитект` matched "варианты архитектуры" in the analysis-only prompt `advisor-1` ("Только анализ, без кода: сравни варианты архитектуры"), so `/blueprint` co-fired and stole `/advisor`'s routing. Narrowed to `архитектур\w*\s+(?:проект|приложени|систем|продукт|сервис)`:
- keeps the canonical "архитектура проекта" phrase (so `verify_triggers.py` stays green),
- design-verb prompts ("спроектируй архитектуру") still route via the independent `спроектируй` alternative,
- no longer fires on "сравни варианты архитектуры".

### A/B measurement (baseline → after)
- Routing accuracy: **100.0% → 100.0%** (no degradation — rollback trigger not hit).
- Ambiguous prompts: **10 → 9** (`advisor-1` now routes to `/advisor` alone).
- `verify_triggers.py`: **no drift** (canonical "архитектура проекта" still routes to blueprint).

### Verification
- Full local CI green: **20 checks** (incl. `verify_routing`, `verify_triggers`, `meta_review`, `verify_snapshot --all`).
- Independent `code-reviewer` (fresh narrow): **PASSED** — reproduced the canonical-preserved / ambiguity-resolved / regex-sound / no-over-narrowing claims live; one cosmetic minor (CHANGELOG regex quote missing `?:`) fixed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
