### PR TITLE
perf(completion-gate): bound the signal ledger (append-only -> amortized-pruned)

### DIFF
--- a/hooks/completion_lib.py
+++ b/hooks/completion_lib.py
@@ -39,6 +39,9 @@ DIR_NAME = "completion"
 SIGNALS_FILE = "signals.jsonl"
 VERDICT_FILE = "completion.json"
 SESSION_WINDOW_SEC = 6 * 3600  # если session_id недоступен — окно свежести сигналов
+MAX_LEDGER_LINES = 2000          # верхняя граница строк леджера сигналов
+LEDGER_SOFT_BYTES = 512 * 1024    # прунинг срабатывает только когда файл перерос этот размер
+                                  # (амортизированный O(1) на append: полный rewrite раз в ~MAX строк)
 
 
 def now_iso() -> str:
@@ -261,8 +264,20 @@ def classify_bash(command: str, tool_response, cwd: Path | None = None) -> dict 
 def append_signal(cwd: Path, session_id: str, sig: dict) -> None:
     sig = dict(sig)
     sig["session"] = str(session_id or "unknown")
-    with signals_path(cwd).open("a", encoding="utf-8") as f:
+    p = signals_path(cwd)
+    with p.open("a", encoding="utf-8") as f:
         f.write(json.dumps(sig, ensure_ascii=False) + "\n")
+    # Amortized bound: keep the ledger from growing without limit. The size gate
+    # keeps this O(1) per append — a full read+rewrite fires only once the file
+    # crosses the soft cap (~every MAX_LEDGER_LINES appends), so read_signals /
+    # the gate never parse an unbounded file. Best-effort: any error is swallowed.
+    try:
+        if p.stat().st_size > LEDGER_SOFT_BYTES:
+            lines = p.read_text(encoding="utf-8", errors="replace").splitlines()
+            if len(lines) > MAX_LEDGER_LINES:
+                p.write_text("\n".join(lines[-MAX_LEDGER_LINES:]) + "\n", encoding="utf-8")
+    except Exception:
+        pass
 
 
 def read_signals(cwd: Path, session_id: str | None) -> list:

--- a/tests/verify_completion_ledger.py
+++ b/tests/verify_completion_ledger.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Regression test: the completion signal ledger is bounded (not append-only-forever).
+
+Appends far more signals than the cap and asserts the file stays bounded while the
+most-recent signals are retained and still readable. Self-contained, stdlib only.
+Run: python3 tests/verify_completion_ledger.py
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hooks"))
+import completion_lib as cl  # noqa: E402
+
+PASS = FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print("PASS  " + name)
+    else:
+        FAIL += 1
+        print("FAIL  " + name + (("  — " + detail) if detail else ""))
+
+
+# small caps so the prune fires quickly and deterministically
+cl.LEDGER_SOFT_BYTES = 2000
+cl.MAX_LEDGER_LINES = 40
+
+with tempfile.TemporaryDirectory() as tmp:
+    d = Path(tmp)
+    N = 400
+    for i in range(N):
+        cl.append_signal(d, "sess", {"i": i, "kind": "test_run", "layer": 2, "outcome": "pass"})
+
+    lines = cl.signals_path(d).read_text(encoding="utf-8").splitlines()
+    # bounded: never the full N; stays near the cap (allow headroom until the size gate trips)
+    check("ledger is bounded (not append-only)", len(lines) < N // 2,
+          "have %d lines for %d appends" % (len(lines), N))
+    check("ledger near the cap", len(lines) <= cl.MAX_LEDGER_LINES * 2,
+          "have %d lines, cap %d" % (len(lines), cl.MAX_LEDGER_LINES))
+
+    # recency retained: the last appended signal survives pruning
+    import json
+    last = json.loads(lines[-1])
+    check("most-recent signal retained after prune", last.get("i") == N - 1,
+          "last i=%r" % last.get("i"))
+
+    # still readable by the normal path
+    sigs = cl.read_signals(d, "sess")
+    check("read_signals returns the bounded set", 0 < len(sigs) <= len(lines))
+
+print("\n%d passed, %d failed" % (PASS, FAIL))
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## Follow-up to #124/#125 — bound the completion signal ledger

`completion-signals` appended to `.claude/completion/signals.jsonl` on every relevant Bash call and **never pruned**. So the ledger grew without limit, and `read_signals` — called by the gate on **every commit** and by `completion-stop` on every dirty-tree Stop — parsed the **whole file** each time. Impact: O(file) read per commit + unbounded disk in long-lived projects.

### Fix
`append_signal` now prunes to the last `MAX_LEDGER_LINES` (2000) once the file crosses a soft byte cap (512 KB). The size gate keeps this **amortized O(1) per append** — a full read+rewrite fires only ~once per `MAX_LEDGER_LINES` appends — so reads never parse an unbounded file. Best-effort: any prune error is swallowed (never breaks a session).

### Test
`tests/verify_completion_ledger.py` (new) — appends 400 signals with small caps, asserts the ledger stays bounded (<< N) and the most-recent signal survives pruning and is still readable.

### Verification
- `verify_completion_ledger` 4/4 (new)
- No regression: `verify_completion_gate` 8/8, `verify_registration_and_counts` 9/9, `verify_gate_taxonomy` 9/9, `verify_hook_table_completeness` 7/7, `verify_harness_map_fixtures` 30/30
- `meta_review` PASSED (0 critical)
- Hook count unchanged (27); no docs/counts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)