### PR TITLE
feat(pre-flight): auto-detect .itd contract drift from CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.65.0] - 2026-07-08
+
+**Contract-drift detection goes automatic.** `pre-flight-check.sh` gains an
+inline advisory: if the project has `.itd/` and CLAUDE.md, the `snapshot @ <sha>`
+markers in derived `.itd/*.md` docs are compared against the last commit that
+touched CLAUDE.md. On drift, one warning line enters the pre-flight context
+(with a pointer to `.itd/check_contract_drift.py` for details). Rate-limited to
+once per 4h per project; advisory-only; any error (no git, not a repo) is a
+silent skip. The logic is implemented INLINE — a user-level hook never executes
+code from the project directory (reads data, does not run scripts).
+
+---
+
 ## [1.64.0] - 2026-07-08
 
 **/session-save: methodology-memory auto-push.** New Step 4.7b — when

--- a/hooks/pre-flight-check.sh
+++ b/hooks/pre-flight-check.sh
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -351,6 +352,77 @@ def itd_state_context(cwd: Path) -> str:
     return "\n".join(lines)
 
 
+_DRIFT_MARKER_RE = re.compile(r"снапшот\s*@\s*([0-9a-f]{7,40})", re.I)
+DRIFT_CHECK_INTERVAL_SEC = 4 * 3600  # advisory раз в 4 часа на проект, не каждый промпт
+
+
+def itd_contract_drift_context(cwd: Path) -> str:
+    """v1.65.0: advisory-детектор дрейфа производных .itd/*.md от CLAUDE.md.
+
+    Логика зеркалит .itd/check_contract_drift.py, но реализована ИНЛАЙН —
+    user-level хук не исполняет код из проектной директории (данные читаем,
+    код не запускаем). Маркер «снапшот @ <sha>» в доке сравнивается с последним
+    коммитом, тронувшим CLAUDE.md. Advisory-only, rate-limited, любая ошибка
+    (нет git, не репо, таймаут) — молчаливый скип: дрейф-чек не имеет права
+    шуметь или ломать pre-flight.
+    """
+    itd_dir = cwd / ".itd"
+    if not itd_dir.is_dir() or not (cwd / "CLAUDE.md").is_file():
+        return ""
+
+    # rate-limit: одна проверка на проект в DRIFT_CHECK_INTERVAL_SEC
+    stamp = Path(tempfile.gettempdir()) / (
+        "claude-itd-drift-" + re.sub(r"[^A-Za-z0-9]+", "-", str(cwd))[-80:] + ".stamp"
+    )
+    try:
+        if stamp.is_file() and (time.time() - stamp.stat().st_mtime) < DRIFT_CHECK_INTERVAL_SEC:
+            return ""
+    except Exception:
+        pass
+
+    try:
+        res = subprocess.run(
+            ["git", "log", "-1", "--format=%h", "--", "CLAUDE.md"],
+            cwd=str(cwd), capture_output=True, text=True, timeout=4,
+        )
+        current = res.stdout.strip().lower()
+        if res.returncode != 0 or not current:
+            return ""
+    except Exception:
+        return ""
+
+    drift: list[str] = []
+    unmarked = 0
+    try:
+        for md in sorted(itd_dir.glob("*.md")):
+            try:
+                m = _DRIFT_MARKER_RE.search(md.read_text(encoding="utf-8", errors="replace"))
+            except Exception:
+                continue
+            if not m:
+                unmarked += 1
+                continue
+            marker = m.group(1).lower()
+            if not (current.startswith(marker) or marker.startswith(current)):
+                drift.append(md.name)
+    except Exception:
+        return ""
+
+    try:
+        stamp.write_text(str(time.time()))
+    except Exception:
+        pass
+
+    if not drift:
+        return ""  # unmarked-доки не шумят в pre-flight — advisory только на реальный дрейф
+    return (
+        f"⚠️ **Дрейф .itd-контрактов**: {', '.join(drift[:6])} — CLAUDE.md ушёл вперёд "
+        f"(@ {current}) с момента снапшота. Пересверь и обнови маркер «снапшот @ <sha>» "
+        f"(детали: `python .itd/check_contract_drift.py`)."
+        + (f" Без маркера: {unmarked}." if unmarked else "")
+    )
+
+
 def session_id() -> str:
     sid = os.environ.get("CLAUDE_SESSION_ID")
     if sid:
@@ -450,6 +522,10 @@ def main() -> int:
     itd_state = itd_state_context(cwd)
     if itd_state:
         sections.append(itd_state)
+
+    drift = itd_contract_drift_context(cwd)
+    if drift:
+        sections.append(drift)
 
     mem_dir = find_project_memory_dir(cwd)
     if mem_dir:


### PR DESCRIPTION
## Why

The .itd contract-drift detector (1.63.0, `check_contract_drift.py`) existed but ran only on demand — the one place where the discipline was manual, not mechanical. Silent drift of derived `.itd/*.md` copies from CLAUDE.md was the exact failure found in the live audit.

## What

Inline advisory in `pre-flight-check.sh`: when the project has `.itd/` and CLAUDE.md, compare `snapshot @ <sha>` markers against the last commit touching CLAUDE.md. On drift — one warning line in the pre-flight context.

- Rate-limited: once per 4h per project (tmp stamp) — no per-prompt noise.
- Advisory-only, fail-silent (no git / not a repo / timeout → quiet skip).
- Logic is INLINE — a user-level hook never executes code from the project dir.
- Unmarked docs never warn on their own.

CHANGELOG 1.65.0.

## Verification

py_compile clean (Win + WSL); 6/6 unit checks: drift warns / ok-doc quiet / unmarked counted / rate-limit silences repeat / fixed marker quiet / non-git quiet. Real run on OneOfS: 8/8 docs in sync (all markers stamped this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)