### PR TITLE
docs(methodology): v1.58.0 — Release D3, /autopilot re-evaluated & hardened (harness-aligned)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.57.0",
+      "version": "1.58.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "description": "Complete project lifecycle methodology — 40 skills + 10 specialized subagents + 24 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, long-goal mode with a persistent unit ledger (GOAL.json, resumable across sessions), a telemetry-driven self-improvement retro (facts from the harness, proposals evidence-gated, merge stays human), strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric, a mechanical subagent narration-final stop-gate and a vendor-neutral verdict-contract stop-gate (SubagentStop).",
   "author": {
     "name": "HiH-DimaN",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.58.0] - 2026-07-05
+
+**Release D3 — `/autopilot` re-evaluation (audit graded it C, worst value/risk).** The plan's D3 item. Re-evaluated and **hardened, harness-aligned** (not deprecated, and not with per-phase human checkpoints — those would duplicate the mechanical harness and defeat the autonomy that is autopilot's whole point). The deciding fact: autopilot is already `disable-model-invocation: true`, so it is never auto-routed — a pure opt-in command. That removes most of the "redundant routing footgun" case for deprecation, leaving only a misleading description and a `context: fork` safety question, both fixed here. No new/removed skill — counts stay 40/10/24.
+
+### Changed
+
+- **`skills/autopilot/SKILL.md` — safety model reframed in harness terms; honest description; explicit boundary.** The old description ("minimal human intervention") oversold hands-free autonomy and understated the gates. Rewrote it around the actual safety model: autopilot auto-advances (that autonomy is the point and is harness-legitimate), and safety comes from the methodology's **mechanical gates** (`check-review-before-commit`, `check-dod-before-commit`, `careful`, `permission-ask`, `pii-egress-guard`) which fire on every tool call regardless of the orchestrating skill — **not** from human "да/нет" between phases. Autopilot owns exactly one hard **boundary**: it never performs an outward/irreversible action itself (no deploy, no `git push`, no `gh pr create`) — it stops at a local commit and hands those to the user. Added an explicit `context: fork` caveat: if a forked context does not inherit the enforcement hooks, the boundary still keeps the worst case to a local commit. Added a "prefer `/kickstart`" steer at the top (same lifecycle, main context, gates always apply; autopilot only for a deliberate hands-free greenfield spike) — turning the redundancy into a clear human choice instead of a trap. `/review` stays a hard gate (mechanically backstopped). Docs-only; no behavior/count change.
+
+---
+
 ## [1.57.0] - 2026-07-05
 
 **Release D2 — routing eval + CI gate for the de-prescribed skills.** Wave 2, next plan item after D1's two de-prescriptions. The audit's "evals for skills with false-match history" made concrete: D1's fixes were measured only *locally* — `verify_routing.py` was **not wired into any CI workflow**, so a re-broadened trigger would keep 100% accuracy while silently re-introducing the ambiguity the de-prescription removed. D2 closes that gap. No new hook/agent/skill — counts stay 40/10/24.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.57.0](https://img.shields.io/badge/Version-1.57.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.58.0](https://img.shields.io/badge/Version-1.58.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.57.0](https://img.shields.io/badge/Version-1.57.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.58.0](https://img.shields.io/badge/Version-1.58.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autopilot
-description: 'Auto-pipeline: runs the full methodology chain (discover → blueprint → kickstart → review → test) with minimal human intervention. Inspired by GSD auto mode.'
+description: 'Auto-pipeline: runs the full methodology chain (discover → blueprint → kickstart → review → test) autonomously under the methodology mechanical gates (review-before-commit, DoD, careful, the native permissions.ask matrix) — it never performs an outward/irreversible action itself (no deploy, no push, no PR; stops at a local commit). Inspired by GSD auto mode.'
 argument-hint: project idea or description (same as /kickstart)
 license: MIT
 allowed-tools: Read Write Edit Glob Grep Bash Skill
@@ -18,6 +18,16 @@ metadata:
 
 
 # Autopilot
+
+> **When to use — prefer `/kickstart` by default.** `/kickstart` runs the same
+> full lifecycle in the **main context**, where the methodology's mechanical
+> gates (review-before-commit, DoD, careful, permission-ask) always apply — that
+> is the safe, recommended path for "idea → built product". Reach for
+> `/autopilot` only for a **deliberate hands-free greenfield spike**, where you
+> knowingly want the chain to auto-advance through review + test. Autopilot adds
+> the auto-advance and the boundary below; it does not add capability over
+> `/kickstart`. This is an explicit, opt-in command (`disable-model-invocation`)
+> — the router never picks it for you.
 
 
 ## Trigger phrases
@@ -69,6 +79,41 @@ Proceed? (да/нет)
 
 Wait for explicit confirmation before proceeding.
 
+### Safety model — the harness enforces, autopilot does not babysit (v1.58.0)
+
+Autopilot auto-advances through the phases — that autonomy is the point, and it
+is **harness-aligned by design**: safety lives in the methodology's MECHANICAL
+gates, not in a human "да/нет" between every phase (that would duplicate the
+harness and defeat the autonomy). The enforcement hooks fire on **every**
+tool call regardless of which skill is orchestrating, so the risky edges stay
+closed under autopilot exactly as they do in manual work:
+
+- `check-review-before-commit.sh` blocks a multi-file commit without `/review`;
+- `check-dod-before-commit.sh` blocks a commit with a migration/payments/auth
+  signal that skipped the matching skill;
+- `careful.sh` + the native `permissions.ask` matrix prompt before deploy /
+  destructive / egress commands;
+- `pii-egress-guard.sh` denies a secret leaving the box.
+
+So autopilot does **not** invent its own per-phase checkpoints. What it owns is a
+single hard **boundary** at the irreversible / outward-facing edge:
+
+- **Autopilot never performs an outward/irreversible action itself** — no deploy,
+  no `git push`, no `gh pr create`. It stops at "generated + reviewed + committed
+  locally" and hands those steps to the user (Step 6 lists them). This is a
+  boundary the skill owns, not a checkpoint it re-asks each phase.
+- **`context: fork` caveat.** If a forked skill context does not inherit the
+  settings.json enforcement hooks, the mechanical gates above may not fire inside
+  autopilot. The boundary is what makes this safe regardless: because autopilot
+  itself performs no deploy/push/PR, the un-gated path can only ever reach a
+  local commit — never an outward action — even in the worst case.
+- **Cost.** A full pipeline is token-heavy; `hooks/cost-tracker.sh` ASKs at the
+  ceiling. Surface that to the user rather than pushing through it.
+
+If the user asks for true unattended execution *including* deploy/push, that
+crosses the boundary above — decline it and point at running the deploy step
+themselves (or `/kickstart` directly for the one-shot lifecycle).
+
 ### Step 1: Discovery phase
 
 Invoke `/discover` with the user's input:
@@ -92,7 +137,7 @@ Invoke `/blueprint` with DISCOVERY.md as input:
 
 Invoke `/kickstart` with the generated plans:
 - /kickstart auto-detects architecture + implementation plan
-- This is the longest phase — code generation, tests, deployment config
+- This is the longest phase — code generation, tests, deployment config (config is *generated*, not deployed — the no-auto-deploy boundary above still holds)
 - **Checkpoint:** Run `/session-save` after each kickstart sub-phase (Phase 2, 3, 4)
 
 **On error:** This is the most error-prone phase. Report to user with specific error. Do NOT auto-retry more than once.
@@ -180,7 +225,9 @@ Skip Phase 1 (/discover). Start directly from /blueprint with user's input.
 
 - NEVER proceed to the next phase if the current phase failed
 - ALWAYS checkpoint with /session-save between phases (crash resilience)
-- ALWAYS ask for user confirmation before starting the pipeline
+- ALWAYS ask for user confirmation before STARTING the pipeline (auto-advance between phases afterward is intended — safety comes from the mechanical harness, not per-phase prompts; see «Safety model»)
+- NEVER perform an outward/irreversible action from autopilot itself — no deploy, no `git push`, no `gh pr create`. Stop at a local commit and hand those to the user
+- `/review` is a HARD gate: never advance past it on a failing review (mechanically backstopped by `check-review-before-commit.sh`)
 - If any phase takes longer than expected, report progress to the user
 - The user can interrupt at any time — respect interruptions immediately
 - Do not combine phases — run them sequentially for clarity


### PR DESCRIPTION
## Release D3 — /autopilot re-evaluated & hardened, harness-aligned (v1.58.0)

The plan's D3 item: `/autopilot` was the audit's **worst value/risk** skill (C). **Re-evaluated and hardened, not deprecated.** Docs-only; no hook/behavior/count change (counts stay **40/10/24**).

### Why harden, not deprecate (practical-effectiveness reasoning)
The deciding fact: `/autopilot` is already `disable-model-invocation: true` — **never auto-routed**, a pure opt-in command. So the "redundant routing footgun / choice-paralysis" case for deprecation is largely moot (the router never picks it). What remained was a **misleading description** and a **`context: fork` safety question** — both fixed here. Deprecating would spend a risky multi-file cascade (benchmark prompts, `fixture-12-autopilot`, greenfield tuple) to remove a working, opt-in, now-safe, tested capability — a capability loss without a real practical gain.

### The harness-aligned reframe
The first draft added per-phase human "да/нет" checkpoints — **rejected as anti-harness** (it duplicates the mechanical gates and defeats the autonomy that is autopilot's whole point). The final framing:
- **Safety = the methodology's mechanical gates** (`check-review-before-commit`, `check-dod-before-commit`, `careful` + the native `permissions.ask` matrix, `pii-egress-guard`) — they fire on **every tool call regardless of the orchestrating skill** (verified: PreToolUse matchers are tool-event-scoped, not skill-scoped). No human checkpoints between phases.
- **One hard boundary:** autopilot never performs an outward/irreversible action itself — no deploy, no `git push`, no `gh pr create`; it stops at a local commit and hands those to the user.
- **`context: fork` caveat:** if a fork does not inherit the enforcement hooks, the boundary still keeps the worst case to a local commit.
- **"Prefer `/kickstart`" steer** — same lifecycle, main context, gates always apply; autopilot only for a deliberate hands-free greenfield spike. Turns the redundancy into a clear human choice instead of a trap.
- Honest description (dropped "minimal human intervention").

### Verification
- Full local CI green (counts 40/10/24; `fixture-12-autopilot` snapshot not broken — it's an output contract, not tied to SKILL.md prose).
- Independent `code-reviewer` (fresh narrow, opus): **PASSED_WITH_WARNINGS** — the harness-alignment claim verified **sound (not an overclaim)** against the adopt settings template, the `context: fork` caveat honest, the no-deploy/push/PR boundary consistent across Safety-model / Rules / Step 6. Two cosmetic minors (deployment-*config*-not-deploy wording; `permission-ask` → `permissions.ask` shorthand) **fixed before commit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
