### PR TITLE
chore(ledger): close LPD002-R6 through the delivered class

### DIFF
--- a/.itd-memory/STATE.json
+++ b/.itd-memory/STATE.json
@@ -39,10 +39,11 @@
   "currentUnit": {
     "id": "LPD002-R6",
     "goal": "LPD-002 R6: карта путь->сьюты как данные в репо (.itd/IMPACT_GRAPH.json), подаётся в impact_closure как impactGraph; машинная полнота (каждый сьют в карте, каждый skills/_shared/*.py и hooks/*.sh имеет владеющий сьют, impactKnown:false -> strict) и пропорциональность (замыкание точечной правки строго меньше полного набора), мутации в обе стороны",
-    "status": "in_progress",
+    "status": "verified",
     "startedAt": "2026-08-19T18:59:41Z",
     "ledger": "STATE",
-    "riskTier": "medium"
+    "riskTier": "medium",
+    "completedAt": "2026-08-20T13:39:55Z"
   },
   "gateResults": {
     "acceptanceContract": "passed",

--- a/.itd/ACCEPTANCE_CONTRACT.json
+++ b/.itd/ACCEPTANCE_CONTRACT.json
@@ -2028,7 +2028,7 @@
   },
   "activeFollowup": {
     "unitId": "LPD002-R6",
-    "status": "in_progress",
+    "status": "verified",
     "selectedClaim": "LOCAL_REVIEWED",
     "rootCause": ".itd/SCOPE_LOCK.md",
     "reviewPolicy": {
@@ -2045,7 +2045,8 @@
       "adjudicator": "sealed-host-union"
     },
     "openedAt": "2026-08-19T19:14:45Z",
-    "scopeNote": "LPD-002 R6 (последний пункт approved-плана, WIP=1, riskTier medium = checkerMode targeted, checkerRequired true, независимость требует другой сессии, но НЕ другой модели/провайдера; контуры static + targeted; minimumIndependentReviewers 1): карта 'путь исходника -> сьюты' становится данными репозитория (.itd/IMPACT_GRAPH.json) и подаётся в существующий impact_closure через impactGraphPath; движок получает операцию impact-audit — машинную полноту (каждый сьют достижим; каждый skills/_shared/*.py и hooks/*.sh имеет владеющий сьют; нет стейл-узлов; impactKnown:false -> strict) и пропорциональность (ни одно замыкание не покрывает полный набор); генератор tests/build_impact_graph.py строит generated из tracked-дерева и проверяет свежесть (--check). RED-прогон аудита нашёл две настоящие дыры (hooks/completion-stop.sh без сьюта; verify_review_broker_server без разрешимого ребра) — закрыты корнем. С delivery-коммитом R6 приезжают отметки закрытия R5 (план: R5 verified) и durable-запись R5 в .itd/DECISIONS.md — тот же шаблон R1 -> ... -> R5. Идентификатор юнита — LPD002-R6 (префиксный выбор критериев)."
+    "scopeNote": "LPD-002 R6 (последний пункт approved-плана, WIP=1, riskTier medium = checkerMode targeted, checkerRequired true, независимость требует другой сессии, но НЕ другой модели/провайдера; контуры static + targeted; minimumIndependentReviewers 1): карта 'путь исходника -> сьюты' становится данными репозитория (.itd/IMPACT_GRAPH.json) и подаётся в существующий impact_closure через impactGraphPath; движок получает операцию impact-audit — машинную полноту (каждый сьют достижим; каждый skills/_shared/*.py и hooks/*.sh имеет владеющий сьют; нет стейл-узлов; impactKnown:false -> strict) и пропорциональность (ни одно замыкание не покрывает полный набор); генератор tests/build_impact_graph.py строит generated из tracked-дерева и проверяет свежесть (--check). RED-прогон аудита нашёл две настоящие дыры (hooks/completion-stop.sh без сьюта; verify_review_broker_server без разрешимого ребра) — закрыты корнем. С delivery-коммитом R6 приезжают отметки закрытия R5 (план: R5 verified) и durable-запись R5 в .itd/DECISIONS.md — тот же шаблон R1 -> ... -> R5. Идентификатор юнита — LPD002-R6 (префиксный выбор критериев).",
+    "closedAt": "2026-08-20T13:40:19Z"
   },
   "doneRule": "A criterion status of passed means only that its verification command passed. GPG-001 and GPG-002 remain verified under their durable completion evidence. GPG-003 additionally requires one exact high-risk adjudication, merged implementation and patch-release PRs, and clean WSL/native-Windows installed-host proof; it never upgrades LOCAL_REVIEWED to PROTECTED. The GPG-004 push-gate unit is closed only after its commit is followed by: the pin-clean-live-evidence follow-up, a fresh committed-head ADJUDICATED chain on the final HEAD, live registry repair through the guarded register flow (the incident fixture row replaced; load_registry validates), and guarded publication — the pre-unit receipts in adf40ca3f6d504c9 are RED-test fixtures only and never authorize a later push. The GPG-004 ladder remainder (PC1..PC5) lands as one combined candidate: producer edits only inside the approved PC-S3 batch with both signed benchmark legs re-run exactly once, and GOAL/STATE closure of GPG-004 requires the /goal verification pass after the remainder is accepted."
 }


### PR DESCRIPTION
The unit is verified (PR #218 merged d659941). The diff is exactly
{.itd-memory/STATE.json, .itd/ACCEPTANCE_CONTRACT.json}, both M, the
contract differing from its base version only in activeFollowup.status and
closedAt - the ledger-close candidate class delivered by LPD-002 R5.
Coverage is inherited from the delivered unit LPD002-R6.
