### PR TITLE
chore(ledger): close INSTALL-HARDENING after PR #247

### DIFF
--- a/.itd-memory/STATE.json
+++ b/.itd-memory/STATE.json
@@ -39,10 +39,11 @@
   "currentUnit": {
     "id": "INSTALL-HARDENING",
     "goal": "P2 из RETRO-2026-08-29 (сужен, P3 в BACKLOG): хуки не роняют байткод в установленный content-addressed runtime, и отказ inventory называет конкретный лишний путь плюс FIX во всех строгих ветках",
-    "status": "in_progress",
-    "startedAt": "2026-08-29T12:51:46Z",
+    "status": "verified",
+    "startedAt": "2026-08-29T14:48:27Z",
     "ledger": "STATE",
-    "riskTier": "medium"
+    "riskTier": "medium",
+    "completedAt": "2026-08-29T14:48:28Z"
   },
   "gateResults": {
     "acceptanceContract": "passed",
@@ -572,5 +573,5 @@
     "lastEventId": "",
     "lastEventAt": "2026-07-14T13:39:02Z"
   },
-  "nextAction": "План 2026-08-23 закрыт ЦЕЛИКОМ (N1-N9). Релиз v1.101.0 опубликован (PR #245, merge 24698e2, tag v1.101.0) и раскатан на четыре цели одним runtime 1.101.0-6ba753846c92ffba. /retro записан: docs/retros/RETRO-2026-08-29.md, восемь кандидатов P1-P8 ЖДУТ РЕШЕНИЯ ВЛАДЕЛЬЦА и в BACKLOG не заведены. Дальше только решением владельца: P1 (repo-first для pre-push - валит публикацию каждого релиза), P2 (__pycache__ блокирует reinstall), P3 (cp1251 settings.json на Windows), SURFACE_TREADMILL, BACKLOG P1 (plumbing-гейт), PE5-008/009 (внешний блокер)."
+  "nextAction": "INSTALL-HARDENING закрыт: PR #247 merged 0d1e9d8, юнит verified, WIP свободен. P2 из RETRO-2026-08-29 закрыт по корню (хуки не пишут байткод в установленный runtime; отказ inventory называет путь и FIX). P3 (кодировка settings.json) выведен в BACKLOG после срабатывания стоп-правила над содержанием, работа сохранена патчем .itd-memory/p3-settings-encoding-attempt.patch. Дальше по решению владельца: RSI (кандидат PILOT P0-1, enum схемы вердикта), P1 ретро (repo-first для pre-push), либо юнит на машинную сверку индекс/SCOPE_LOCK/контракт/леджер (класс сработал трижды за юнит: r6, r9, r10; текст кандидата — в скрэтчпаде p1-scope-consistency-root.md)."
 }

--- a/.itd/ACCEPTANCE_CONTRACT.json
+++ b/.itd/ACCEPTANCE_CONTRACT.json
@@ -2881,7 +2881,7 @@
   },
   "activeFollowup": {
     "unitId": "INSTALL-HARDENING",
-    "status": "open",
+    "status": "closed",
     "selectedClaim": "LOCAL_REVIEWED",
     "rootCause": ".itd/SCOPE_LOCK.md",
     "reviewPolicy": {
@@ -2896,7 +2896,9 @@
       "explorer": "isolated-machine-oracle",
       "adjudicator": "sealed-host-union"
     },
-    "openedAt": "2026-08-29T09:20:00Z"
+    "openedAt": "2026-08-29T09:20:00Z",
+    "closedAt": "2026-08-29T14:48:29Z",
+    "closedBy": "PR #247 merged 0d1e9d8; this candidate records the unit's STATE transition to verified. Timestamps: the unit's lifecycle was reopened and re-verified at 14:48:27/14:48:28Z while an earlier accounting detour (INSTALL-HARDENING-CLOSE, superseded) was undone, so this closure is stamped after it."
   },
   "doneRule": "A criterion status of passed means only that its verification command passed. GPG-001 and GPG-002 remain verified under their durable completion evidence. GPG-003 additionally requires one exact high-risk adjudication, merged implementation and patch-release PRs, and clean WSL/native-Windows installed-host proof; it never upgrades LOCAL_REVIEWED to PROTECTED. The GPG-004 push-gate unit is closed only after its commit is followed by: the pin-clean-live-evidence follow-up, a fresh committed-head ADJUDICATED chain on the final HEAD, live registry repair through the guarded register flow (the incident fixture row replaced; load_registry validates), and guarded publication — the pre-unit receipts in adf40ca3f6d504c9 are RED-test fixtures only and never authorize a later push. The GPG-004 ladder remainder (PC1..PC5) lands as one combined candidate: producer edits only inside the approved PC-S3 batch with both signed benchmark legs re-run exactly once, and GOAL/STATE closure of GPG-004 requires the /goal verification pass after the remainder is accepted."
 }


### PR DESCRIPTION
Accounting only; no behavior changes. Closes the `INSTALL-HARDENING` unit in the ledger after PR #247 (`0d1e9d8`).

**What the diff does**
- `STATE.json`: the unit moves `in_progress` -> `verified`.
- `ACCEPTANCE_CONTRACT.json`: `activeFollowup` is closed, so the matrix stops gating later candidates (LPD002-R5 ledger-close class).

**Evidence the unit was closed on** (all from PR #247, not from this candidate)
- Independent cross-vendor reviewer PASSED, `findings=[]`, `unverified=[]`, tree `b36fa9c3` (round r11).
- Machine receipt: six oracles at exit 0; adjudication revalidates.
- Full `tests/run-all.sh`: `DONE fails:none`.
- `verify_itd_runtime_install.py` 25 -> 41 checks, every new guarantee killed by a mutation.
- CI on #247: Gate 1 meta-review SUCCESS, windows-verify SUCCESS - the latter confirming the `os.mkfifo` guard on a real Windows runner.

**Route disclosure (owner decision).** This closing candidate has NO clean producer PASS. Three close rounds each returned one medium finding, all of the same class - the candidate's self-description not matching what the diff shows: (a) `currentUnit` pointed at a temporary accounting unit while the contract claimed the original was verified; (b) `closedBy` said "six-oracle receipt" while this candidate's receipt carries three; (c) the reopened lifecycle stamped 14:48:27/28Z against a `closedAt` of 14:05:00Z. Each was repaired, and each repair produced the next instance of the same class - the stop rule's signature for a defective FORM. The owner chose the owner-route rather than a fourth round: pushed with `--no-verify`, recorded honestly here.

None of the three findings touched code. The code shipped and was independently reviewed in #247.

**Follow-up already in BACKLOG**: no oracle checks the index against `SCOPE_LOCK`, the acceptance contract and the ledger, which is why a human reviewer had to catch this class by eye six times today (r6, r9, r10 in the unit; three close rounds here).
