### PR TITLE
docs: close R1-SCRUB in the unit ledger

### DIFF
--- a/.itd-memory/STATE.json
+++ b/.itd-memory/STATE.json
@@ -40,8 +40,9 @@
     "id": "R1-SCRUB",
     "riskTier": "high",
     "goal": "Producer scrub contract: redaction is not a finding; reviewer receives scrubbed text, refusal only on detector hits (retro R1)",
-    "status": "in_progress",
-    "startedAt": "2026-08-10T21:43:44Z"
+    "status": "verified",
+    "startedAt": "2026-08-10T21:43:44Z",
+    "completedAt": "2026-08-11T07:02:24Z"
   },
   "gateResults": {
     "acceptanceContract": "pending",

--- a/.itd/ACCEPTANCE_CONTRACT.json
+++ b/.itd/ACCEPTANCE_CONTRACT.json
@@ -643,6 +643,8 @@
   "doneRule": "A criterion status of passed means only that its verification command passed. GPG-001 and GPG-002 remain verified under their durable completion evidence. GPG-003 additionally requires one exact high-risk adjudication, merged implementation and patch-release PRs, and clean WSL/native-Windows installed-host proof; it never upgrades LOCAL_REVIEWED to PROTECTED. The GPG-004 push-gate unit is closed only after its commit is followed by: the pin-clean-live-evidence follow-up, a fresh committed-head ADJUDICATED chain on the final HEAD, live registry repair through the guarded register flow (the incident fixture row replaced; load_registry validates), and guarded publication — the pre-unit receipts in adf40ca3f6d504c9 are RED-test fixtures only and never authorize a later push. The GPG-004 ladder remainder (PC1..PC5) lands as one combined candidate: producer edits only inside the approved PC-S3 batch with both signed benchmark legs re-run exactly once, and GOAL/STATE closure of GPG-004 requires the /goal verification pass after the remainder is accepted.",
   "activeFollowup": {
     "unitId": "R1-SCRUB",
-    "status": "in_progress"
+    "status": "verified",
+    "closedAt": "2026-08-11",
+    "evidence": "Merged as PR #188 (a2ce0a3). On the merged main, read-only: verify_free_reviewer_producer 140 checks PASSED (liveExternalCalls 0); verify_independent_review_efficacy PASSED with hostParityVerified true, wsl+windows criticalHigh/medium detection 1.0 and cleanFalseBlockRate 0.0, u12 cross-vendor ladder 1.0/1.0/0.0; tests/run-all.sh --quick DONE fails:none. STATE.json records R1-SCRUB verified via itd_unit_log.py after an explicit backfill-activation reconciliation (the activation event was written in the isolated worktree, not this checkout)."
   }
 }

--- a/.itd/SCOPE_LOCK.md
+++ b/.itd/SCOPE_LOCK.md
@@ -92,3 +92,29 @@ text already never leaves); R3 (ceremonial SKILL_BYPASS) — separate slice;
 snapshot `a7` mint and the U16 route — operational steps after this merges;
 narrowing the `producerSha256` binding granularity (retro R2) — separate
 decision.
+
+## Closure (2026-08-11)
+
+Merged as PR #188 (`a2ce0a3`, implementation commit `0715a6a`). All four
+acceptance items verified on the merged `main`, read-only, in this checkout:
+
+1./2. `verify_free_reviewer_producer` — 140 checks PASSED,
+   `liveExternalCalls: 0`, `paidApiCalls: 0` (redaction reaches the reviewer
+   scrubbed; the four mutation cases still refuse fail-closed).
+3. `verify_independent_review_efficacy --expected-keyring-sha256-file
+   .itd-memory/host-inputs/GPG-003_REVIEW_EFFICACY_KEYRING.sha256` — PASSED,
+   `hostParityVerified: true`, wsl and windows both
+   `criticalHighDetection 1.0 / mediumDetection 1.0 / cleanFalseBlockRate 0.0`,
+   u12 cross-vendor ladder 1.0/1.0/0.0, evidence source
+   `real-keyless-model-reports`.
+4. `tests/run-all.sh --quick` — `DONE fails:none`.
+
+Ledger: `STATE.json` records R1-SCRUB `verified` (riskTier high) via
+`itd_unit_log.py`. The activation event was written 2026-08-10T21:43:44Z
+(`evt-unit-1786398224`) inside the isolated worktree
+`.claude/worktrees/r1-producer-scrub`, so the main-checkout ledger needed an
+explicit `backfill-activation` reconciliation before the pair could close —
+recorded as `actor: harness-reconciliation`, not as a fresh activation.
+
+Next operational steps (separate units, not this slice): mint snapshot `a7`
+over the patched producer + scrubber, run the U16 route with it, then R3.


### PR DESCRIPTION
R1 landed on main as PR #188 (a2ce0a3, implementation 0715a6a). This closes
its bookkeeping against fresh read-only evidence taken on the merged tree:
verify_free_reviewer_producer 140 checks PASSED with liveExternalCalls 0,
verify_independent_review_efficacy PASSED with hostParityVerified true
(wsl and windows both criticalHigh/medium detection 1.0, cleanFalseBlockRate
0.0; u12 cross-vendor ladder 1.0/1.0/0.0), and tests/run-all.sh --quick
DONE fails:none. That covers all four acceptance items of the slice.

STATE.json records R1-SCRUB verified via itd_unit_log.py. The activation
event was written 2026-08-10T21:43:44Z inside the isolated worktree
.claude/worktrees/r1-producer-scrub, so the main-checkout ledger had no
pair and the tool refused a bare verified; the gap is reconciled by an
explicit backfill-activation recorded as actor harness-reconciliation.

The acceptance contract's activeFollowup flips to verified with the same
evidence, and the scope lock gains a closure section. Snapshot a7, the U16
route and R3 stay out of this slice.

Reviewed through the standard high-tier chain on the exact staged candidate
(tree a25ef1cf, diff 818492 98): machine oracle PASSED, cross-vendor free
route PASSED with findings=[] and unverified=[] (reviewer gpt-5.6-terra,
independenceLevel cross-vendor, no tools/network/secrets), checker PASSED
and adjudication PASSED. Receipts in
.itd-memory/verification-loop/receipts/r1-scrub-close/. This was also the
first live route through the freshly minted a7 producer snapshot, so it
doubles as the operational proof that R1's scrub contract no longer refuses
a candidate whose diff merely touches redactable text.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
