### PR TITLE
fix(completion-gate): harden classifier + add drift detector & WIP=1 check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.63.0] - 2026-07-08
+
+**Completion Gate hardening + contract-drift detector + WIP=1 cross-check.**
+Follow-up to 1.62.0 closing three defects found by auditing the gate on a live
+project.
+
+### Fixed (completion_lib.py classifier)
+
+- `outcome_from` now reads an echoed exit code (`EXIT: 0` / `TSC_EXIT=0` /
+  `exit: 1`). Commands that pipe through `head`/`tail` mask `$?` and the host
+  tool-response often omits a structured exit code, so every signal landed as
+  `unknown` and L1 never turned `pass`.
+- VCS/submission commands (`git`/`gh`/`hg`/`svn`/`jj`) are excluded from signal
+  classification. A `git commit ... && git log` was classified as an L2
+  `test_run` - the act of submitting masqueraded as proof (violated the gate's
+  own "commit != test").
+- PASS text heuristic tightened to strong signals only (test/build summaries).
+  Weak phrases (`clean`, `no errors`, bare `PASS`, `ok N`) no longer yield a
+  false `pass` on arbitrary output - they degrade to `unknown` (safe). A false
+  `pass` is a dangerous false-green; a false `unknown` is a safe advisory.
+- Projects with declared `l2_evidence_patterns` (no unit tests) no longer
+  hard-block every commit on an incidental test-file scan match: the generic
+  scan is suppressed, hard block only for real unit tests, otherwise advisory.
+
+### Added
+
+- `scripts/validate_state.py`: WIP=1 cross-ledger check. `STATE.currentUnit`
+  (ad-hoc /task unit) and `GOAL.json` (long goal) may not be active at the same
+  time - removes the dual source of "current unit" (fail-closed).
+- `docs/templates/itd/check_contract_drift.py`: detector for silent drift of
+  derived `.itd/*` contract copies from CLAUDE.md. Compares a `snapshot @ <sha>`
+  marker against the last commit touching CLAUDE.md; `--strict` for a gate,
+  `--selftest` for the compare logic.
+
+---
+
 ## [1.62.0] - 2026-07-06
 
 **Completion Gate — a harness subsystem against premature "done".** Closes the

--- a/docs/templates/itd/check_contract_drift.py
+++ b/docs/templates/itd/check_contract_drift.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Детектор дрейфа производных .itd-контрактов от источника истины (CLAUDE.md).
+
+Проблема (упр. 3 аудита idea-to-deploy): файлы .itd/*.md — ПРОИЗВОДНЫЕ копии
+правил из проектного CLAUDE.md. CLAUDE.md уходит вперёд, копии молча устаревают
+и начинают вводить в заблуждение по деталям. Единственный источник истины —
+CLAUDE.md; эта проверка делает рассинхрон ВИДИМЫМ, а не тихим.
+
+Механика (вендор-нейтральная, stdlib-only):
+  - Каждый производный док несёт маркер «снапшот @ <sha>» (короткий git-sha
+    коммита CLAUDE.md, с которого он синхронизирован).
+  - Проверка берёт последний коммит, тронувший CLAUDE.md, и сравнивает.
+    marker == current  -> ok (в синхроне)
+    marker != current  -> DRIFT (CLAUDE.md изменился с момента снапшота)
+    нет маркера         -> UNMARKED (производная копия вне трекинга)
+
+Advisory по умолчанию (exit 0). `--strict` -> exit 1 при любом DRIFT (для гейта/
+хука). `--selftest` -> проверяет чистую логику сравнения без git. Никогда не
+роняет сессию: git недоступен / не git-репо -> печатает и exit 0.
+
+Usage:
+  python3 .itd/check_contract_drift.py [--strict] [--selftest]
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ITD_DIR = ROOT / ".itd"
+CLAUDE_MD = ROOT / "CLAUDE.md"
+MARKER_RE = re.compile(r"снапшот\s*@\s*([0-9a-f]{7,40})", re.I)
+
+
+def compare_sha(marker: str, current: str) -> str:
+    """ok | drift | unmarked — чистая, тестируемая логика сравнения."""
+    if not marker:
+        return "unmarked"
+    m, c = marker.lower(), current.lower()
+    if m == c or c.startswith(m) or m.startswith(c):
+        return "ok"
+    return "drift"
+
+
+def current_claude_sha() -> str | None:
+    """Короткий sha последнего коммита, тронувшего CLAUDE.md (или None)."""
+    try:
+        res = subprocess.run(
+            ["git", "log", "-1", "--format=%h", "--", "CLAUDE.md"],
+            cwd=str(ROOT), capture_output=True, text=True, timeout=6,
+        )
+        sha = res.stdout.strip()
+        return sha or None
+    except Exception:
+        return None
+
+
+def marker_in(path: Path) -> str:
+    try:
+        m = MARKER_RE.search(path.read_text(encoding="utf-8", errors="replace"))
+        return m.group(1) if m else ""
+    except Exception:
+        return ""
+
+
+def run_check(strict: bool) -> int:
+    if not CLAUDE_MD.is_file():
+        print("SKIP: CLAUDE.md не найден — нечего сверять."); return 0
+    current = current_claude_sha()
+    if current is None:
+        print("SKIP: git недоступен или не git-репо — дрейф не проверяется (advisory)."); return 0
+
+    print(f"CLAUDE.md @ {current} (последний коммит источника истины)")
+    drift, unmarked = [], []
+    for md in sorted(ITD_DIR.glob("*.md")):
+        status = compare_sha(marker_in(md), current)
+        tag = {"ok": "  ok  ", "drift": " DRIFT", "unmarked": " unmk "}[status]
+        print(f"{tag}  {md.name}  (маркер: {marker_in(md) or '—'})")
+        if status == "drift":
+            drift.append(md.name)
+        elif status == "unmarked":
+            unmarked.append(md.name)
+
+    print()
+    if drift:
+        print(f"ДРЕЙФ ({len(drift)}): {', '.join(drift)} — CLAUDE.md изменился с момента снапшота.")
+        print("FIX: пересверь эти доки с CLAUDE.md и обнови маркер «снапшот @ <sha>».")
+    if unmarked:
+        print(f"Без маркера ({len(unmarked)}): {', '.join(unmarked)} — вне трекинга дрейфа (опц. добавить маркер).")
+    if not drift and not unmarked:
+        print("Все производные .itd-доки в синхроне с CLAUDE.md.")
+    return 1 if (strict and drift) else 0
+
+
+def selftest() -> int:
+    cases = [
+        ("8d4fd43", "8d4fd43", "ok"),
+        ("8d4fd43", "8d4fd43abc9", "ok"),      # marker короче — префикс
+        ("8d4fd43abc9", "8d4fd43", "ok"),      # current короче — префикс
+        ("8d4fd43", "abc1234", "drift"),
+        ("", "8d4fd43", "unmarked"),
+    ]
+    ok = True
+    for marker, current, exp in cases:
+        got = compare_sha(marker, current)
+        p = got == exp
+        ok = ok and p
+        print(("  OK  " if p else " FAIL "), f"compare_sha({marker!r},{current!r}) -> {got!r}", "" if p else f"(exp {exp!r})")
+    print("SELFTEST:", "ALL PASS" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Детектор дрейфа .itd-контрактов от CLAUDE.md.")
+    ap.add_argument("--strict", action="store_true", help="exit 1 при DRIFT")
+    ap.add_argument("--selftest", action="store_true", help="проверить логику сравнения")
+    args = ap.parse_args()
+    sys.exit(selftest() if args.selftest else run_check(args.strict))
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/completion_lib.py
+++ b/hooks/completion_lib.py
@@ -112,6 +112,12 @@ SIDE_EFFECT_RE = re.compile(
     re.I,
 )
 
+# VCS / сдача-репорт — НЕ доказательство. Коммит / пуш / открытие PR — это акт
+# СДАЧИ, а не ПРОВЕРКИ; он никогда не должен выдаваться за прогон теста слоя 2.
+# Прямое исполнение принципа «commit ≠ test»: до этого `git commit … && git log`
+# ловился как test_run/L2 и «зеленил» слой поведения самим фактом коммита.
+VCS_LEAD_RE = re.compile(r"^\s*(git|gh|hg|svn|jj)\s", re.I)
+
 # Очистка временных ресурсов -> layer 0 (учёт «cleanup»).
 CLEANUP_RE = re.compile(
     r"(^|\s|;|&&|\|\|)(rm\s+-rf?\s+[^|]*\b(tmp|temp|\.cache|node_modules/\.cache|dist|build|coverage)\b|"
@@ -161,27 +167,46 @@ FAIL_TEXT_RE = re.compile(
     re.I,
 )
 
-# Явные признаки успеха.
+# Явные признаки успеха. ТОЛЬКО сильные сигналы (test-summary / build-summary /
+# TAP): ложный `pass` = опасная false-зелёнка (гейт зелёный на сломанном), тогда
+# как ложный `unknown` безопасно деградирует в advisory. Поэтому слабые фразы
+# («clean», «no errors», голое «ok») из pass-детекции УБРАНЫ — они встречаются в
+# произвольном выводе (HTTP 200-логи, прогресс сборки) и давали FP на L2/L3.
+# Реальный успех почти всегда несёт exit-код или эхо EXIT=0 (см. outcome_from),
+# которые авторитетнее текста; сюда доходит лишь текст-only фоллбэк.
 PASS_TEXT_RE = re.compile(
     r"("
     r"\ball\s+tests?\s+pass|"
     r"\b0\s+fail(ing|ed|ures?)?\b|"
     r"tests?:\s*.*?\b\d+\s+passed(?!.*\bfailed)|"
     r"=+\s*\d+\s+passed(?!.*failed)|"
-    r"\bPASS\b|\bok\b\s+\d+|"
-    r"compiled successfully|build succeeded|"
     r"\b\d+\s+passing\b|"
-    r"no\s+(lint\s+)?errors?|clean)",
+    r"compiled successfully|build succeeded|build passed)",
     re.I,
 )
 
 
+# Эхнутый exit-код команды. Раннеры часто маскируют реальный $? пайпом через
+# head/tail, а хостовый tool_response не всегда несёт структурный exit-код.
+# Проектная конвенция — дописывать echo "EXIT: $?" / TSC_EXIT=$? / "exit: N".
+# Матчит "EXIT: 0", "TSC_EXIT=0", "exit: 0" (последний в выводе — авторитетный).
+_EXIT_ECHO_RE = re.compile(r"\b(?:[A-Z][A-Z0-9_]*_)?EXIT\s*[:=]\s*(\d+)\b", re.I)
+
+
 def outcome_from(text: str, exit_code: int | None) -> str:
-    """pass | fail | unknown — из exit-кода (приоритет) и текста."""
+    """pass | fail | unknown — из exit-кода, эхнутого EXIT=N, затем текста."""
     if exit_code is not None:
         return "pass" if exit_code == 0 else "fail"
     if not text:
         return "unknown"
+    # Эхнутый код команды (последний в выводе) авторитетнее эвристики по тексту:
+    # без него «tsc … ; echo EXIT: 0» молча оставался unknown и слой L1 никогда
+    # не становился pass.
+    m = None
+    for mm in _EXIT_ECHO_RE.finditer(text):
+        m = mm
+    if m is not None:
+        return "pass" if m.group(1) == "0" else "fail"
     if FAIL_TEXT_RE.search(text):
         return "fail"
     if PASS_TEXT_RE.search(text):
@@ -226,6 +251,11 @@ def classify_bash(command: str, tool_response, cwd: Path | None = None) -> dict 
     доказательство поведения для проектов без юнит-тестов.
     """
     if not command:
+        return None
+    # VCS/сдача — не runtime-доказательство (см. VCS_LEAD_RE). Коммит и его
+    # многострочное тело часто случайно матчат L2-паттерны; сбрасываем до
+    # классификации, чтобы акт сдачи не считался проверкой.
+    if VCS_LEAD_RE.search(command):
         return None
     text, code = _extract_output(tool_response)
     outcome = outcome_from(text, code)
@@ -419,7 +449,13 @@ def compute_verdict(cwd: Path, signals: list) -> dict:
         "degraded": bool  # True => нет данных для суждения (best-effort деградация)
       }
     """
-    has_tests = repo_has_tests(cwd)
+    # Проект, объявивший l2_evidence_patterns (compare-registers/репост в
+    # config.json), ЗАЯВЛЯЕТ об отсутствии юнит-тестов — доказательство даёт
+    # ручная сверка. Инцидентный матч generic-скана (случайный .spec./test-путь)
+    # для него ложный, поэтому источник истины — декларация: real_tests подавляем.
+    declared_l2 = bool(_project_l2_patterns(cwd))
+    real_tests = False if declared_l2 else repo_has_tests(cwd)
+    has_tests = real_tests or declared_l2
     l1s, l1e = _layer_status(signals, 1)
     l2s, l2e = _layer_status(signals, 2)
     l3s, l3e = _layer_status(signals, 3)
@@ -460,13 +496,25 @@ def compute_verdict(cwd: Path, signals: list) -> dict:
         return verdict
 
     if has_tests and l2s == "unknown":
-        # тесты в репо есть, но в этой сессии их не прогнали (или результат неясен)
-        # — классический признак преждевременной сдачи.
-        verdict["blocked"] = True
-        verdict["reason"] = red_mark(
-            "Слой 2 (тесты) не подтверждён",
-            "в репозитории есть тесты, но в этой сессии не зафиксирован их успешный прогон",
-            "прогони тесты (npm test / pytest / go test …) — «код написан» ≠ «работает»",
+        if real_tests:
+            # реальные юнит-тесты в репо есть, но в этой сессии не прогнаны —
+            # классический признак преждевременной сдачи → жёсткий блок.
+            verdict["blocked"] = True
+            verdict["reason"] = red_mark(
+                "Слой 2 (тесты) не подтверждён",
+                "в репозитории есть тесты, но в этой сессии не зафиксирован их успешный прогон",
+                "прогони тесты (npm test / pytest / go test …) — «код написан» ≠ «работает»",
+            )
+            return verdict
+        # только объявленный L2 (compare-registers/репост) — ручная, привязанная
+        # к конкретному диффу сверка. Знать, нужна ли она ИМЕННО этому диффу,
+        # автоматически нельзя → advisory, а не false-блок каждого коммита
+        # (в т.ч. docs/reports). Реальный провал L2 (l2s=="fail") перехвачен выше.
+        verdict["degraded"] = True
+        verdict["reason"] = (
+            "Слой 2 для этого проекта — ручная сверка (compare-registers/"
+            "репост). Если изменение затрагивает проведение документов — "
+            "прогони сверку регистров с 1С; иначе обход осознанный."
         )
         return verdict
 

--- a/scripts/validate_state.py
+++ b/scripts/validate_state.py
@@ -36,10 +36,35 @@ _OBJECT_FIELDS = ("classification", "architecture", "existingProject", "currentU
 _LIST_FIELDS = ("verificationHistory", "decisionLog", "artifacts",
                 "completedModules", "failedValidations", "blockers")
 
+_ACTIVE_UNIT_STATUSES = {"in_progress", "verifying", "recovery_required"}
+
 
 def fail(message: str) -> None:
     print(f"ERROR: {message}")
     sys.exit(1)
+
+
+def _check_single_wip(path: Path, state: dict) -> None:
+    """WIP=1 across both state ledgers. Removes the dual source of "current
+    unit": STATE.currentUnit (ad-hoc /task unit) and GOAL.json (long goal) must
+    not be active simultaneously -- otherwise it is ambiguous what is in flight.
+    GOAL.json owns long-goal units; STATE.currentUnit owns /task units.
+    """
+    cu = state.get("currentUnit") or {}
+    state_active = str(cu.get("status", "")).strip() in _ACTIVE_UNIT_STATUSES
+    goal_path = path.parent / "GOAL.json"
+    goal_active, goal_unit = False, ""
+    if goal_path.is_file():
+        try:
+            goal = json.loads(goal_path.read_text(encoding="utf-8"))
+            goal_unit = str(goal.get("currentUnitId", "")).strip()
+            goal_active = str(goal.get("status", "")).strip() != "done" and bool(goal_unit)
+        except Exception:
+            goal_active = False
+    if state_active and goal_active:
+        fail(f"{path}: WIP=1 violated -- both STATE.currentUnit "
+             f"('{cu.get('id', '')}') and GOAL.json ('{goal_unit}') are active. "
+             f"Finish/close one before activating the other.")
 
 
 def validate_state(path: Path) -> None:
@@ -66,6 +91,8 @@ def validate_state(path: Path) -> None:
         fail(f"{path}: gateResults.nextStepApproval must be present")
     if not state.get("nextAction"):
         fail(f"{path}: nextAction must not be empty (fail-closed)")
+
+    _check_single_wip(path, state)
 
 
 def validate_goal(path: Path) -> None:


### PR DESCRIPTION
## Why

Follow-up to the Completion Gate release (1.62.0). An audit of the gate on a
live project surfaced three defects that let it produce false positives /
`unknown`-everything, plus two contract-discipline gaps.

## What

**Fixed — `hooks/completion_lib.py` classifier**
- `outcome_from` reads an echoed exit code (`EXIT: 0` / `TSC_EXIT=0` / `exit: 1`).
  Piping through `head`/`tail` masks `$?` and the host tool-response often omits
  a structured exit code, so every signal was landing as `unknown` and L1 never
  turned `pass`.
- VCS/submission commands (`git`/`gh`/`hg`/`svn`/`jj`) excluded from signal
  classification — a `git commit ... && git log` was classified as an L2
  `test_run`, i.e. the act of submitting masqueraded as proof (violated the
  gate's own "commit != test").
- PASS text heuristic tightened to strong test/build summaries only; weak
  `clean` / `no errors` / bare `PASS` / `ok N` no longer yield a false `pass`
  on arbitrary output — they degrade to `unknown` (safe). A false `pass` is a
  dangerous false-green; a false `unknown` is a safe advisory.
- Projects with declared `l2_evidence_patterns` (no unit tests) no longer
  hard-block every commit on an incidental test-file scan match: the generic
  scan is suppressed, hard block only for real unit tests, otherwise advisory.

**Added**
- `scripts/validate_state.py`: WIP=1 cross-ledger check — `STATE.currentUnit`
  and `GOAL.json` may not be active simultaneously (fail-closed), removing the
  dual source of "current unit".
- `docs/templates/itd/check_contract_drift.py`: detector for silent drift of
  derived `.itd/*` contract copies from CLAUDE.md via `snapshot @ <sha>`
  markers; `--strict` for a gate, `--selftest` for the compare logic.

## Verification

- Gate classifier self-test: 15/15 PASS (EXIT-echo, VCS exclusion, weak→unknown,
  strong→pass, declared-L2 advisory vs generic block).
- `validate_state.py` positive + negative: dual-active → FAIL(WIP=1),
  STATE-active + GOAL-done → OK.
- `check_contract_drift.py --selftest`: ALL PASS; real run flags drift/unmarked.
- The 8/8 Completion Gate goal checks stay green after the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
