### PR TITLE
v1.60.0 — Ось 2 (Agentic engineering): auto-ping, fleet refute, model-risk invariant, machine-readable DoD, stall-resilience

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "repo": "hihol-labs/idea-to-deploy"
       },
       "homepage": "https://github.com/hihol-labs/idea-to-deploy",
-      "version": "1.59.0",
+      "version": "1.60.0",
       "images": [
         "https://raw.githubusercontent.com/hihol-labs/idea-to-deploy/main/docs/demo.svg"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-to-deploy",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Complete project lifecycle methodology — 40 skills + 10 specialized subagents + 24 enforcement hooks from idea to deployed and hardened product. Product discovery (MoSCoW/RICE), market & community research, planning, scaffolding, coding, testing, debugging, optimization, security audit (with Red/Blue Team mode), dependency audit, safe DB migrations, production migration between hosts, deployment, production hardening, infrastructure-as-code, browser smoke-testing, library docs lookup (MCP/Context7), session context persistence, context handoff, daily-work routing, long-goal mode with a persistent unit ledger (GOAL.json, resumable across sessions), a telemetry-driven self-improvement retro (facts from the harness, proposals evidence-gated, merge stays human), strategic replanning, advisory/consulting mode, decision stress-testing, self-review mode, legacy project adoption, external-tool sync (GitHub/Linear/Notion), Obsidian export, safety guardrails, live execution tracing, skill enforcement with escalation, a Definition-of-Done pre-commit gate, an opt-in cross-vendor pre-commit second-opinion review (codex/gemini, fail-open), session-open diagnostics, context-switch detection, memory staleness warnings, session-end handoff-readiness detection, WIP=1 scope gating with a Verified Completion Rate metric, a mechanical subagent narration-final stop-gate and a vendor-neutral verdict-contract stop-gate (SubagentStop).",
   "author": {
     "name": "HiH-DimaN",

--- a/.github/workflows/meta-review.yml
+++ b/.github/workflows/meta-review.yml
@@ -62,5 +62,8 @@ jobs:
       - name: Run refute-pass fleet doc-contract (v1.60.0, Ось 2)
         run: python3 tests/verify_refute_fleet.py
 
+      - name: Run risk-tier => model monotonicity invariant (v1.60.0, Ось 2)
+        run: python3 tests/verify_model_risk_monotonic.py
+
       - name: Verify sync-to-active hook registration (drift guard, v1.20.1+)
         run: bash scripts/verify-sync-to-active.sh

--- a/.github/workflows/meta-review.yml
+++ b/.github/workflows/meta-review.yml
@@ -59,5 +59,8 @@ jobs:
       - name: Run caller-side auto-ping-for-verdict doc-contract (v1.60.0, Ось 2)
         run: python3 tests/verify_review_autoping.py
 
+      - name: Run refute-pass fleet doc-contract (v1.60.0, Ось 2)
+        run: python3 tests/verify_refute_fleet.py
+
       - name: Verify sync-to-active hook registration (drift guard, v1.20.1+)
         run: bash scripts/verify-sync-to-active.sh

--- a/.github/workflows/meta-review.yml
+++ b/.github/workflows/meta-review.yml
@@ -65,5 +65,8 @@ jobs:
       - name: Run risk-tier => model monotonicity invariant (v1.60.0, Ось 2)
         run: python3 tests/verify_model_risk_monotonic.py
 
+      - name: Run skill DoD machine-readable coverage (v1.60.0, Ось 2)
+        run: python3 tests/verify_dod_coverage.py
+
       - name: Verify sync-to-active hook registration (drift guard, v1.20.1+)
         run: bash scripts/verify-sync-to-active.sh

--- a/.github/workflows/meta-review.yml
+++ b/.github/workflows/meta-review.yml
@@ -56,5 +56,8 @@ jobs:
       - name: Run subagent-review sentinel tests (v1.25.0)
         run: python3 tests/verify_agent_review_sentinel.py
 
+      - name: Run caller-side auto-ping-for-verdict doc-contract (v1.60.0, Ось 2)
+        run: python3 tests/verify_review_autoping.py
+
       - name: Verify sync-to-active hook registration (drift guard, v1.20.1+)
         run: bash scripts/verify-sync-to-active.sh

--- a/.github/workflows/meta-review.yml
+++ b/.github/workflows/meta-review.yml
@@ -68,5 +68,8 @@ jobs:
       - name: Run skill DoD machine-readable coverage (v1.60.0, Ось 2)
         run: python3 tests/verify_dod_coverage.py
 
+      - name: Run stall-resilience fresh-narrow-agent fallback doc-contract (v1.60.0, Ось 2)
+        run: python3 tests/verify_stall_fallback.py
+
       - name: Verify sync-to-active hook registration (drift guard, v1.20.1+)
         run: bash scripts/verify-sync-to-active.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.60.0] - 2026-07-06
+
+**Ось 2 — Agentic engineering (multi-unit; goal `.itd-memory/GOAL.json`).** A push to raise the agentic-engineering axis from a self-graded ~7.5 toward ~9: make subagent recovery mechanical (never a manual ping), extend the adversarial refute discipline across the whole verify fleet, lock the risk-tier⇒model ordering, make the skill Definition-of-Done machine-readable, and turn stall recovery into an automatic fallback. Every unit is backed by a section-scoped, mutation-tested CI gate. Counts stay **40/10/24** throughout.
+
+### G-001 — caller-side auto-ping-for-verdict in `/review`
+
+The #1 agentic drag was a subagent ending its final message on process narration instead of a verdict, recovered only by a human ping. `/review` gains **Step 2.7**: after each Agent-tool dispatch, the conductor detects a verdict-less return by the **absence of the verdict marker** (not by regex-guessing the prose — strictly less reliable) and **auto-re-pings once, without asking the user**, bounded by `ITD_AUTOPING_MAX` (default 2). `/cross-review` gets the symmetric step 3a. The two SubagentStop hooks (`narration-final.sh`, `verdict-contract.sh`) are the *suspenders* to this caller-side *belt*; the layers degrade independently (harness best-effort invariant).
+
+**Tests** — `tests/verify_review_autoping.py` (new, 12 checks, section-scoped to Step 2.7 / 3a).
+
+### G-002 — refute pass across the whole verify fleet
+
+The `/review` Step 2.6 adversarial refute is extended to the rest of the verify fleet: `/security-audit` **Step 2.5** (refute exploitability of each Critical/Important vuln; security tie-break — vague doubt is not a refutation), `/perf` **Step 2.5** (refute each HIGH/MEDIUM bottleneck; must be measured on the hot path), `/test` **Step 5.5** (mutation-check each behavior-asserting test — green under a mutation = vacuous coverage). Shared invariant: the refute pass can only REMOVE findings, never invent one; minor/low findings are exempt.
+
+**Tests** — `tests/verify_refute_fleet.py` (new, 19 checks, section-scoped per skill).
+
+### G-003 — risk-tier ⇒ model monotonicity invariant
+
+A machine-checked invariant: the `security-reviewer`'s model tier is never below the `code-reviewer`'s (security is the higher-risk verify class). `MODEL-ROUTING-POLICY.md` is reconciled with the actual frontmatter (its table previously said code-review→opus while the `code-reviewer` subagent runs sonnet+high) — the interactive `/review` conductor row (opus) and the thin `code-reviewer` subagent row (sonnet+high) are now split and consistent.
+
+**Tests** — `tests/verify_model_risk_monotonic.py` (new) parses the `model:` frontmatter (tier-normalized, tolerant of a pinned full id) and pins both doc tables to it; a future inversion or doc-drift fails CI.
+
+### G-004 — machine-readable skill Definition-of-Done
+
+`VERIFICATION_CONTRACT.json` gains a `skillDefinitionOfDone` registry: each verify/impl skill's DoD is expressed as ≥1 **structured** done-signal (sentinel / command / artifact / json_field / evidence), not only prose. Anti-fabrication: every `sentinel` done-signal must actually be **written** by its skill (a redirection/`tee` line, not a prose mention).
+
+**Tests** — `tests/verify_dod_coverage.py` (new) counts coverage of the required verify/impl set (==100%) and grounds every sentinel ref.
+
+### G-005 — mechanical stall-resilience fresh-narrow fallback
+
+`skills/_shared/helpers.md` gains **§9**: on ANY subagent stall (watchdog timeout / autocompact death / empty return), the recovery is a fresh narrow agent spawned **automatically** — the default procedure, not a manual «resume or retry?» decision — generalizing §8's post-BLOCKED rule. Bounded by `ITD_STALL_MAX_RESPAWNS` (default 2), then escalates a visible blocker. Referenced from `/review` Step 0 and `/task` Step 3f.
+
+**Tests** — `tests/verify_stall_fallback.py` (new, 8 checks, section-scoped to §9).
+
+All five gates wired into `.github/workflows/meta-review.yml`. Live dogfood: during G-005's own review the `code-reviewer` ended on narration without a verdict — Step 2.7's caller-side auto-re-ping recovered the verdict in one message, zero manual pings.
+
+---
+
 ## [1.59.0] - 2026-07-06
 
 **Ось 1 — Harness engineering (multi-unit; goal `.itd-memory/GOAL.json`).** A push to raise the harness-engineering axis from a self-graded ~7.5 toward ~9.5: diff-bind the review gate, make the self-grading honest and behaviourally fixture-proofed, split hard vs soft gates explicitly, cut ceremony friction, and prove hook-inheritance + gate-robustness empirically. Counts stay **40/10/24** throughout.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then just describe what you want in Claude Code — methodology routes you autom
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#skills)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#subagents)
-[![Version: 1.59.0](https://img.shields.io/badge/Version-1.59.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.60.0](https://img.shields.io/badge/Version-1.60.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Skills: 40](https://img.shields.io/badge/Skills-40-green.svg)](#скиллы)
 [![Agents: 10](https://img.shields.io/badge/Agents-10-orange.svg)](#субагенты)
-[![Version: 1.59.0](https://img.shields.io/badge/Version-1.59.0-purple.svg)](.claude-plugin/plugin.json)
+[![Version: 1.60.0](https://img.shields.io/badge/Version-1.60.0-purple.svg)](.claude-plugin/plugin.json)
 [![meta-review](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml/badge.svg)](https://github.com/hihol-labs/idea-to-deploy/actions/workflows/meta-review.yml)
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](CHANGELOG.md)
 [![Type: Claude Code Plugin](https://img.shields.io/badge/Type-Claude%20Code%20Plugin-blueviolet.svg)](.claude-plugin/plugin.json)

--- a/docs/MODEL-ROUTING-POLICY.md
+++ b/docs/MODEL-ROUTING-POLICY.md
@@ -28,8 +28,9 @@ opaque router to debug.
 |---|---|---|
 | Requirements, discovery (`/discover`, `/blueprint` strategy) | **opus** | Open-ended reasoning, market/spec synthesis — frontier judgment pays for itself. |
 | Architecture, design (`/blueprint` architecture, `architect`/`devils-advocate` agents) | **opus** | Cross-cutting trade-offs held in working memory; cheap models miss interactions. |
-| Cross-document / code review (`/review`, `code-reviewer`) | **opus** | Must hold 6 docs + ~30 rubric checks at once; the quality floor of the whole methodology. |
-| Security & production judgment (`/security-audit`, `/harden`) | **opus** | Exploitability reasoning and cross-layer hardening are high-stakes, low-volume. |
+| Cross-document review — interactive `/review` conductor | **opus** | Must hold 6 docs + ~30 rubric checks at once; the quality floor of the whole methodology. |
+| Code review — the `code-reviewer` **subagent** (thin, one focused diff) | **sonnet + high effort** | Dispatched with a thin prompt against one target by path, it holds a bounded diff, not 6 docs — `sonnet`+`high` covers it (per `AGENT_EFFORT_TIERS.md`); `effort` buys the depth here, not `model`. |
+| Security & production judgment (`/security-audit`, `/harden`, `security-reviewer`) | **opus** | Exploitability reasoning and cross-layer hardening are high-stakes, low-volume — and, being the higher-risk verify class, its model tier must never sit below the code reviewer's (see "Risk-tier ⇒ model monotonicity" below). |
 | Implementation (`/kickstart` codegen, `/bugfix`, `/refactor`) | **opus → sonnet** | Opus for novel/complex logic; sonnet once the pattern is established and the change is mechanical. |
 | Test generation (`/test`) | **sonnet** | Pattern-matching against existing test conventions; sonnet covers all major frameworks. |
 | Routing & wrap-up (`/task`, `/session-save`, `/doc` formatting) | **sonnet (haiku-class acceptable)** | Mechanical: one routing question, summarize git log, format prose. High volume → cheapest safe tier. |
@@ -48,6 +49,21 @@ current — see the `claude-api` skill for live ids; do not hardcode an id here.
 3. **Cost feedback:** `hooks/cost-tracker.sh` + `/session-save` Step 4.6 make the
    actual spend visible, so the policy can be tuned against real numbers rather than
    guessed. (Accounting only — not an observability platform; see ADR-001.)
+
+## Risk-tier ⇒ model monotonicity (invariant, v1.60.0 — Ось 2)
+
+Routing to a cheaper tier is legitimate — but the **higher-risk** a verify agent's
+surface is, the **higher** (never lower) its model tier must be. Concretely: the
+`security-reviewer` gates the highest-stakes surface (exploitability, production
+safety), so its `model` frontmatter is never below the `code-reviewer`'s. Today
+`security-reviewer` = `opus`, `code-reviewer` = `sonnet` — monotone. This is not a
+comment we hope stays true: `tests/verify_model_risk_monotonic.py` parses the
+`model:` frontmatter of both agents and FAILS CI if the ordering ever inverts (a
+future cost-cut that quietly drops `security-reviewer` to `sonnet` while
+`code-reviewer` is `opus`, say). The gate also pins this table and
+`AGENT_EFFORT_TIERS.md` to the actual frontmatter, so the *contract* (the docs)
+can no longer invert from the *model* (the frontmatter) — the class of drift this
+invariant exists to kill.
 
 ## Non-goals (explicit)
 

--- a/docs/templates/itd/VERIFICATION_CONTRACT.json
+++ b/docs/templates/itd/VERIFICATION_CONTRACT.json
@@ -35,5 +35,139 @@
     "Failures are recorded as recovery, not success."
   ],
   "failureMode": "RECOVERY_REQUIRED",
-  "failClosed": "If a command is missing, never ran, or its parser is ambiguous, status MUST be RECOVERY_REQUIRED — never passed."
+  "failClosed": "If a command is missing, never ran, or its parser is ambiguous, status MUST be RECOVERY_REQUIRED — never passed.",
+  "skillDoneSignalSchema": {
+    "purpose": "Machine-readable Definition-of-Done for the verify/impl skills (v1.60.0 — Ось 2). A skill's DoD must be expressed as >=1 structured done-signal below, not only prose Self-validation — so 'done' is a check, not a vibe. verify_dod_coverage.py enforces coverage of the required set and cross-checks every sentinel ref against the skill that writes it.",
+    "allowedDoneSignalTypes": [
+      "sentinel",
+      "command",
+      "artifact",
+      "json_field",
+      "evidence"
+    ],
+    "requiredCoverageSkills": [
+      "review",
+      "test",
+      "security-audit",
+      "perf",
+      "bugfix",
+      "refactor",
+      "deps-audit",
+      "migrate",
+      "harden",
+      "infra"
+    ]
+  },
+  "skillDefinitionOfDone": {
+    "review": {
+      "roleClass": "verify",
+      "doneSignals": [
+        {
+          "type": "sentinel",
+          "ref": "claude-review-done",
+          "desc": "/review ran this session, bound to the staged tree"
+        },
+        {
+          "type": "json_field",
+          "ref": "verdict",
+          "desc": "machine-readable verdict block: PASSED | PASSED_WITH_WARNINGS | BLOCKED"
+        }
+      ]
+    },
+    "test": {
+      "roleClass": "verify",
+      "doneSignals": [
+        {
+          "type": "sentinel",
+          "ref": "claude-test-done",
+          "desc": "suite actually ran and passed this session"
+        },
+        {
+          "type": "evidence",
+          "ref": "red->green",
+          "desc": "fail-closed TDD evidence: real run output, not 'should pass'"
+        }
+      ]
+    },
+    "security-audit": {
+      "roleClass": "verify",
+      "doneSignals": [
+        {
+          "type": "sentinel",
+          "ref": "claude-security-audit-done",
+          "desc": "audit was performed this session (verdict may still be BLOCKED)"
+        }
+      ]
+    },
+    "perf": {
+      "roleClass": "verify",
+      "doneSignals": [
+        {
+          "type": "evidence",
+          "ref": "before/after",
+          "desc": "fail-closed: bottleneck measured before/after, not guessed"
+        }
+      ]
+    },
+    "bugfix": {
+      "roleClass": "impl",
+      "doneSignals": [
+        {
+          "type": "evidence",
+          "ref": "red->green",
+          "desc": "regression test fails on the old code, passes on the fix"
+        }
+      ]
+    },
+    "refactor": {
+      "roleClass": "impl",
+      "doneSignals": [
+        {
+          "type": "command",
+          "ref": "test-suite",
+          "desc": "behavior-preserving: existing suite green before AND after"
+        }
+      ]
+    },
+    "deps-audit": {
+      "roleClass": "verify",
+      "doneSignals": [
+        {
+          "type": "artifact",
+          "ref": "deps-audit-report",
+          "desc": "severity-tiered CVE/license/abandonment report produced"
+        }
+      ]
+    },
+    "migrate": {
+      "roleClass": "impl",
+      "doneSignals": [
+        {
+          "type": "sentinel",
+          "ref": "claude-migrate-done",
+          "desc": "migration ran with a backup + a rollback path"
+        }
+      ]
+    },
+    "harden": {
+      "roleClass": "impl",
+      "doneSignals": [
+        {
+          "type": "artifact",
+          "ref": "runbook+health",
+          "desc": "generated hardening artifacts (health checks, runbook, limits)"
+        }
+      ]
+    },
+    "infra": {
+      "roleClass": "impl",
+      "doneSignals": [
+        {
+          "type": "artifact",
+          "ref": "iac+plan-step",
+          "desc": "generated IaC (Terraform/Helm/K8s) plus a documented plan/validate step the user runs before apply — /infra generates, it does not itself apply"
+        }
+      ]
+    }
+  }
 }

--- a/skills/_shared/helpers.md
+++ b/skills/_shared/helpers.md
@@ -212,3 +212,43 @@ Two companion rules:
   reasoning — the same fresh-context property the refute pass relies on. Pass the
   specific findings + fixed file paths by value; keep the scope to "is each prior
   finding resolved + any new defect introduced," not a from-scratch re-review.
+
+## 9. Stall-resilience — fresh narrow agent as the AUTOMATIC stall fallback (v1.60.0 — Ось 2)
+
+> Generalizes §8's post-BLOCKED fresh-agent rule to EVERY stall. A subagent that
+> stalls — autocompact-thrashes until it dies, trips a watchdog with no progress,
+> or returns empty/truncated — used to force a manual «resume or retry?» decision.
+> That manual step is itself a stall in the loop. This makes the recovery
+> **mechanical and automatic**: on a detected stall, spawn a fresh narrow agent —
+> do not deliberate, do not ask the user.
+
+**Detect a stall by MECHANICAL signals, not by judgement:**
+
+- a watchdog/turn timeout elapsed with no new tool call or output (no-progress);
+- the subagent died mid-run (autocompact death, terminal API error after retries)
+  and returned nothing usable;
+- the returned final is empty or truncated (no deliverable / no verdict marker —
+  overlaps `/review` Step 2.7's absence check).
+
+**Automatic response — a fresh narrow agent, NOT a manual choice:**
+
+1. **Spawn fresh, do not resume.** Dispatch a NEW `Agent(...)` from a thin
+   context — never resume the stalled transcript (a resumed long transcript
+   re-loads the same bloat that caused the stall; §8 evidence: resume stalled at
+   the 600s watchdog while a fresh narrow agent returned in 84s).
+2. **Narrow the scope.** Split the original task into the smallest independently
+   useful slice (one dimension, one file, one finding) and pass inputs by value /
+   by path — a smaller prompt is both cheaper and far less stall-prone.
+3. **This is the default path, not an option to weigh.** Do not stop to ask
+   «resume or retry?» — for a detected stall the fresh narrow agent IS the
+   procedure. Proceed automatically (reversible, in-scope recovery).
+4. **Bounded, then escalate.** At most `ITD_STALL_MAX_RESPAWNS` (default 2) fresh
+   respawns per task; still stalling → surface a visible blocker to the user with
+   what was and wasn't done — a persistently stuck task is a reported blocker,
+   never a silent drop.
+
+Belt-and-suspenders with the hooks: `hooks/narration-final.sh` catches a
+verdict-less stop at the subagent boundary; this §9 is the caller-side procedure
+when the subagent stalls hard enough that nothing usable comes back at all. The
+layers are independent — if a harness drops the hook (best-effort invariant), the
+documented fresh-narrow fallback still recovers.

--- a/skills/cross-review/SKILL.md
+++ b/skills/cross-review/SKILL.md
@@ -89,6 +89,18 @@ parse and summarize its findings. No heavy generation. Set via `/model sonnet`.
    Pipe the scrubbed diff with a focused review prompt (correctness bugs, security,
    missed edge cases) and capture stdout. Treat any non-zero exit as "unavailable".
 
+3a. **Verdict-completeness — auto-re-ping once on a verdict-less return (v1.60.0
+   — Ось 2, agentic engineering).** Whether the reviewer is an external CLI or
+   the native red-team fallback (an Agent-tool `code-reviewer` dispatch), its
+   output must end on a findings/verdict conclusion. If the captured output ends
+   **without one** — a truncated stream, a dangling narration, an empty tail —
+   **auto-re-ping ONCE, caller-side, without asking the user**: re-run the CLI
+   with «выдай вердикт и список находок одним ответом», or resume the subagent
+   per `/review` Step 2.7. Detect by the **ABSENCE of the conclusion marker**,
+   not by pattern-matching whether the prose "looks like" narration. Bounded to
+   one retry; still empty → report «внешний ревьюер не вернул вердикт» and
+   degrade (fail-open) — never silently treat an empty return as clean.
+
 4. **Fold findings into review notes.** Summarize the external model's findings,
    de-duplicate against what Claude already knows, and present a short ranked list
    (file:line + concrete fix). Always state which engine actually ran (codex /

--- a/skills/perf/SKILL.md
+++ b/skills/perf/SKILL.md
@@ -88,6 +88,35 @@ For each finding:
 **Trade-off**: any downsides
 ```
 
+### Step 2.5: Refute pass — adversarially verify each surfaced bottleneck before you trust it (v1.60.0 — Ось 2, agentic engineering)
+
+The refute pass from `/review` Step 2.6, applied to the perf verify fleet. A
+plausible-but-wrong bottleneck (a hot-looking loop that is actually cold, an N+1
+on a 3-row table, an "optimization" that trades against a real constraint)
+wastes effort and can regress correctness — this pass filters them before they
+reach the prioritized list. Put every **HIGH and MEDIUM** finding through an
+independent refutation.
+
+For each such finding, run a **fresh** adversarial verification (a separate
+reasoning pass, or `Agent(subagent_type: "perf-analyzer", …)` with a refute
+prompt) that tries to prove the finding is NOT worth acting on — read the code
+and the evidence and look for the reason: **is it actually on the hot path**
+(measured, not guessed — this skill's «measure first» rule is the refutation's
+teeth), is the input size real, would the proposed fix *measurably* help, does
+the trade-off cost more than it saves. **Default to `refuted: true` under
+uncertainty**: a bottleneck you cannot back with a measurement or a concrete
+hot-path argument is dropped, not shipped as a guess.
+
+- Refuted (cold path / negligible N / fix wouldn't help / bad trade-off) → move
+  to "Additional observations" with a `refuted` note; it does not gate priority.
+- Confirmed (measured on the hot path, fix helps) → keep it, ranked by impact.
+- **LOW-impact / micro-optimization findings are NOT refuted** — they never gate,
+  so the cost is not justified.
+
+**Invariant:** the refute pass can only REMOVE unconfirmed findings from the
+prioritized set; it never invents a new bottleneck and never manufactures a
+measurement it did not take.
+
 ### Step 3: Prioritize
 Sort by impact. Focus on real bottlenecks, not micro-optimizations.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -217,6 +217,54 @@ escalation; it never turns a rubric-Critical FAIL into a pass. If a Critical
 rubric check itself fails, that is deterministic and stands regardless of any
 finding-level refutation (Rule 4).
 
+### Step 2.7: Caller-side verdict-completeness — auto-re-ping a subagent that returned without a verdict (v1.60.0 — Ось 2, agentic engineering)
+
+Every subagent this skill dispatches via the **Agent tool** — the Step 0
+delegation to `code-reviewer`, and each Step 2.6 refuter — is contracted to end
+on a verdict (a `PASSED` / `PASSED_WITH_WARNINGS` / `BLOCKED` marker, or the
+fenced ```json verdict block from Step 3). When the returned final message
+carries **no verdict marker at all**, the subagent stopped mid-work (process
+narration, a dangling «далее проверю…», an autocompact death). The historical
+failure mode was the human pinging «выдай итог одним сообщением» by hand — the
+#1 drag, observed ×4 in a single session. This step makes the recovery
+**mechanical and caller-side**: the conductor issues the re-ping itself, so the
+user never does.
+
+Rule — after each Agent-tool dispatch returns, **before** you use its result:
+
+1. **Detect by ABSENCE of the contract marker, not by pattern-matching the
+   prose.** Check whether the returned final message contains a verdict marker
+   (`PASSED` / `PASSED_WITH_WARNINGS` / `BLOCKED` / `FINAL STATUS` / `Verdict` /
+   `Вердикт` / `Итог`, or the ```json verdict block). The ```json verdict block
+   from Step 3 is the **canonical** marker; the bare verdict words are a
+   deliberate tolerance so a subagent that voiced a valid verdict but garbled
+   the JSON fencing still short-circuits the re-ping instead of looping — the
+   JSON-block *completeness* is separately enforced by `verdict-contract.sh`, so
+   this step does not double-gate it. Marker present → accept the result, done. Do **not** try to classify a return by guessing whether the
+   prose "looks like" a narration opener — the only question is «есть ли маркер
+   вердикта». Regex-guessing the opener is the subagent-side hook's job (below),
+   never the caller's decision; widening a narration regex is strictly less
+   reliable than checking for the presence of the required marker.
+2. **Absent → auto-re-ping ONCE, without asking the user.** Continue the same
+   subagent (SendMessage / resume) with the minimal instruction: «Заверши: выдай
+   вердикт одним сообщением — verdict-блок (PASSED / PASSED_WITH_WARNINGS /
+   BLOCKED + findings). Не пересказывай процесс.» This is a reversible, in-scope
+   recovery — proceed automatically (never «Хочешь, я переспрошу?»).
+3. **Bounded.** At most `ITD_AUTOPING_MAX` (default 2) re-pings per subagent; if
+   still no verdict, escalate to the user with what the subagent DID return — a
+   genuinely stuck subagent becomes a visible blocker, not a silent green.
+
+**Belt and suspenders.** This caller-side step is the *belt*. The *suspenders*
+are two SubagentStop hooks that catch the same defect at the subagent boundary,
+so it usually never reaches the caller: `hooks/narration-final.sh` blocks a
+subagent stop whose final paragraph is a dangling narration opener with no
+verdict marker (feeding the resume instruction back to the subagent), and
+`hooks/verdict-contract.sh` blocks a prose verdict that ships without the
+machine-readable ```json block. If a harness drops SubagentStop hooks
+(vendor/version switch — harness best-effort invariant), the suspenders silently
+disappear but this documented caller-side belt still recovers the verdict; the
+two layers degrade independently, never to a false green.
+
 ### Step 3: Generate report
 
 Output the report in **exactly** the format specified at the bottom of `references/review-checklist.md` (`## Reporting format` section). The format is parseable so other skills (`/kickstart` Quality Gate 1) can consume it.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -74,6 +74,11 @@ already exists. Dispatching the Agent is still possible from within a fork, so d
 the size check and switch to Agent-tool dispatch **first thing** — before loading
 any more context — if `CLAUDE.md` is large.
 
+This fork-thrash fallback is one instance of the general **stall-resilience**
+rule: on ANY subagent stall (watchdog timeout, autocompact death, empty return),
+a fresh narrow agent is the **automatic** fallback — not a manual «resume or
+retry?» decision. See `skills/_shared/helpers.md` §9.
+
 ### Step 0.4: Resolve the review TARGET path (v1.42.0 — do not silently review cwd)
 
 `$ARGUMENTS` may point the review at a DIFFERENT repo/path than the current

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -66,6 +66,39 @@ For each check, look at specific files:
 - CORS/CSP: server response headers, middleware setup
 - Dependencies: `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml` — flag known-vulnerable versions if recognizable
 
+### Step 2.5: Refute pass — adversarially verify each Critical/Important finding before it escalates (v1.60.0 — Ось 2, agentic engineering)
+
+The refute pass from `/review` Step 2.6, applied to the security verify fleet. A
+plausible-but-wrong vulnerability that survives to the report is a false alarm
+that erodes trust in the gate and wastes remediation effort — this pass exists to
+kill exactly those. Before writing the report, put every **Critical and
+Important** candidate finding through an independent refutation.
+
+For each such finding, dispatch a **fresh-context** subagent via the **Agent
+tool** (`Agent(subagent_type: "security-reviewer", …)`) with a **refute prompt**:
+state the single finding verbatim (its `file:line`, the vuln class, the claimed
+exploit path) and instruct the agent to **REFUTE exploitability** — read the
+actual code and look for a **concrete** reason it is NOT exploitable (input
+sanitized upstream, route unreachable / behind auth, the "secret" is a test
+fixture, the sink is not attacker-reachable). Fresh context is load-bearing: the
+refuter must not inherit your reasoning, or it will rubber-stamp — pass the
+finding by value, the target by path.
+
+- A finding **refuted with a concrete reason** → move it to "Informational" with
+  a `refuted` note; it no longer gates.
+- A finding **not refuted** → keep it at its tier. Security-specific tie-break:
+  vague doubt is **not** a refutation — «я не смог подтвердить» drops nothing
+  (false-negative on a real vuln is worse than a false-positive here).
+- **Minor / Recommended / Informational findings are NOT refuted** — they never
+  gate, so the cost is not justified; report them as observations.
+
+**Invariant:** the refute pass can only REMOVE unconfirmed findings from
+escalation; it never invents a new vulnerability and never downgrades a
+*confirmed* Critical. If subagents cannot be dispatched in this runner, do the
+refutation inline as a separate adversarial reasoning pass and say so ("refute
+pass: inline"). This is distinct from `--redblue` (Step 5), which *models*
+attack/defense pairs; the refute pass *filters* the findings already surfaced.
+
 ### Step 3: Generate report
 
 Use this exact format (parseable by `/review` and other downstream skills):

--- a/skills/task/SKILL.md
+++ b/skills/task/SKILL.md
@@ -175,6 +175,13 @@ implementation:
 Tier note (Step 1b): a feature is **standard** by default; escalate to
 **high-risk** when it touches prod data, schema, auth, payments, or security.
 
+Stall-resilience: when any step here dispatches a subagent (the routed skill's
+verify/review agents, an Explore/refute agent) and it **stalls** — watchdog
+timeout, autocompact death, empty return — the recovery is **automatic**: spawn a
+fresh narrow agent scoped to the smallest useful slice, do not stop to ask
+«resume or retry?». This is the shared rule in `skills/_shared/helpers.md` §9,
+not a per-skill judgement call.
+
 ### Step 3.5: Unit bookkeeping — WIP=1 (v1.41.0, only when `.itd-memory/` exists)
 
 If `$PROJECT_ROOT/.itd-memory/STATE.json` exists, keep the machine-readable

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -142,6 +142,36 @@ All tests must pass before finishing.
 
 **TDD evidence gate (v1.21 — PFO port):** for a behavior change (new feature or bugfix), prefer writing the test **first** and capturing red→green evidence: the test fails on the old code, passes on the new. Note both states explicitly ("red: AssertionError … → green: 1 passed"). When red-first is genuinely impractical (UI glitch, race condition, env-specific bug), state that exception explicitly rather than silently skipping it.
 
+### Step 5.5: Refute pass — mutation-check each new test before you trust it as coverage (v1.60.0 — Ось 2, agentic engineering)
+
+The refute pass from `/review` Step 2.6, applied to the test verify fleet. Here
+the "finding" is a new test's implicit claim «this asserts real behavior». A
+test that passes on BOTH the correct and the broken code is vacuous coverage — a
+green that proves nothing and lies to every later reader. This pass adversarially
+challenges that claim before the suite's green is trusted.
+
+For each **behavior-asserting** test just written (not trivial getters /
+formatting / snapshot-only tests), run a **fresh** mutation check: break the code
+path the test claims to cover — invert a condition, drop a guard, return a wrong
+constant (or dispatch `Agent(subagent_type: "test-generator", …)` with a refute
+prompt to attempt it) — and confirm the test now **FAILS**. A test that stays
+green under the mutation is **refuted as meaningful coverage**. This is the
+red→green TDD gate (Step 5) run in reverse: green→red-under-mutation. **Default
+to `refuted: true` under uncertainty** — if you cannot make the test fail by
+breaking what it supposedly checks, treat its coverage claim as unproven.
+
+- Refuted (survives the mutation) → the test is vacuous: fix it (tighten the
+  assertion) or drop it; do not count it as coverage.
+- Confirmed (fails under mutation) → real coverage, keep it.
+- **Trivial / non-behavioral tests are NOT mutation-checked** — the cost is not
+  justified.
+
+**Invariant:** the refute pass can only REMOVE vacuous tests from the trusted
+coverage set; it never fabricates a passing test and never reports mutation
+evidence it did not actually run. When a real mutation run is impractical
+(env-specific, flaky), state that exception explicitly rather than silently
+claiming the coverage is proven — same honesty rule as the TDD gate above.
+
 ### Step 6: Mark `/test` as done for this session (v1.23.0)
 
 Final step of every `/test` invocation, **after the suite has actually run and passed** (see the fail-closed gate above). Write a session marker so `hooks/check-dod-before-commit.sh` knows `/test` was run — this is what unblocks a `git commit` the DoD gate flags as test-requiring (DB migrations, brand-new source files). The sentinel asserts "tests were run this session", so only write it when verification genuinely passed — never to silence the gate.

--- a/tests/verify_dod_coverage.py
+++ b/tests/verify_dod_coverage.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Coverage test for the machine-readable skill Definition-of-Done (v1.60.0 —
+Ось 2, agentic engineering, unit G-004).
+
+Before v1.60.0 a skill's DoD lived only as a prose "Self-validation" checklist
+plus a per-unit VERIFICATION_CONTRACT with an empty commands[]. v1.60.0 extends
+VERIFICATION_CONTRACT.json with a `skillDefinitionOfDone` registry: each
+verify/impl skill's "done" is expressed as >=1 STRUCTURED done-signal (sentinel /
+command / artifact / json_field / evidence), not a vibe. This gate enforces that
+the registry covers the required set, every entry is machine-readable, and — the
+anti-fabrication check — every `sentinel` done-signal actually names a sentinel
+the corresponding skill really writes (grep of skills/<skill>/SKILL.md).
+
+Asserts:
+  1. the schema block + `skillDefinitionOfDone` exist and parse;
+  2. coverage of `requiredCoverageSkills` == 100% (every required skill has an
+     entry with roleClass in {verify,impl} and >=1 done-signal);
+  3. every done-signal `type` is in `allowedDoneSignalTypes` (machine-readable,
+     never a prose-only entry);
+  4. every `sentinel` ref is grounded: it appears in skills/<skill>/SKILL.md
+     (the registry cannot cite a done-signal the skill does not emit);
+  5. the gate is wired into a CI workflow.
+
+Self-contained, stdlib only, cross-platform. Run:
+  python3 tests/verify_dod_coverage.py
+Exits non-zero if coverage drops or a done-signal is fabricated.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "templates" / "itd" / "VERIFICATION_CONTRACT.json"
+SKILLS = ROOT / "skills"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def main() -> int:
+    if not CONTRACT.is_file():
+        check("VERIFICATION_CONTRACT.json exists", False, str(CONTRACT))
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+    try:
+        contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    except Exception as e:
+        check("VERIFICATION_CONTRACT.json parses", False, str(e))
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+
+    schema = contract.get("skillDoneSignalSchema", {})
+    allowed = schema.get("allowedDoneSignalTypes", [])
+    required = schema.get("requiredCoverageSkills", [])
+    dod = contract.get("skillDefinitionOfDone", {})
+
+    check("schema block present (allowedDoneSignalTypes + requiredCoverageSkills)",
+          bool(allowed) and bool(required),
+          "skillDoneSignalSchema is missing or empty")
+    check("skillDefinitionOfDone registry present",
+          isinstance(dod, dict) and bool(dod), "registry missing/empty")
+    if not (allowed and required and isinstance(dod, dict) and dod):
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+
+    allowed_set = set(allowed)
+
+    # 2 + 3: coverage of the required set, each entry machine-readable
+    covered = 0
+    for skill in required:
+        entry = dod.get(skill)
+        ok = (isinstance(entry, dict)
+              and entry.get("roleClass") in {"verify", "impl"}
+              and isinstance(entry.get("doneSignals"), list)
+              and len(entry["doneSignals"]) >= 1
+              and all(isinstance(s, dict) and s.get("type") in allowed_set
+                      for s in entry["doneSignals"]))
+        check("DoD entry for required skill '%s' (machine-readable)" % skill, ok,
+              "missing / wrong roleClass / no structured done-signal")
+        if ok:
+            covered += 1
+
+    coverage = covered / len(required) if required else 0.0
+    check("coverage of required verify/impl skills == 100%%",
+          covered == len(required),
+          "coverage %.0f%% (%d/%d)" % (coverage * 100, covered, len(required)))
+
+    # 4: anti-fabrication — every sentinel done-signal is grounded in its skill
+    for skill, entry in dod.items():
+        if not isinstance(entry, dict):
+            continue
+        for sig in entry.get("doneSignals", []):
+            if not (isinstance(sig, dict) and sig.get("type") == "sentinel"):
+                continue
+            ref = sig.get("ref", "")
+            skill_md = SKILLS / skill / "SKILL.md"
+            # Anti-fabrication: the ref must appear on a line that actually
+            # WRITES the sentinel (a redirection / tee), not merely mention it
+            # in prose — otherwise a done-signal could be gamed by naming a
+            # sentinel the skill never emits (review G-004 #2).
+            grounded = False
+            if skill_md.is_file():
+                for ln in skill_md.read_text(encoding="utf-8").splitlines():
+                    if ref in ln and (">" in ln or "tee " in ln):
+                        grounded = True
+                        break
+            check("sentinel done-signal '%s' written (not just mentioned) in "
+                  "skills/%s/SKILL.md" % (ref, skill), grounded,
+                  "the skill must actually write this sentinel, not name it in prose")
+
+    # 5: CI wiring
+    wired = False
+    if WORKFLOWS.is_dir():
+        for yml in WORKFLOWS.glob("*.yml"):
+            if "verify_dod_coverage.py" in yml.read_text(encoding="utf-8"):
+                wired = True
+                break
+    check("gate is wired into a CI workflow", wired,
+          "add 'python3 tests/verify_dod_coverage.py' to a workflow")
+
+    print("\ncoverage: %d/%d required verify/impl skills have machine-readable DoD"
+          % (covered, len(required)))
+    print("%d passed, %d failed" % (PASSED, FAILED))
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/verify_model_risk_monotonic.py
+++ b/tests/verify_model_risk_monotonic.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Invariant test: risk-tier ⇒ model monotonicity for the verify agents (v1.60.0
+— Ось 2, agentic engineering, unit G-003).
+
+The higher-risk a verify agent's surface, the higher (never lower) its model
+tier must be. The named invariant: the `security-reviewer` (gates exploitability
+/ production safety — the highest-stakes verify class) must never sit on a model
+tier BELOW the `code-reviewer`. Today security=opus, code=sonnet — monotone; the
+value inversion the unit guards against does not currently exist, so this gate's
+job is to make regression IMPOSSIBLE (a future cost-cut that quietly drops
+security-reviewer to sonnet while code-reviewer is opus fails CI here) AND to pin
+the DOCS (MODEL-ROUTING-POLICY.md, AGENT_EFFORT_TIERS.md) to the actual
+frontmatter, so the contract can no longer invert from the model.
+
+Asserts:
+  1. rank(security-reviewer.model) >= rank(code-reviewer.model)  [named invariant]
+  2. security-reviewer.model == opus  [highest-risk verify agent at the top tier]
+  3. AGENT_EFFORT_TIERS.md model cells for both agents match their frontmatter
+  4. MODEL-ROUTING-POLICY.md documents the monotonicity invariant + names the gate
+  5. the gate is wired into a CI workflow ("и в CI" clause)
+
+Self-contained, stdlib only, cross-platform. Run:
+  python3 tests/verify_model_risk_monotonic.py
+Exits non-zero if the invariant or any doc-consistency check fails.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AGENTS = ROOT / "agents"
+POLICY = ROOT / "docs" / "MODEL-ROUTING-POLICY.md"
+TIERS = ROOT / "docs" / "AGENT_EFFORT_TIERS.md"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+RANK = {"haiku": 1, "sonnet": 2, "opus": 3}
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def normalize_tier(token: str) -> str:
+    """Map a `model:` value to its tier alias. Accepts a bare tier (`opus`) or a
+    pinned full id (`claude-opus-4-20250514`) — the family word inside the id is
+    the tier. Unknown families fall through unchanged, so they land outside RANK
+    and fail SAFE (a clear diagnostic), never a false-pass. This keeps the gate
+    policing the invariant, not the naming convention (review G-003 #1)."""
+    t = token.strip().lower()
+    if t in RANK:
+        return t
+    for family in RANK:  # opus / sonnet / haiku inside a claude-<family>-… id
+        if re.search(r"(?:^|[-_.])" + family + r"(?:[-_.]|$)", t):
+            return family
+    return t
+
+
+def frontmatter_model(agent: str) -> str | None:
+    """Read the `model:` value from an agent's YAML frontmatter (tier-normalized)."""
+    f = AGENTS / (agent + ".md")
+    if not f.is_file():
+        return None
+    for line in f.read_text(encoding="utf-8").splitlines():
+        m = re.match(r"\s*model:\s*([A-Za-z0-9._-]+)", line)
+        if m:
+            return normalize_tier(m.group(1))
+    return None
+
+
+def tiers_model(agent: str) -> str | None:
+    """Extract the model token from the AGENT_EFFORT_TIERS.md row for `agent`."""
+    if not TIERS.is_file():
+        return None
+    for line in TIERS.read_text(encoding="utf-8").splitlines():
+        if "`" + agent + "`" in line and "|" in line:
+            cells = [c.strip().lower() for c in line.split("|")]
+            for c in cells:
+                token = c.strip("* ")
+                if token in RANK:
+                    return token
+    return None
+
+
+def main() -> int:
+    sec = frontmatter_model("security-reviewer")
+    code = frontmatter_model("code-reviewer")
+
+    check("security-reviewer has a parseable model frontmatter",
+          sec in RANK, "got %r" % sec)
+    check("code-reviewer has a parseable model frontmatter",
+          code in RANK, "got %r" % code)
+    if sec not in RANK or code not in RANK:
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+
+    # 1. named invariant: security tier >= code tier
+    check("invariant: rank(security-reviewer) >= rank(code-reviewer)",
+          RANK[sec] >= RANK[code],
+          "security=%s(%d) < code=%s(%d) — INVERSION" %
+          (sec, RANK[sec], code, RANK[code]))
+
+    # 2. highest-risk verify agent at the top tier
+    check("security-reviewer sits at the top model tier (opus)",
+          sec == "opus", "security-reviewer model = %s, expected opus" % sec)
+
+    # 3. AGENT_EFFORT_TIERS.md rows agree with frontmatter (no doc drift)
+    t_sec = tiers_model("security-reviewer")
+    t_code = tiers_model("code-reviewer")
+    check("AGENT_EFFORT_TIERS.md security-reviewer model matches frontmatter",
+          t_sec == sec, "table=%r frontmatter=%r" % (t_sec, sec))
+    check("AGENT_EFFORT_TIERS.md code-reviewer model matches frontmatter",
+          t_code == code, "table=%r frontmatter=%r" % (t_code, code))
+
+    # 4. MODEL-ROUTING-POLICY.md documents the invariant + names the gate
+    pol = POLICY.read_text(encoding="utf-8") if POLICY.is_file() else ""
+    pol_low = pol.lower()
+    check("MODEL-ROUTING-POLICY.md documents risk-tier => model monotonicity",
+          "monoton" in pol_low
+          and "security-reviewer" in pol_low and "code-reviewer" in pol_low,
+          "policy must state the monotonicity invariant over the two agents")
+    check("MODEL-ROUTING-POLICY.md names this gate as the enforcer",
+          "verify_model_risk_monotonic.py" in pol,
+          "policy should point at the CI gate that enforces the invariant")
+
+    # 5. CI wiring
+    wired = False
+    if WORKFLOWS.is_dir():
+        for yml in WORKFLOWS.glob("*.yml"):
+            if "verify_model_risk_monotonic.py" in yml.read_text(encoding="utf-8"):
+                wired = True
+                break
+    check("gate is wired into a CI workflow", wired,
+          "add 'python3 tests/verify_model_risk_monotonic.py' to a workflow")
+
+    print("\n%d passed, %d failed" % (PASSED, FAILED))
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/verify_refute_fleet.py
+++ b/tests/verify_refute_fleet.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Doc-contract test for the refute pass across the whole verify fleet (v1.60.0
+— Ось 2, agentic engineering, unit G-002).
+
+/review Step 2.6 already adversarially refutes each surfaced finding before it
+gates. v1.60.0 extends the SAME discipline to the rest of the verify fleet so a
+plausible-but-wrong finding never survives to any gate:
+
+  * /security-audit Step 2.5 — refute EXPLOITABILITY of each Critical/Important
+    vuln (fresh-context; security tie-break: vague doubt is not a refutation);
+  * /perf Step 2.5 — refute each HIGH/MEDIUM bottleneck (must be measured on the
+    hot path; default-refuted under uncertainty);
+  * /test Step 5.5 — mutation-check each behavior-asserting test (green under a
+    mutation = vacuous coverage, refuted; default-refuted under uncertainty).
+
+Shared invariants asserted per section (section-SCOPED so a coincidental match
+elsewhere in the file cannot false-pass — same hardening as
+verify_review_autoping.py): the section exists; it is an adversarial refute pass;
+fresh/independent context; minor/low findings are NOT refuted (cost); the pass
+can only REMOVE findings, never invent one; it references the /review Step 2.6
+pattern. Uncertainty handling is checked per domain (perf/test: default-refuted;
+security: the documented vague-doubt-drops-nothing tie-break). Plus the gate is
+wired into CI ("и в CI" clause of the unit).
+
+Self-contained, stdlib only, cross-platform. Run:
+  python3 tests/verify_refute_fleet.py
+Exits non-zero if any property is missing.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SEC = ROOT / "skills" / "security-audit" / "SKILL.md"
+PERF = ROOT / "skills" / "perf" / "SKILL.md"
+TEST = ROOT / "skills" / "test" / "SKILL.md"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def norm(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+def has_all(hay: str, *needles: str) -> bool:
+    low = hay.lower()
+    return all(n.lower() in low for n in needles)
+
+
+def has_any(hay: str, *needles: str) -> bool:
+    low = hay.lower()
+    return any(n.lower() in low for n in needles)
+
+
+def slice_section(raw: str, start_pat: str, end_pat: str) -> str | None:
+    m = re.search(start_pat, raw)
+    if not m:
+        return None
+    rest = raw[m.start():]
+    e = re.search(end_pat, rest[1:])
+    return rest if not e else rest[: e.start() + 1]
+
+
+def shared_invariants(label: str, sec: str) -> None:
+    """The invariants every fleet refute pass must carry."""
+    check(label + ": adversarial refute framing",
+          has_all(sec, "refute") and has_any(sec, "adversari", "REFUTE"),
+          "no adversarial-refute language")
+    check(label + ": fresh / independent context",
+          has_all(sec, "fresh")
+          and has_any(sec, "Agent(", "subagent", "separate", "independent"),
+          "refuter must not inherit the finder's reasoning")
+    check(label + ": minor/low findings are NOT refuted (cost)",
+          has_all(sec, "not justified")
+          and has_any(sec, "not refuted", "not mutation-checked",
+                      "never gate", "not mutation"),
+          "must exempt minor/low findings from the refute cost")
+    check(label + ": pass can only REMOVE, never invent a finding",
+          has_all(sec, "only remove")
+          and has_any(sec, "never invent", "never fabricat", "never manufactur"),
+          "refute must not fabricate new findings or verdicts")
+    check(label + ": references the /review Step 2.6 pattern",
+          has_all(sec, "Step 2.6"),
+          "should tie back to the canonical refute pass")
+
+
+def main() -> int:
+    for p in (SEC, PERF, TEST):
+        if not p.is_file():
+            check("skill file exists: " + p.name, False, str(p))
+            print("\n%d passed, %d failed" % (PASSED, FAILED))
+            return 1
+
+    sec = slice_section(SEC.read_text(encoding="utf-8"),
+                        r"###\s+Step\s+2\.5", r"###\s+Step\s+3\b")
+    perf = slice_section(PERF.read_text(encoding="utf-8"),
+                         r"###\s+Step\s+2\.5", r"###\s+Step\s+3\b")
+    test = slice_section(TEST.read_text(encoding="utf-8"),
+                         r"###\s+Step\s+5\.5", r"###\s+Step\s+6\b")
+
+    if sec is None:
+        check("security-audit: Step 2.5 refute section present", False,
+              "no '### Step 2.5' heading")
+    if perf is None:
+        check("perf: Step 2.5 refute section present", False,
+              "no '### Step 2.5' heading")
+    if test is None:
+        check("test: Step 5.5 refute section present", False,
+              "no '### Step 5.5' heading")
+    if None in (sec, perf, test):
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+
+    sec_n, perf_n, test_n = norm(sec), norm(perf), norm(test)
+
+    # --- shared invariants across the whole fleet ---------------------------
+    shared_invariants("security-audit", sec_n)
+    shared_invariants("perf", perf_n)
+    shared_invariants("test", test_n)
+
+    # --- domain-specific uncertainty handling -------------------------------
+    check("security-audit: security tie-break (vague doubt is not a refutation)",
+          has_any(sec_n, "vague doubt", "not a refutation",
+                  "false-negative"),
+          "security must NOT drop an unrefuted finding on vague doubt")
+    check("perf: default-refuted under uncertainty + measured-on-hot-path teeth",
+          has_all(perf_n, "default") and has_all(perf_n, "refuted")
+          and has_all(perf_n, "uncertainty") and has_all(perf_n, "hot path"),
+          "perf refutation must lean on measurement / hot-path")
+    check("test: mutation-based refutation, default-refuted under uncertainty",
+          has_all(test_n, "mutation")
+          and has_all(test_n, "default") and has_all(test_n, "refuted")
+          and has_all(test_n, "uncertainty"),
+          "test refutation must be mutation-based")
+
+    # --- CI wiring ----------------------------------------------------------
+    wired = False
+    if WORKFLOWS.is_dir():
+        for yml in WORKFLOWS.glob("*.yml"):
+            if "verify_refute_fleet.py" in yml.read_text(encoding="utf-8"):
+                wired = True
+                break
+    check("gate is wired into a CI workflow", wired,
+          "add 'python3 tests/verify_refute_fleet.py' to a workflow")
+
+    print("\n%d passed, %d failed" % (PASSED, FAILED))
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/verify_review_autoping.py
+++ b/tests/verify_review_autoping.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Doc-contract test for the caller-side auto-ping-for-verdict step (v1.60.0 —
+Ось 2, agentic engineering, unit G-001).
+
+The #1 agentic drag was a subagent ending its FINAL message on process
+narration instead of a verdict, recovered only by the human pinging «выдай итог
+одним сообщением» by hand (observed x4 in one session). v1.60.0 makes the
+recovery mechanical AND caller-side: the /review conductor (and /cross-review)
+must, on a subagent/reviewer return that carries NO verdict marker, auto-re-ping
+ONCE without asking the user — detecting by the ABSENCE of the required marker,
+NOT by regex-guessing whether the prose "looks like" a narration opener (which
+is strictly the subagent-side hooks' job, and less reliable than checking for
+the marker's presence).
+
+This gate asserts the DOCUMENTED contract survives edits (the belt), independent
+of the two SubagentStop hooks that enforce the same defect at the subagent
+boundary (the suspenders). It checks invariant PROPERTIES via stable keywords,
+not verbatim sentences, so rewording does not break it while a semantic removal
+does. It also asserts the gate is wired into CI ("и в CI" clause of the unit).
+
+Self-contained, stdlib only, cross-platform. Run:
+  python3 tests/verify_review_autoping.py
+Exits non-zero if any property is missing.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REVIEW = ROOT / "skills" / "review" / "SKILL.md"
+CROSS = ROOT / "skills" / "cross-review" / "SKILL.md"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def norm(text: str) -> str:
+    """Collapse whitespace so line-wrapping never breaks a substring match."""
+    return re.sub(r"\s+", " ", text)
+
+
+def has_all(hay: str, *needles: str) -> bool:
+    low = hay.lower()
+    return all(n.lower() in low for n in needles)
+
+
+def slice_section(raw: str, start_pat: str, end_pat: str) -> str | None:
+    """Return the raw text from the start heading up to the next section
+    boundary — so keyword checks are scoped to the RELEVANT section, not the
+    whole 700+-line file (a coincidental match elsewhere must not false-pass
+    the gate; review finding v1.60.0-G-001 #2). None if the section is absent
+    (which is itself a failure — the documented step must exist as a heading)."""
+    m = re.search(start_pat, raw)
+    if not m:
+        return None
+    rest = raw[m.start():]
+    e = re.search(end_pat, rest[1:])  # skip char 0 so start≠end on same anchor
+    return rest if not e else rest[: e.start() + 1]
+
+
+def main() -> int:
+    if not REVIEW.is_file():
+        check("skills/review/SKILL.md exists", False, str(REVIEW))
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+    if not CROSS.is_file():
+        check("skills/cross-review/SKILL.md exists", False, str(CROSS))
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+
+    review_raw = REVIEW.read_text(encoding="utf-8")
+    cross_raw = CROSS.read_text(encoding="utf-8")
+
+    # Scope keyword checks to the RELEVANT section, not the whole file — a
+    # coincidental match elsewhere must not false-pass the gate (review #2).
+    rv_sec = slice_section(review_raw, r"###\s+Step\s+2\.7", r"###\s+Step\s+3\b")
+    cx_sec = slice_section(cross_raw, r"\n3a\.", r"\n4\.\s+\*\*Fold\s+findings")
+    if rv_sec is None:
+        check("review: Step 2.7 section present as a heading", False,
+              "no '### Step 2.7' heading found")
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+    if cx_sec is None:
+        check("cross-review: step 3a section present", False,
+              "no '3a.' step found between step 3 and step 4")
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+    rv = norm(rv_sec)
+    cx = norm(cx_sec)
+
+    # --- /review: caller-side auto-ping step exists and is correctly framed ---
+    check("review: dedicated caller-side auto-ping step present",
+          has_all(rv, "Step 2.7") and has_all(rv, "caller-side")
+          and (has_all(rv, "auto-re-ping") or has_all(rv, "re-ping")),
+          "no Step 2.7 / caller-side / re-ping keywords")
+
+    check("review: detection is by ABSENCE of the verdict marker",
+          has_all(rv, "absence") and has_all(rv, "marker"),
+          "does not frame detection as 'absence of marker'")
+
+    check("review: explicitly rejects regex-guessing the prose (load-bearing)",
+          (has_all(rv, "not", "pattern-matching")
+           or has_all(rv, "regex-guessing"))
+          and has_all(rv, "narration"),
+          "must say detection is NOT regex/pattern-matching the narration")
+
+    check("review: recovery proceeds without asking the user",
+          has_all(rv, "without asking the user"),
+          "auto-ping must be automatic, not «Хочешь, переспрошу?»")
+
+    check("review: re-ping is bounded (ping cap)",
+          has_all(rv, "ITD_AUTOPING_MAX")
+          or (has_all(rv, "bounded") and has_all(rv, "re-ping")),
+          "no cap on re-pings")
+
+    check("review: names both SubagentStop hooks as suspenders",
+          has_all(rv, "narration-final.sh")
+          and has_all(rv, "verdict-contract.sh"),
+          "both hooks must be named as the suspenders to this belt")
+
+    check("review: belt/suspenders degrade independently (best-effort)",
+          has_all(rv, "belt") and has_all(rv, "suspenders")
+          and (has_all(rv, "best-effort") or has_all(rv, "degrade")),
+          "must state the two layers degrade independently")
+
+    # --- /cross-review: symmetric verdict-completeness instruction ------------
+    check("cross-review: symmetric auto-re-ping on verdict-less return",
+          (has_all(cx, "auto-re-ping") or has_all(cx, "re-ping"))
+          and has_all(cx, "caller-side"),
+          "cross-review must carry the same caller-side auto-re-ping")
+
+    check("cross-review: detect by ABSENCE, not prose pattern-matching",
+          has_all(cx, "absence")
+          and (has_all(cx, "not", "pattern-matching")
+               or has_all(cx, "marker")),
+          "cross-review must detect by absence of the conclusion marker")
+
+    check("cross-review: references /review Step 2.7",
+          has_all(cx, "Step 2.7"),
+          "should point at the /review caller-side step")
+
+    check("cross-review: stays fail-open, never treats empty as clean",
+          has_all(cx, "fail-open")
+          and (has_all(cx, "never silently treat")
+               or has_all(cx, "empty return as clean")
+               or has_all(cx, "empty as clean")),
+          "must not silently treat an empty return as clean")
+
+    # --- CI wiring: the gate itself is run in CI ("и в CI" clause) -----------
+    wired = False
+    if WORKFLOWS.is_dir():
+        for yml in WORKFLOWS.glob("*.yml"):
+            if "verify_review_autoping.py" in yml.read_text(encoding="utf-8"):
+                wired = True
+                break
+    check("gate is wired into a CI workflow",
+          wired,
+          "add 'python3 tests/verify_review_autoping.py' to a workflow")
+
+    print("\n%d passed, %d failed" % (PASSED, FAILED))
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/verify_stall_fallback.py
+++ b/tests/verify_stall_fallback.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Doc-contract test for the mechanical stall-resilience fallback (v1.60.0 —
+Ось 2, agentic engineering, unit G-005).
+
+A stalled subagent (watchdog timeout / autocompact death / empty return) used to
+force a manual «resume or retry?» decision — itself a stall in the loop. v1.60.0
+makes the recovery mechanical and AUTOMATIC: on a detected stall, spawn a fresh
+narrow agent (thin context, smallest useful slice) — the default procedure, not
+an option to weigh. Documented in skills/_shared/helpers.md §9 and referenced
+from /review (the fork-thrash fallback is one instance) and /task.
+
+Asserts (section-SCOPED, so a coincidental match elsewhere cannot false-pass):
+  1. helpers.md §9 exists as a section;
+  2. stall is detected by MECHANICAL signals (watchdog/no-progress/autocompact/
+     empty), not judgement;
+  3. the response is a FRESH agent, explicitly NOT a resume;
+  4. the scope is NARROWED (smallest slice);
+  5. it is AUTOMATIC — explicitly NOT a manual «resume or retry?» choice;
+  6. bounded + escalate (a persistent stall becomes a visible blocker);
+  7. /review references the shared stall fallback (helpers §9);
+  8. /task references the shared stall fallback (helpers §9);
+  9. the gate is wired into a CI workflow.
+
+Self-contained, stdlib only, cross-platform. Run:
+  python3 tests/verify_stall_fallback.py
+Exits non-zero if a property is missing.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPERS = ROOT / "skills" / "_shared" / "helpers.md"
+REVIEW = ROOT / "skills" / "review" / "SKILL.md"
+TASK = ROOT / "skills" / "task" / "SKILL.md"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+PASSED, FAILED = 0, 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASSED, FAILED
+    if cond:
+        PASSED += 1
+        print("PASS  " + name)
+    else:
+        FAILED += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+def norm(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+def has_all(hay: str, *needles: str) -> bool:
+    low = hay.lower()
+    return all(n.lower() in low for n in needles)
+
+
+def has_any(hay: str, *needles: str) -> bool:
+    low = hay.lower()
+    return any(n.lower() in low for n in needles)
+
+
+def slice_section(raw: str, start_pat: str, end_pat: str) -> str | None:
+    m = re.search(start_pat, raw)
+    if not m:
+        return None
+    rest = raw[m.start():]
+    e = re.search(end_pat, rest[1:])
+    return rest if not e else rest[: e.start() + 1]
+
+
+def main() -> int:
+    for p in (HELPERS, REVIEW, TASK):
+        if not p.is_file():
+            check("file exists: " + p.name, False, str(p))
+            print("\n%d passed, %d failed" % (PASSED, FAILED))
+            return 1
+
+    # §9 is the last section; end anchor is a non-existent "## 10." → to EOF.
+    sec = slice_section(HELPERS.read_text(encoding="utf-8"),
+                        r"##\s+9\.\s+Stall-resilience", r"\n##\s+10\.")
+    if sec is None:
+        check("helpers.md §9 Stall-resilience section present", False,
+              "no '## 9. Stall-resilience' heading")
+        print("\n%d passed, %d failed" % (PASSED, FAILED))
+        return 1
+    s = norm(sec)
+
+    check("§9: mechanical stall detection (not judgement)",
+          has_any(s, "watchdog", "no-progress", "no progress")
+          and has_any(s, "autocompact", "empty return", "truncated")
+          and has_any(s, "mechanical", "signal"),
+          "must detect a stall by mechanical signals")
+    check("§9: response is a FRESH agent, explicitly not a resume",
+          has_all(s, "fresh") and has_any(s, "not resume", "do not resume",
+                                          "never resume", "not a resume"),
+          "must spawn fresh, never resume the stalled transcript")
+    check("§9: scope is narrowed to the smallest useful slice",
+          has_any(s, "narrow", "smallest", "slice", "reduce"),
+          "fresh agent must run on a narrowed scope")
+    check("§9: AUTOMATIC — explicitly NOT a manual resume/retry choice",
+          has_all(s, "automatic")
+          and has_any(s, "not a manual", "do not ask", "not an option",
+                      "not deliberate", "do not deliberate", "not a per-skill"),
+          "the fallback must be automatic, not a manual decision")
+    check("§9: bounded, then escalate to a visible blocker",
+          has_any(s, "ITD_STALL_MAX_RESPAWNS", "bounded")
+          and has_any(s, "escalate", "blocker"),
+          "must bound respawns and escalate a persistent stall")
+
+    # cross-references from /review and /task
+    rv = norm(REVIEW.read_text(encoding="utf-8"))
+    tk = norm(TASK.read_text(encoding="utf-8"))
+    check("/review references the shared stall fallback (helpers §9)",
+          has_any(rv, "helpers.md §9", "helpers §9", "§9")
+          and has_all(rv, "stall"),
+          "review must point at the shared stall-resilience rule")
+    check("/task references the shared stall fallback (helpers §9)",
+          has_any(tk, "helpers.md §9", "helpers §9", "§9")
+          and has_all(tk, "stall"),
+          "task must point at the shared stall-resilience rule")
+
+    # CI wiring
+    wired = False
+    if WORKFLOWS.is_dir():
+        for yml in WORKFLOWS.glob("*.yml"):
+            if "verify_stall_fallback.py" in yml.read_text(encoding="utf-8"):
+                wired = True
+                break
+    check("gate is wired into a CI workflow", wired,
+          "add 'python3 tests/verify_stall_fallback.py' to a workflow")
+
+    print("\n%d passed, %d failed" % (PASSED, FAILED))
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## v1.60.0 — Axis 2: Agentic engineering

Raises the agentic-engineering axis from a self-graded ~7.5 toward ~9. Six ordered units, driven one at a time (WIP=1) through the standard `/task` -> `/test` -> `/review` pipeline via `/goal`. Every substantive unit ships a section-scoped, mutation-tested CI gate wired into `meta-review.yml`. Counts stay 40/10/24 throughout.

### Units

- **G-001 — caller-side auto-ping-for-verdict in `/review`.** The #1 agentic drag was a subagent ending on process narration instead of a verdict, recovered only by a human ping. New Step 2.7: the conductor detects a verdict-less return by the absence of the verdict marker (not by regex-guessing the prose) and auto-re-pings once, without asking the user, bounded by `ITD_AUTOPING_MAX`. `/cross-review` gets the symmetric step 3a. The two SubagentStop hooks are the suspenders to this caller-side belt; the layers degrade independently. Gate: `verify_review_autoping.py`.
- **G-002 — refute pass across the whole verify fleet.** The `/review` adversarial refute is extended to `/security-audit` (exploitability), `/perf` (measured on the hot path), and `/test` (mutation-check each behavior-asserting test). Shared invariant: the refute pass only removes findings, never invents one. Gate: `verify_refute_fleet.py`.
- **G-003 — risk-tier to model monotonicity invariant.** A machine-checked invariant: the `security-reviewer`'s model tier is never below the `code-reviewer`'s. `MODEL-ROUTING-POLICY.md` reconciled with the actual frontmatter (interactive `/review` conductor = opus vs thin `code-reviewer` subagent = sonnet+high). Gate: `verify_model_risk_monotonic.py`.
- **G-004 — machine-readable skill Definition-of-Done.** `VERIFICATION_CONTRACT.json` gains a `skillDefinitionOfDone` registry: each verify/impl skill's DoD is a structured done-signal, not only prose. Anti-fabrication: every sentinel done-signal must actually be written by its skill. Gate: `verify_dod_coverage.py`.
- **G-005 — mechanical stall-resilience fresh-narrow fallback.** `helpers.md` §9: on any subagent stall, the recovery is a fresh narrow agent spawned automatically — the default procedure, not a manual "resume or retry?" decision. Bounded, then escalates a visible blocker. Gate: `verify_stall_fallback.py`.
- **G-006 — release v1.60.0.** Version bumped across all carriers, CHANGELOG entry, full CI-equivalent suite green (both `meta-review.yml` and `windows-verify.yml`).

### Verification

All six units are evidence-gated (`itd_goal_verify.py`, exit-0 required). Full local CI-equivalent green: `meta-review.yml` (11 steps incl. the 5 new gates) + `windows-verify.yml` (12 steps); `verify_registration_and_counts` 9/9, `verify_snapshot --all` 24/24 contracts. Each gate is mutation-tested (removing the guarded property flips it to rc=1) and section-scoped so a coincidental match elsewhere cannot false-pass.

Live dogfood: during G-005's own review, the `code-reviewer` subagent ended on narration without a verdict — Step 2.7's caller-side auto-re-ping recovered the verdict in one message, zero manual pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
