### PR TITLE
chore(ledger): close REL-1.103.0 acceptance follow-up

### DIFF
--- a/.itd-memory/STATE.json
+++ b/.itd-memory/STATE.json
@@ -573,7 +573,7 @@
     "lastEventId": "",
     "lastEventAt": "2026-07-14T13:39:02Z"
   },
-  "nextAction": "REL-1.103.0 verified by the harness after PR #261 merged as 6776ae4, v1.103.0 release, dual-host rollout, and medium postdeploy adjudication .itd-memory/verification-loop/REL-1.103.0-postdeploy-adjudication-a1.json. Keep WIP=1: Phase A persists the harness-owned GOAL transition under the still-open active followup; Phase B then performs the classified STATE + acceptance-contract close. Do not activate a new unit before both ledger PRs are accepted.",
+  "nextAction": "REL-1.103.0 is ledger-closed by this classified candidate after Phase A PR #262 merged c904b73. Start Q6 only in a later session after this close is accepted; do not activate Q6 or any other unit in this ledger commit. The reviewer-provider freshness debt remains separately scoped.",
   "ledgerFiles": [
     ".itd-memory/events.jsonl"
   ]

--- a/.itd/ACCEPTANCE_CONTRACT.json
+++ b/.itd/ACCEPTANCE_CONTRACT.json
@@ -3334,7 +3334,7 @@
   },
   "activeFollowup": {
     "unitId": "REL-1.103.0",
-    "status": "open",
+    "status": "closed",
     "openedAt": "2026-09-04",
     "selectedClaim": "LOCAL_REVIEWED",
     "rootCause": ".itd/SCOPE_LOCK.md",
@@ -3348,7 +3348,8 @@
       "minimumIndependentReviewers": 1,
       "explorer": "isolated-machine-oracle",
       "adjudicator": "sealed-host-union"
-    }
+    },
+    "closedAt": "2026-09-05"
   },
   "doneRule": "A criterion status of passed means only that its verification command passed. GPG-001 and GPG-002 remain verified under their durable completion evidence. GPG-003 additionally requires one exact high-risk adjudication, merged implementation and patch-release PRs, and clean WSL/native-Windows installed-host proof; it never upgrades LOCAL_REVIEWED to PROTECTED. The GPG-004 push-gate unit is closed only after its commit is followed by: the pin-clean-live-evidence follow-up, a fresh committed-head ADJUDICATED chain on the final HEAD, live registry repair through the guarded register flow (the incident fixture row replaced; load_registry validates), and guarded publication — the pre-unit receipts in adf40ca3f6d504c9 are RED-test fixtures only and never authorize a later push. The GPG-004 ladder remainder (PC1..PC5) lands as one combined candidate: producer edits only inside the approved PC-S3 batch with both signed benchmark legs re-run exactly once, and GOAL/STATE closure of GPG-004 requires the /goal verification pass after the remainder is accepted.",
   "closedFollowups": [


### PR DESCRIPTION
Closes the REL-1.103.0 acceptance follow-up after release PR #261 and the verified-state persistence in #262. The diff modifies only STATE.nextAction and activeFollowup.status/closedAt; GOAL, events, source code, and all other contracts remain unchanged.

The inherited ledger-close route, eight exact-tree machine checks, one fresh Sol review, checker, adjudication, and mandatory-route revalidation all passed. This final close has a clean signed keyless PASS; it does not reuse either prior owner signature.

The next approved item is Q6 setup in a later session. No next unit is activated here; reviewer freshness remains the separately recorded debt.
