### PR TITLE
fix(sync): sync hooks/*.py libraries, not only *.sh (completion_lib.py)

### DIFF
--- a/scripts/sync-to-active.sh
+++ b/scripts/sync-to-active.sh
@@ -140,7 +140,10 @@ h_added=0
 h_updated=0
 h_unchanged=0
 
-for src_hook in "$REPO_ROOT"/hooks/*.sh; do
+# Sync executable hooks (*.sh) AND their Python libraries (*.py, e.g.
+# completion_lib.py imported by the completion-* hooks) — a lib left unsynced
+# makes its hooks silently no-op on a fresh machine (import fails, fail-safe).
+for src_hook in "$REPO_ROOT"/hooks/*.sh "$REPO_ROOT"/hooks/*.py; do
   [ -e "$src_hook" ] || continue
   name="$(basename "$src_hook")"
   dst="$ACTIVE/hooks/$name"


### PR DESCRIPTION
## Follow-up to #124 — surfaced during rollout

`scripts/sync-to-active.sh` Step 2 globbed only `hooks/*.sh`, so **`completion_lib.py`** — the library imported by the `completion-*` hooks — never reached the active `~/.claude/hooks`. On a fresh machine the 3 hooks are registered but their `import completion_lib` fails and they **silently no-op** (fail-safe), disabling the whole Completion Gate.

Caught deploying #124 to a WSL target: hooks present, `completion_lib.py` missing (Windows worked only because the file was written there manually first).

### Fix
Extend the Step 2 copy glob to `hooks/*.sh hooks/*.py`.

- Hook **count is unchanged** — drift-guards count `*.sh` = 27; `completion_lib.py` is a library, not a gate. Only the file-copy set grows to 28.
- Verified on a fresh `CLAUDE_HOME` dry-run: `completion_lib.py` now in the would-add set (`+28 added`).
- `verify_registration_and_counts` and `verify_gate_taxonomy` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)