### PR TITLE
feat(methodology): v1.56.0 — Release D1 second A/B, harden vault ∌ obsidian vault

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.55.0",
+      "version": "1.56.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "description": "Complete project lifecycle methodology — 40 skills + 10 specialized subagents + 24 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, long-goal mode with a persistent unit ledger (GOAL.json, resumable across sessions), a telemetry-driven self-improvement retro (facts from the harness, proposals evidence-gated, merge stays human), strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric, a mechanical subagent narration-final stop-gate and a vendor-neutral verdict-contract stop-gate (SubagentStop).",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.56.0] - 2026-07-05
+
+**Release D1 — second measured A/B (advisor↔blueprint was the first).** Continuing wave 2 one A/B at a time. After D1's first change, the remaining 9 routing ambiguities were classified bug-vs-by-design: most are broad-gate co-fires that route correctly and are intentional (`/review` co-firing on the literal word "review"/"audit"; `migrate`⊂`migrate-prod` substring, already handled). This release fixes the one clean, non-by-design case. No new hook/agent/skill — counts stay 40/10/24.
+
+### Changed
+
+- **`check-skills.sh` — harden's bare `vault` trigger no longer matches "obsidian vault".** `\bvault\b` (the secrets-manager Vault, a canonical harden phrase alongside "doppler"/"secrets management") also matched "obsidian vault", so `/harden` co-fired on `obsidian-export-2` ("Export this to my Obsidian vault as linked notes"). Added a fixed-width negative-lookbehind — `(?<!obsidian )\bvault\b` — that excludes ONLY "obsidian vault"; the canonical "vault" phrase and "secrets vault"/"hashicorp vault" still match (so `verify_triggers.py` stays green), and the obsidian-export trigger already owns `obsidian\s+vault`. **A/B measured:** routing accuracy 100.0% → 100.0% (no degradation); ambiguous prompts 9 → 8 (`obsidian-export-2` now routes to `/obsidian-export` alone); no trigger drift.
+
+---
+
 ## [1.55.0] - 2026-07-05
 
 **Release D1 — skill-overlap de-prescription (wave 2, strictly one A/B at a time).** The 2026-07-05 `/advisor` audit flagged conceptual overlaps between skills; Release D resolves them one *measured* A/B at a time (baseline → change → `verify_routing.py` re-measure → rollback on any accuracy drop). Of the three pairs the audit named (project↔task, blueprint↔strategy, advisor↔grill-me), the routing benchmark showed **none** as a measurable ambiguity — the router is already 100% accurate. D1 therefore targets the only overlap that *did* surface as measurable routing ambiguity, `advisor`↔`blueprint`, chosen on evidence rather than the plan's assumed pairs. No new hook/agent/skill — counts stay 40/10/24.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.55.0](https://img.shields.io/badge/Version-1.55.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.56.0](https://img.shields.io/badge/Version-1.56.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.55.0](https://img.shields.io/badge/Version-1.55.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.56.0](https://img.shields.io/badge/Version-1.56.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/hooks/check-skills.sh
+++ b/hooks/check-skills.sh
@@ -207,7 +207,13 @@ TRIGGERS = [
         r"load\s+test|нагрузочн\w+\s+тест|\bk6\b|"
         r"health\s*check|/healthz|liveness|readiness|"
         r"structured\s+log|structured\s+logs|logs?\s+to\s+json|"
-        r"secrets?\s+management|\bvault\b|\bdoppler\b|"
+        # v1.56.0 (Release D1, second A/B): bare `vault` (the secrets manager)
+        # also matched "obsidian vault", so /harden co-fired obsidian-export-2.
+        # Fixed-width negative-lookbehind excludes ONLY "obsidian vault"; the
+        # canonical harden phrase "vault", plus "secrets vault"/"hashicorp vault",
+        # still match (verify_triggers stays green). The obsidian-export trigger
+        # already owns `obsidian\s+vault`, so real Obsidian prompts route there.
+        r"secrets?\s+management|(?<!obsidian )\bvault\b|\bdoppler\b|"
         r"backup\s+strateg|стратеги\w+\s+бэкап)",
         "🔔 Триггер 'production hardening' → используй /harden (рубрика health/logs/metrics/backups/load-test/runbook, генерация артефактов с согласия пользователя). Вызови Skill ПЕРВЫМ.",
     ),


### PR DESCRIPTION
## Release D1 — second measured A/B: harden `vault` ∌ "obsidian vault" (v1.56.0)

Wave 2, one A/B at a time. After D1's first change (advisor↔blueprint, #117), the remaining 9 routing ambiguities were classified **bug-vs-by-design** — most are broad-gate co-fires that route correctly and are intentional (`/review` co-firing on the literal word "review"/"audit"; `migrate`⊂`migrate-prod` substring, already handled). This fixes the one clean, non-by-design case. No new hook/agent/skill — counts stay **40/10/24**.

### The change
`hooks/check-skills.sh`: harden's bare `\bvault\b` (the secrets-manager Vault — a canonical harden phrase alongside "doppler"/"secrets management") also matched "obsidian vault", so `/harden` co-fired on `obsidian-export-2` ("Export this to my Obsidian vault as linked notes"). Added a fixed-width negative-lookbehind `(?<!obsidian )\bvault\b`:
- excludes ONLY "obsidian vault";
- the canonical "vault" phrase and "secrets vault" / "hashicorp vault" still match (so `verify_triggers.py` stays green);
- `obsidian-export` already owns `obsidian\s+vault`, so real Obsidian prompts route there.

### A/B measurement (baseline → after)
- Routing accuracy: **100.0% → 100.0%** (no degradation).
- Ambiguous prompts: **9 → 8** (`obsidian-export-2` now routes to `/obsidian-export` alone).
- `verify_triggers.py`: **no drift** (canonical "vault" still routes to harden).

### Verification
- Full local CI green: **20 checks**.
- Independent `code-reviewer` (fresh narrow): **PASSED** — reproduced lookbehind compilation, "obsidian vault" exclusion, standalone/secrets/hashicorp "vault" still matching, verify_triggers no drift, verify_routing 100%/ambiguity-8. One minor (double-space "obsidian  vault" edge case) — acceptable: obsidian-export still routes correctly, not present in the benchmark.

### Remaining Wave-2 ambiguities (documented as by-design / delicate)
`security-audit-2`, `deps-audit-2`, `strategy-2`, `security-guidance-setup-2` (broad `/review`+audit co-fires), `migrate-prod-2` (substring, handled), `deploy-2` (deploy/harden genuine overlap) → **by-design, left untouched**. `explain-1` (auth), `adopt-2` (existing-project) → fixing trades a legitimate trigger signal for cosmetic ambiguity on already-correctly-routing prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
