### PR TITLE
docs: close U6 installed-skill parity in the unit ledger

### DIFF
--- a/.itd-memory/STATE.json
+++ b/.itd-memory/STATE.json
@@ -37,11 +37,12 @@
     "lastAnalysisSummary": "GPG-003 is being simplified under accepted ADR-006 to one fresh opposite-GPT reviewer: Sol maker to Terra, Terra maker to Sol. Evidence-first exact-tree machine oracles, strict receipts, efficacy gates, PR/release and dual-host rollout remain required; Anthropic, Copilot, Antigravity and paid API transports are optional and cannot block unrelated projects."
   },
   "currentUnit": {
-    "id": "GPG-004",
-    "goal": "GPG-004 reviewer independence policy — VERIFIED and published. Closed class {anthropic, openai} with cross-vendor route for anthropic makers, flagged same-vendor fallback with typed cross-vendor unavailability, independenceLevel/mint-override wiring, exact-equality reviewer cardinality, three signed efficacy legs and the honest U12 comparison. Commits b38d893+28119f9+a3aa462 landed through the full ladder (two ADR-007 human adjudications: 4 dispositions on the commit chain, 1 on the push chain), guarded registry re-registered, Draft PR #184 published (head a3aa462, LOCAL_REVIEWED). Final machine evidence: committed-head receipt GPG-004-machine-pushchain.json — 15/15 oracles PASSED on the exact HEAD tree f1a86608, including reviewer-independence-policy and live-model-evidence-replay.",
-    "riskTier": "high",
+    "id": "U6",
+    "riskTier": "low",
+    "goal": "Installed-skill parity: repo==installed cross-review hash on WSL, recorded Windows check; fresh evidence, no install mutations",
     "status": "verified",
-    "startedAt": "2026-08-02T23:25:00Z"
+    "startedAt": "2026-08-10T10:03:35Z",
+    "completedAt": "2026-08-10T10:04:16Z"
   },
   "gateResults": {
     "acceptanceContract": "pending",
@@ -565,5 +566,5 @@
     "lastEventId": "",
     "lastEventAt": "2026-07-14T13:39:02Z"
   },
-  "nextAction": "GPG-004 closed. Next candidates by plan: U6 (installed-skill parity), U16 (pre-deploy), U17 (design-stage), the queued BACKLOG follow-ups (benchmark scenario devils-advocate fix, completion-ledger writer schema, doctor independence label), and the GENG /strategy session recorded in project memory. PR #184 merge + CI watch by explicit user command."
+  "nextAction": "U6 (installed-skill parity) closed on fresh evidence 2026-08-10; GENG /strategy formalized as ADR-009 (PR #186 merged 7ed8e43). Next candidates by plan: U16 (pre-deploy), U17 (design-stage), the queued BACKLOG follow-ups (benchmark scenario devils-advocate fix, completion-ledger writer schema, doctor independence label, itd pr create up-to-date push bug, __pycache__ sync-scan noise). GENG-000 starts via /goal after U16/U17."
 }

--- a/.itd/SCOPE_LOCK.md
+++ b/.itd/SCOPE_LOCK.md
@@ -1,45 +1,53 @@
-# Scope Lock — GENG-STRATEGY: formalize the approved Graph Contract Layer amendments (docs-only)
+# Scope Lock — U6: installed-skill parity (evidence-only closure, docs commit)
 
 ## Current Task
 
-Single advisory/planning unit (opened 2026-08-10 after GPG-004 closed and
-v1.96.0 shipped): formalize the three user-approved amendments to the GENG
-Graph Contract Layer plan (project memory `project_geng_plan_amendments.md`,
-approved 2026-08-07) as durable repo docs. No code, no gates, no skill/hook
-surface touched.
+Close unit U6 «Installed-skill parity (F6)» from the GPG-004 ladder plan on
+fresh read-only evidence (2026-08-10, main @ 7ed8e43, after the v1.96.0
+rollout): the installed cross-review skill matches the repository version by
+content hash on WSL, and the same check is recorded for Windows. No install
+mutations, no code changes — parity is already factual; only the ledgers and
+this contract change.
 
 ## Allowed zones
 
-- `docs/adr/ADR-009-graph-contract-layer.md` (new decision record)
-- `BACKLOG.md` (new "P1 — GENG" section + Last reviewed date)
+- `.itd-memory/STATE.json` (unit bookkeeping via `itd_unit_log.py`:
+  activated + verified U6)
+- `BACKLOG.md` (one follow-up line: `__pycache__` noise in
+  `sync-to-active.sh --check`)
 - `.itd/SCOPE_LOCK.md` (this contract, rewritten for the unit)
 
-Nothing else. `.itd/DECISIONS.md` (untracked journal) received the paired
-durable entry 2026-08-10.
+Untracked local stores updated alongside (not part of the git candidate):
+`.itd-memory/GPG-004_UNIT_PLAN.json` (U6 → verified + evidence),
+`.itd-memory/contracts/U6.md`, `.itd-memory/events.jsonl` (harness writer).
 
 ## Acceptance (this unit)
 
-1. ADR records variant B invariants (no owned runtime; human authorizes exact
-   graphDigest; Verification Loop is the sole completion authority;
-   durability = `.itd-memory` + receipts) and the three amendments:
-   numbering (ADR-009; ADR-008 stays reserved for the reviewer-independence
-   ladder ADR per `.itd/DECISIONS.md` 2026-08-09), GENG-004 entry gated on a
-   dedicated Codex isolated-transport stability check, incremental proof
-   graph as a separate GENG-003 exit criterion.
-2. User approved the formalization (AskUserQuestion, 2026-08-10); /review ran
-   before commit (PASSED_WITH_WARNINGS, both Important findings fixed in the
-   candidate).
-3. Machine oracle: `tests/meta_review.py` green (docs-vs-code consistency,
-   Critical = 0) on the exact committed-head candidate.
+1. Unit verificationCommand exit 0: sha256(repo skills/cross-review/SKILL.md)
+   == sha256(~/.claude/skills/cross-review/SKILL.md) —
+   c82ea90e56e9bd7e6070976351c6c604f5ef16c4000730608a14cd5db9f6a201.
+2. `scripts/sync-to-active.sh --check`: zero pending changes outside
+   `skills/_shared/__pycache__/*.pyc` bytecode (0 non-pyc diffs; 40 skills /
+   32 hooks / 10 agents / 41 templates unchanged).
+3. Windows install byte-identical for cross-review
+   (`/mnt/c/Users/Дмитрий/.claude/skills/cross-review/SKILL.md`, cmp exit 0).
+4. Machine oracle on the exact committed-head candidate: the three checks
+   above plus meta-review and `tests/run-all.sh --quick` green.
 
 ## Risk tier
 
-low — docs-only additive planning artifacts; no executable surface, no
-schema, no gate semantics changed. Route per verification-loop-v1: machine
-evidence, no independent checker (machine_only).
+low — read-only verification plus ledger/docs bookkeeping. The plan's
+declared high tier guarded against rolling out unreviewed WIP (user decision
+A5); that rollout has since happened through the reviewed v1.96.0 release, so
+no mutation class remains in this unit.
 
 ## Out of scope
 
-The GENG-000…010 program text (enters the repo as a /goal unit ledger when
-GENG-000 starts), any GENG code, LAUNCH_PLAN.md (locked to the vibe-coding
-enrichment scope), ledger-drift housekeeping (G-001/PE5-015).
+Excluding `__pycache__` from the sync scan (queued in BACKLOG); a fresh
+full-tree hash re-scan of both installs — the v1.96.0 rollout scan is
+recorded only in the local session memory (`session_2026-08-10.md`:
+skills/hooks/agents trees wsl==win, agents byte-identical to repo, deltas
+explained; the Windows install intentionally carries no plugin manifest),
+and this unit re-checked only the cross-review skill per its criterion
+(WSL sync --check full, Windows single-file cmp); any install mutation or
+rollout; U16/U17.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -52,6 +52,10 @@ the slice stays one reviewable change. None of them is a known-broken invariant.
   `skills/_shared/.claude/traces/` silently entered the H4 tree pin, and the mismatch
   only surfaced later in the isolated staged candidate as three failing checks. The
   pin should either exclude the same paths Git ignores or fail loudly at run time.
+- [ ] Exclude `__pycache__`/`*.pyc` bytecode from the `sync-to-active.sh` drift
+  scan (found closing U6, 2026-08-10): the only reported skill drift on a fully
+  synced install was `skills/_shared/__pycache__` — pure noise that makes a
+  clean parity check read as "~1 updated".
 
 ## P0 — Deferred out of GPG-004 push-gate/adjudication execution (2026-08-09)
 


### PR DESCRIPTION
Fresh read-only evidence on main after the v1.96.0 rollout: the unit
verificationCommand passes (repo == installed cross-review SKILL.md,
sha256 c82ea90e…a201, WSL), sync-to-active --check reports zero pending
changes outside __pycache__ bytecode, and the Windows installed
cross-review skill is byte-identical to the repo. No install mutations.
STATE.json records U6 activated+verified (riskTier low) via
itd_unit_log.py; the unit scope lock is rewritten for this closure;
BACKLOG gains the __pycache__ sync-scan noise follow-up. Review:
PASSED_WITH_WARNINGS with both Important findings fixed, re-verified
PASSED on the exact staged candidate; verification receipts in
.itd-memory/verification-loop/receipts/u6-staged/.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
