### PR TITLE
docs: adopt GENG Graph Contract Layer plan as ADR-009 with backlog section

### DIFF
--- a/.itd/SCOPE_LOCK.md
+++ b/.itd/SCOPE_LOCK.md
@@ -1,106 +1,45 @@
-# Scope Lock — GPG-004 ladder remainder: reviewer independence policy
+# Scope Lock — GENG-STRATEGY: formalize the approved Graph Contract Layer amendments (docs-only)
 
 ## Current Task
 
-Ladder remainder of GPG-004 (compressed plan agreed 2026-08-09, phase after A
-and after the accepted push-gate slice): make reviewer independence an
-explicit, honest, machine-checked policy instead of a hard-coded Sol/Terra
-convention.
+Single advisory/planning unit (opened 2026-08-10 after GPG-004 closed and
+v1.96.0 shipped): formalize the three user-approved amendments to the GENG
+Graph Contract Layer plan (project memory `project_geng_plan_amendments.md`,
+approved 2026-08-07) as durable repo docs. No code, no gates, no skill/hook
+surface touched.
 
-1. **Closed vendor independence class {Claude (anthropic), Codex (openai)}**
-   for the maker/reviewer pair. Live proof of necessity: an honest anthropic
-   maker today dead-ends with typed UNAVAILABLE "maker is not a supported
-   Sol/Terra model" (`select_openai_reviewer_model`,
-   `require_opposite_openai_model` in
-   `skills/_shared/itd_free_reviewer_producer.py`) — cross-vendor review for
-   an anthropic maker is structurally impossible, so authorized work made by
-   Claude can never obtain the mandatory independent review.
-2. **Flagged same-vendor-different-model fallback** — selectable only after
-   the cross-vendor route returns a typed unavailability; every receipt and
-   claim surface carries the honest `same-vendor-different-model` label,
-   never silently, never for a same-model pair, and it never upgrades the
-   recorded independence claim.
-3. **HUMAN_OVERRIDE_NO_INDEPENDENT_REVIEW** — explicit audited human override
-   class for "no independent route available at all": bound to the exact
-   candidate digest, recorded under its own honest label, never counted as an
-   independent review by any downstream gate.
-4. **Reviewer cardinality** — restore the `minimumIndependentReviewers`
-   contract and the removed `low-reviewer` / `high-quorum` structural cases
-   in the efficacy suite; quorum deduplicates by provider/model/session
-   identity.
-5. **U12 measurement** — measure the ladder: same-vendor vs cross-vendor
-   reviewer legs over the frozen seeded benchmark corpus, published as signed
-   host-derived evidence, recorded honestly whatever the result.
+## Allowed zones
 
-## Slicing (fixed for this unit)
+- `docs/adr/ADR-009-graph-contract-layer.md` (new decision record)
+- `BACKLOG.md` (new "P1 — GENG" section + Last reviewed date)
+- `.itd/SCOPE_LOCK.md` (this contract, rewritten for the unit)
 
-- **PC-S1 (contracts, this session):** BACKLOG delta, this scope lock,
-  `GPG-004-PC1..PC5` in `.itd/ACCEPTANCE_CONTRACT.json`, plan approval. No
-  code.
-- **PC-S2 (RED-first, after plan approval):** policy module + tests outside
-  the frozen producer; RED tests pin today's anthropic-maker UNAVAILABLE
-  dead-end, the cardinality gaps, and the missing override class.
-- **PC-S3 (producer batch, separate explicit approval):** ALL producer edits
-  for PC1/PC2/PC5 land as ONE batch; both signed benchmark legs are re-run
-  exactly once after the batch (a single producer byte invalidates both
-  legs). This is the most expensive slice of the unit and starts only on its
-  own explicit user approval.
-- The unit commit is one combined candidate (PC-S2 + PC-S3) so
-  `coverage_matrix` sees every active criterion passed before the commit
-  review — same pattern as the accepted phase-A combined slice.
+Nothing else. `.itd/DECISIONS.md` (untracked journal) received the paired
+durable entry 2026-08-10.
 
-## Allowed Change Areas
+## Acceptance (this unit)
 
-- new policy module for the independence class and its threading through the
-  reviewer selection surface (`skills/_shared/itd_free_reviewer_producer.py`
-  ONLY inside the approved PC-S3 batch)
-- `skills/_shared/itd_verification_loop.py`,
-  `skills/_shared/itd_gate_control.py` — honest label surfaces
-  (independence level, override class) without changing gate defaults
-- new focused RED-first tests
-  (`tests/verify_reviewer_independence_policy.py`) plus bounded extensions of
-  `tests/verify_independent_review_efficacy.py` (cardinality cases + U12),
-  `tests/verify_mandatory_keyless_review.py`, and oracle-id registration in
-  the evidence-coverage mapping
-- amendment 2026-08-09 (after the legs were minted): ONE broker-suite fixture
-  line in `tests/verify_review_broker.py` — the foreign-maker negative
-  fixture moves from the out-of-class provider `forged-maker` to a
-  class-member but still foreign `anthropic-subscription/opus` identity,
-  because the closed class refuses to label out-of-class pairs at mint time
-  and a producer-byte fix would burn all three freshly signed legs; the
-  fixture's downstream intent (maker claim must match signed PR provenance;
-  no Check Run, no token spend) is unchanged
-- a new ADR for the independence policy if the design departs from ADR-006/7
-- `.itd/SCOPE_LOCK.md`, `.itd/ACCEPTANCE_CONTRACT.json` (PC criteria),
-  CHANGELOG/BACKLOG/HANDOFF and `.itd-memory` state records
+1. ADR records variant B invariants (no owned runtime; human authorizes exact
+   graphDigest; Verification Loop is the sole completion authority;
+   durability = `.itd-memory` + receipts) and the three amendments:
+   numbering (ADR-009; ADR-008 stays reserved for the reviewer-independence
+   ladder ADR per `.itd/DECISIONS.md` 2026-08-09), GENG-004 entry gated on a
+   dedicated Codex isolated-transport stability check, incremental proof
+   graph as a separate GENG-003 exit criterion.
+2. User approved the formalization (AskUserQuestion, 2026-08-10); /review ran
+   before commit (PASSED_WITH_WARNINGS, both Important findings fixed in the
+   candidate).
+3. Machine oracle: `tests/meta_review.py` green (docs-vs-code consistency,
+   Critical = 0) on the exact committed-head candidate.
 
-## Forbidden Change Areas
+## Risk tier
 
-- any producer byte outside the explicitly approved PC-S3 batch; piecemeal
-  producer edits (each byte invalidates both signed benchmark legs)
-- same-model maker/reviewer pairs; silent fallback selection; recording
-  HUMAN_OVERRIDE_NO_INDEPENDENT_REVIEW as PASSED, ADJUDICATED or any form of
-  independent review; widening checker `acceptedVerdicts`
-- weakening `--require-mandatory-route` defaults, the ADR-007 channel, or the
-  push-gate/registry-isolation behavior accepted in PB1..PB3
-- `--no-verify`, environment kill-switches, direct `git push`, manual edits
-  of `~/.config/itd/gates.json` outside the guarded register flow
-- U6 (installed-skill parity), U16 (pre-deploy), U17 (design-stage) — separate
-  deferred units; the completion-gate and fixture-hardening BACKLOG candidates
-  recorded 2026-08-09 — separate bounded fixes
-- push or PR before: unit acceptance + the "pin clean live evidence state"
-  follow-up (skills/ edits burn the H4 content pin) + a fresh committed-head
-  chain
+low — docs-only additive planning artifacts; no executable surface, no
+schema, no gate semantics changed. Route per verification-loop-v1: machine
+evidence, no independent checker (machine_only).
 
-## Acceptance Boundary
+## Out of scope
 
-The unit remainder is accepted only when GPG-004-PC1..PC5 pass: RED-first
-tests reproduce the anthropic-maker dead-end, the silent-fallback and
-label-laundering mutations, the missing override class and the cardinality
-gaps, then turn GREEN only through the policy; mutation checks kill each
-guard individually; both signed benchmark legs revalidate after the single
-PC-S3 batch; the U12 comparison is recorded as signed host-derived numbers;
-the full quick suite stays green; and the unit commit passes the commit
-review gate (through the ADR-007 channel if the fresh route returns findings)
-without bypass. GOAL/STATE closure of GPG-004 additionally requires the /goal
-pass over the unit's verificationCommands after this remainder lands.
+The GENG-000…010 program text (enters the repo as a /goal unit ledger when
+GENG-000 starts), any GENG code, LAUNCH_PLAN.md (locked to the vibe-coding
+enrichment scope), ledger-drift housekeeping (G-001/PE5-015).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # BACKLOG — Harness-demo UX absorption
 
 **Decision:** [ADR-004](docs/adr/ADR-004-harness-demo-ux-absorption.md)
-**Last reviewed:** 2026-08-09
+**Last reviewed:** 2026-08-10
 **Next review:** 2026-08-30
 
 ## P0 — Must do
@@ -113,6 +113,23 @@ adjudication; each was deliberately kept out of those bounded slices.
 - [ ] Build the fresh-session worktree/resource-isolation pilot kit.
 - [ ] Run three serial, user-authorized brownfield units in named project roots with
   isolated mutable resources and exact-candidate receipts.
+
+## P1 — GENG: Graph Contract Layer (ADR-009, accepted 2026-08-10)
+
+Decision record: [ADR-009](docs/adr/ADR-009-graph-contract-layer.md). Program
+GENG-000…GENG-010 (variant B, approved 2026-08-07; full unit text enters the
+repo as a /goal ledger at GENG-000 start). Ordered after the queued GPG
+follow-ups (U6/U16/U17); no GENG code before GENG-000 is started as a unit.
+
+- [ ] GENG-000 Harness Readiness Freeze — first GENG unit via /goal; imports
+  the program text from the originating sessions into the unit ledger.
+- [ ] GENG-003 carries the amended exit criterion: content-addressed node
+  receipts with downstream-only invalidation; final integration oracle always
+  over the single exact candidate (ADR-009, amendment 3).
+- [ ] GENG-004 (Codex Shadow Mode) is entry-gated on a dedicated Codex
+  isolated-transport stability check (repeated clean passes; U8's adjudicated
+  closure does not itself certify stability — transport root cause unknown);
+  serial fallback stays first-class until then (ADR-009, amendment 2).
 
 ## P2 — Conditional
 

--- a/docs/adr/ADR-009-graph-contract-layer.md
+++ b/docs/adr/ADR-009-graph-contract-layer.md
@@ -1,0 +1,104 @@
+# ADR-009 — Graph Contract Layer (GENG program), host-neutral, no owned runtime
+
+- **Status:** accepted (user approval 2026-08-10 — approval gate v1.42.0)
+- **Date:** 2026-08-10
+- **Review date:** 2026-09-28 — jointly with the ADR-001 review, as proposed in
+  the originating Codex (GPT 5.6) session.
+- **Amends:** [ADR-001](ADR-001-no-own-runtime.md) — refines, does not revoke:
+  ITD still builds no runtime of its own; graph *contracts, policies, and
+  proofs* are ITD-owned, graph *execution* stays native to the host.
+- **Numbering note (amendment 1):** the originating plan named this record
+  "ADR-007". That number was already taken on `main` by
+  [ADR-007-human-adjudication-of-independent-review.md](ADR-007-human-adjudication-of-independent-review.md)
+  (and by `ADR-007-vendor-neutral-independent-review.md` in the frozen GPG-003
+  candidate). The next number, ADR-008, is already reserved by
+  `.itd/DECISIONS.md` (entry 2026-08-09) for the deferred
+  reviewer-independence-ladder ADR that ADR-007 explicitly defers. The GENG
+  decision record therefore takes the next free number after that reservation,
+  **ADR-009**. All references to "GENG-ADR" resolve here.
+
+## Context
+
+Advisory session 2026-08-07 (`/advisor`; business-analyst
+PASSED_WITH_WARNINGS, devils-advocate BLOCKED for any runtime-owning variant)
+analyzed the proposal to bring Graph Engineering into idea-to-deploy, against
+five public sources (LangChain "3 Years of Graph Engineering", the Claude
+dynamic-workflows blog, a deep-research workflow gist, Anthropic Institute
+RSI, 0xCodez "14-step Graph Engineering"). In a parallel Codex (GPT 5.6)
+session the user approved **variant B: "Codex-first host-neutral Graph
+Contract Layer"**, program **GENG-000 … GENG-010**, and then approved three
+amendments to that plan (recorded 2026-08-07 in project memory,
+`project_geng_plan_amendments.md`). Formalization was deliberately deferred
+until GPG-004 closed (WIP=1, Scope Lock); GPG-004 is `verified` and released
+in v1.96.0, so the deferral condition is met.
+
+Host constraints confirmed against the harness contract: dynamic-workflow
+concurrency min(16, cores−2), 1000-agent ceiling, resume only within the same
+session ⇒ a host checkpoint is a cache, never canonical durability.
+
+## Decision
+
+Adopt the Graph Contract Layer under these locked invariants:
+
+1. **No owned graph runtime.** ITD owns graph contracts, policies, and proof
+   formats; execution is native to the host (per ADR-001).
+2. **Proposal ≠ authorization.** Claude/Codex may *propose* a graph; only the
+   human authorizes, and authorizes an **exact `graphDigest`**.
+3. **Verification Loop stays the single completion authority.** No graph
+   mechanism mints `verified`.
+4. **Durability lives in `.itd-memory` + receipts.** Host checkpoints are
+   cache only.
+
+### Amendment 2 — entry criterion for GENG-004 (Codex Shadow Mode)
+
+GENG-004 may not start until the **Codex isolated transport is demonstrably
+stable**, established by a dedicated transport-stability check (repeated
+clean isolated-transport passes), not inferred from unit closure. The
+GPG-004 U8 line is closed, but its closure criterion was acceptance on one
+exact candidate via a human-adjudicated route — that closure does not itself
+certify transport stability. Rationale: 13 probes showed non-deterministic
+Codex transport failure depending on the shape of `CODEX_HOME`; the
+mechanism remains unknown and is not to be guessed at. Until the dedicated
+check passes, the **serial fallback is first-class**, not an emergency path.
+
+### Amendment 3 — incremental proof graph as a separate GENG-003 exit criterion
+
+GENG-003 is not done without **content-addressed node receipts** binding:
+graph version + node version + input digest + dependency digests + policy
+digest + candidate/tree + provenance — with **downstream-only invalidation**
+(a changed node re-proves itself and its descendants, nothing upstream).
+The **final integration oracle always runs over the single exact candidate**;
+node-level receipts never substitute for it. This is the element that
+addresses the pain of multi-day runs re-proving everything from scratch.
+
+## Alternatives considered
+
+- **ITD-owned graph runtime / scheduler** — rejected (devils-advocate
+  BLOCKED): contradicts ADR-001, the harness-best-effort invariant, WIP=1,
+  and exact-candidate adjudication. Also already in the BACKLOG icebox
+  ("Ralph or any ITD-owned scheduler/runtime").
+- **Do nothing (no graph work)** — rejected: multi-day proof runs re-execute
+  the full ladder on every change; the contract layer attacks that cost
+  without new runtime surface.
+- **Keep the plan's original "ADR-007" number** — rejected: collides with the
+  merged ADR-007 on `main`.
+
+## Consequences
+
+- **Positive:** graph work becomes plannable as ordered GENG units under the
+  existing /goal + Verification Loop machinery; incremental proof receipts
+  bound re-verification cost; the transport entry criterion prevents building
+  Shadow Mode on a flaky channel.
+- **Negative / cost:** proof-graph receipt schemas are new security-relevant
+  surface; contract-only ownership means host behavior changes can still
+  invalidate assumptions (mitigated by the best-effort invariant: a missing
+  host feature degrades to the serial path, never to a false green).
+- **Risks:** Codex transport root cause stays unknown — GENG-004 may stay
+  gated for a long time; that is intended fail-closed behavior.
+
+## Follow-up
+
+The full GENG-000…GENG-010 unit text lives in the two originating session
+transcripts and project memory; it enters the repo as a `/goal` unit ledger
+when GENG-000 (Harness Readiness Freeze) is started as the next unit after
+the currently queued GPG follow-ups (U6/U16/U17). No GENG code before that.


### PR DESCRIPTION
Formalizes the three user-approved amendments to the GENG-000..010 Graph Contract Layer program (approved 2026-08-07, deferred until GPG-004 closed):

- ADR numbering: the GENG decision record takes ADR-009; ADR-008 stays reserved for the deferred reviewer-independence-ladder ADR (`.itd/DECISIONS.md` 2026-08-09).
- GENG-004 (Codex Shadow Mode) entry is gated on a dedicated Codex isolated-transport stability check; U8's adjudicated closure does not itself certify stability.
- Incremental proof graph is a separate GENG-003 exit criterion: content-addressed node receipts with downstream-only invalidation; the final integration oracle always runs over the single exact candidate.

Docs-only (ADR-009 + BACKLOG P1 section + unit scope lock); no GENG code. Local /review: PASSED_WITH_WARNINGS, both Important findings fixed in the candidate. Verification Loop: machine PASSED (meta-review + quick suite) on committed-head 2c2838f, low-tier adjudication PASSED, registry LOCAL_REVIEWED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)