### PR TITLE
fix: complete external review gate adjudication check

### DIFF
--- a/.github/workflows/external-review-gate.yml
+++ b/.github/workflows/external-review-gate.yml
@@ -286,7 +286,9 @@ jobs:
           adjudication="$(python3 "$vl" adjudicate --root .itd-candidate \
             --unit-id "PR-${{ github.event.client_payload.pull_request }}:external-review" \
             --risk-tier high --machine "$machine" --checker "$checker")"
-          python3 "$vl" check --root .itd-candidate --receipt "$adjudication"
+          python3 "$vl" check --root .itd-candidate \
+            --unit-id "PR-${{ github.event.client_payload.pull_request }}:external-review" \
+            --risk-tier high --receipt "$adjudication"
           echo "adjudication=$adjudication" >> "$GITHUB_OUTPUT"
 
       - name: Upload privacy-safe evidence

--- a/tests/verify_api_reviewer.py
+++ b/tests/verify_api_reviewer.py
@@ -361,7 +361,8 @@ def phase_modes(checks: Checks) -> None:
                     "CI gate is not default-branch-dispatched with trusted tooling")
         checks.that("test -z \"${OPENAI_API_KEY:-}\"" in workflow
                     and "adjudicate --root .itd-candidate" in workflow
-                    and " check --root .itd-candidate" in workflow,
+                    and " check --root .itd-candidate" in workflow
+                    and '--risk-tier high --receipt "$adjudication"' in workflow,
                     "CI gate does not separate the secret from candidate execution "
                     "or finish through adjudication")
         checks.that("ITD_PROVENANCE_HMAC_KEY" in workflow


### PR DESCRIPTION
## Root cause

The first real signed canary reached the managed OpenAI reviewer and produced a validated `PASSED` result, but the workflow then invoked Verification Loop `check` without its required `--unit-id` and `--risk-tier` arguments.

## Fix

- Pass the same immutable PR unit id and `high` risk tier into the final `check` command.
- Strengthen `verify_api_reviewer.py` so this invocation cannot regress.

## Evidence

- Canary API review before the workflow bug: `PASSED`, same-vendor different-model, exact candidate bound, $0.005465 observed cost.
- `python3 tests/verify_api_reviewer.py`: passed.
- Native Windows Python 3.12 reviewer test: passed.
- `python3 tests/verify_host_adapters.py`: passed.
- `bash tests/run-all.sh --quick`: passed.
- Secret scan: passed.
