### PR TITLE
docs(retro): record the 2026-09-10 retro and accept its two cheap fixes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1801,3 +1801,41 @@ candidate must sit on a path Windows git trusts over UNC (registered in the Wind
 ownership") and outside this repository (otherwise `verify_host_neutral_memory` goes red); and
 the installed runtime accumulates `__pycache__` while the oracle replays through it, which the
 next `validate_runtime` reports as "installed runtime directory inventory drifted".
+
+## P1 2026-09-10 (accepted from retro 2026-09-10) - the installed runtime poisons its own inventory with bytecode
+
+**Source: retro 2026-09-10, proposal P4. Owner accepted into the backlog on 2026-09-10.**
+
+Signal, measured three times in one session on both hosts: the oracle replays through the
+installed runtime, Python writes `__pycache__` beside the modules it imports there, and the next
+`validate_runtime` reports `installed runtime directory inventory drifted: scripts/__pycache__`
+on WSL and `skills/_shared/__pycache__` plus `skills/review/scripts/__pycache__` on Windows.
+Every mint of the REL-1.104.0 installed-proof had to clear those directories by hand first; the
+runner `.itd-memory/verification-loop/REL-1.104.0-run-machine-close2.py` carries the workaround
+as a pre-flight step, which is exactly the sign it belongs in the product instead.
+
+Fix directions, either is enough: exclude the single name `__pycache__` from the runtime
+inventory in `scripts/itd_install_runtime.py`, or bind `sys.dont_write_bytecode` in the wrappers
+that `scripts/itd_install_cli.py` and `scripts/itd_install_git_hooks.py` render, so nothing is
+written into the runtime at all. RED-first either way: a mutation that puts a genuinely foreign
+file in the runtime must still be reported as drift. Effort S.
+
+## P1 2026-09-10 (accepted from retro 2026-09-10) - VCR counts an owner-route close as machine-verified
+
+**Source: retro 2026-09-10, proposal P2. Owner accepted into the backlog on 2026-09-10.**
+
+Signal, straight from the scan of 2026-09-10: `VCR глобально: 1.0 (12 verified из 12 жизненных
+циклов)`, while the event ledger holds eleven `verified` events with actor `harness` and one with
+actor `human-owner`. The owner-route close of REL-1.104.0 entered the numerator beside eleven
+machine-verified units, so the headline number cannot distinguish a machine proof from a human
+attestation - the one distinction this goal exists to measure.
+
+Fix: `skills/retro/scripts/itd_retro_scan.py` and `skills/_shared/itd_metrics.py` split the count
+into `verified(machine)` and `verified(owner-route)` by the event actor, and VCR is computed from
+the machine half alone; the owner-route half stays visible as its own line rather than being
+hidden or dropped. Effort S.
+
+Note on direction: this change lowers the reported number. That is deliberate - it is the
+anti-Goodhart case, a proposal that makes our own metric worse in order to make it true. The
+count of owner-route closes to date is four in the series (LPD-003-3, N7, N8, REL-1.104.0),
+which is the signal that made the blindness worth fixing rather than tolerating.

--- a/docs/retros/RETRO-2026-09-10.md
+++ b/docs/retros/RETRO-2026-09-10.md
@@ -1,0 +1,175 @@
+# RETRO 2026-09-10 — the day one missing receipt froze four gates
+
+Scope: the REL-1.104.0 ledger-close day. Facts come from `itd_retro_scan.py` and from the
+repository's own ledgers; proposals are ranked below and **nothing here is implemented** -
+`/retro` never edits the methodology. What goes into a release is the owner's call.
+
+## Step 1 — FACTS (scan output, as produced)
+
+Command:
+
+```
+sh skills/_shared/itd_py.sh skills/retro/scripts/itd_retro_scan.py .
+```
+
+```
+## Retro scan — факты из телеметрии (без интерпретации)
+
+Проектов с `.itd-memory`: **1** (workspace: .)
+**VCR глобально:** 1.0 (12 verified из 12 жизненных циклов; вне знаменателя: 0 закрытых явным решением (blocked 0), wip 0), регрессий: 0, проваленных верификаций: 3
+
+**Активные цели (/goal):**
+- : Довести практическую эффективность Idea to Deploy до машинно подтверждённых 5,0… — 43/48 verified, давление 5; blocked: PE5-008 (External pilot paused by human decision on 2026-07-16. Gmail invitations to Max…); PE5-009 (PE5-008 external outcome evidence is blocked; therefore the frozen all-axis eva…)
+
+**SKILL_BYPASS:** всего 1 за 1 сессий (**1.0/сессия** — метрика трения, должна падать от релиза к релизу), по инструментам: Bash×1; из них ceremonial (гейт уже был открыт — привычная аннотация, не реальный обход): 1
+
+**Cost-леджеры:** 1 сессий, 500 токенов, ~$0.01
+
+**Реестр инструкций (lifecycle):** секций 7, записей 7, проблем 0
+
+**Находки /review (леджер):** ревью 166, находок 149, классов 11, словарь v1
+Повторяющиеся классы — кандидаты в автопроверки (пункт 4: review-находка → hook/тест; `~` = фингерпринт без явной category):
+- `~unclassified` ×81 (critical×41, important×40) — напр. hooks/x.sh
+- `correctness` ×24 (important×19, critical×2, minor×3) — напр. hooks/x.sh; hooks/x.sh
+- `security` ×20 (critical×19, minor×1)
+- `documentation-accuracy` ×8 (minor×4, important×4) — напр. .itd-memory/events.jsonl; .itd/ACCEPTANCE_CONTRACT.json
+- `unsupported-claim` ×4 (critical×2, important×1, minor×1) — напр. .itd/ACCEPTANCE_CONTRACT.json; .itd-memory/contracts/REL-1.103.0.md
+- `test-coverage` ×3 (important×1, minor×2) — напр. tests/verify_scrubber_precision.py; tests/verify_free_reviewer_producer.py
+- `specification-compliance` ×2 (important×2) — напр. scripts/itd_stop_rule.py; .itd/SCOPE_LOCK.md
+- `reconciliation` ×2 (minor×1, important×1) — напр. BACKLOG.md; .itd/SCOPE_LOCK.md
+- `incomplete-fix` ×2 (minor×1, important×1) — напр. .itd-memory/events.jsonl; .itd/SCOPE_LOCK.md
+- `swallowed-diagnostic` ×2 (minor×2) — напр. .itd-memory/GOAL.json; (hook: completion-signals)
+
+| Проект | Юниты (verified/activated) | VCR | Регрессии | Незакрытые гейты |
+|---|---|---|---|---|
+|  | 12/12 | 1.0 | 0 | acceptanceContract, branchFinish, codeQualityReview, deploy… |
+```
+
+Step 1b, abstentions re-review (`itd_ledger_abstentions.py`): five entries stand -
+F-14 artifact publishing, F-15 background agents with mutation rights, F-17 transcript search
+to an external model, F-19 on-disk checkpoints outside git, F-20 graduated trust. **No external
+safe-use signal appeared for any of them today, so all five stay `abstain`.**
+
+Ledger cross-checks run for this retro:
+
+| fact | value | source |
+| --- | --- | --- |
+| verified events by actor | `harness` 11, `human-owner` 1 | `.itd-memory/events.jsonl` |
+| session files of Aug-Sep naming an owner route | 7 | `.itd-memory/session_2026-0[89]*.md` |
+| BACKLOG lines dated 2026-09-10 | 6 | `BACKLOG.md` |
+| `MEMORY.md` size against the 24.4 KB index limit | 45.7 KB | session-start warning |
+
+## Step 2 — PROPOSALS
+
+Ranked: live incident first, then repeating signals, then single ones. Every row carries its
+evidence. Nothing below is justified by "it would improve our own metric" - the second proposal
+deliberately makes the headline metric *worse*.
+
+### P1 (live incident) - one unobtainable receipt froze four independent gates
+
+**Signal.** On 2026-09-10 the same adjudicated receipt was demanded by four separate places, and
+one producer defect stopped all of them at once:
+
+| gate | refusal |
+| --- | --- |
+| unit transition | `UNVERIFIED REL-1.104.0 - full checker receipt is missing` |
+| review cache | `plain review verdict is not trusted without an adjudicated receipt` |
+| commit gate | `[REVIEW GATE] Коммит заблокирован ... нет успешного /review для exact current context` |
+| registry profile | `{"reason": "local-review profile evidence is invalid", "status": "UNVERIFIED"}` |
+
+Six producer attempts (`machine-close1` … `close6`), all red on one leg. The unit's own sealed
+command was green on the host at the same moment.
+
+**Proposal.** A typed *degraded route*: when the machine leg is green on the host and the
+producer is unavailable for a **named open backlog id**, the four gates accept one
+`owner-attested` record carrying who, why, the backlog id and the candidate tree hash, and that
+record is visible as its own class everywhere the ordinary receipt is. Without the owner
+signature or without an open defect id it refuses exactly as today.
+
+**Effort** M. **Risk** the exception becomes the habit - held down by P2 (the metric counts it
+separately) and by requiring an open backlog id, so the route dies when the defect is fixed.
+
+### P2 (metric blindness) - VCR counts an owner-route close as a machine-verified one
+
+**Signal.** The scan reports `VCR глобально: 1.0 (12 verified из 12)`, while the event ledger
+holds `harness` 11 and `human-owner` 1. Today's owner-route close entered the numerator beside
+eleven machine-verified units.
+
+**Proposal.** `itd_retro_scan.py` and `itd_metrics.py` split the line into
+`verified(machine)` and `verified(owner-route)`, and VCR is computed from the machine half only.
+
+**Effort** S. **Risk** the headline number drops. That is the point: this proposal lowers our own
+metric to make it honest, which is the opposite of Goodharting it.
+
+### P3 (repeating, 3 re-recordings in one day) - any package edit invalidates the native canaries
+
+**Signal.** Three canary pairs were burned on 2026-09-10: `a1/a4` bound to tree `563a5dd4` died
+when PR #277 moved `main`; `a2/a5` on `c8027f0f` died when the BACKLOG entry was staged; `a3/a6`
+on `dee8abbf` survived only because the package was frozen first. Each cycle costs roughly ten
+minutes and needs the Windows host in a UTF-8 console.
+
+**Proposal.** Split the binding. A canary proves the *installed runtime* - its hash, wrappers and
+adapter inventory - and only `INSTALLED.json` is bound to the candidate tree. Then editing the
+bookkeeping stops destroying the rollout proof.
+
+**Effort** M. **Risk** weaker exact-binding; needs a RED-first mutation proving the canary still
+catches a swapped runtime before the change lands.
+
+### P4 (repeating, 3 hits in one session, both hosts) - the installed runtime poisons its own inventory
+
+**Signal.** `installed runtime directory inventory drifted: scripts/__pycache__` on WSL, and on
+Windows `skills/_shared/__pycache__` plus `skills/review/scripts/__pycache__`. The oracle creates
+them while replaying through the runtime, and the next `validate_runtime` calls it drift. Today
+this blocked the proof three times and had to be cleared by hand before every mint.
+
+**Proposal.** Either `validate_runtime` excludes `__pycache__` by name from the inventory, or the
+installers bind `sys.dont_write_bytecode` in the wrappers so nothing is written there at all.
+
+**Effort** S. **Risk** masking a genuinely foreign file - bounded by excluding that one name and
+leaving every other extra entry as drift.
+
+### P5 (repeating, 54 % of the findings ledger) - most review findings carry no class
+
+**Signal.** Straight from the scan: `~unclassified ×81 (critical×41, important×40)` out of 149
+findings. The rule "a repeating class becomes an automated check" cannot fire on the majority of
+the evidence we have.
+
+**Proposal.** Mine the unclassified fingerprints and extend the verdict taxonomy for any group of
+three or more identical fingerprints; leave the rest unclassified rather than inventing classes.
+
+**Effort** M. **Risk** vocabulary bloat - bounded by the three-occurrence threshold.
+
+### P6 (single, two losses in two days) - the session scratchpad is not durable
+
+**Signal.** The ledger-close drafts written to the session scratchpad on 2026-09-09 were gone
+entirely the next day, and the probe logs written there on 2026-09-10 were lost mid-session
+across three Claude Code restarts.
+
+**Proposal.** State the rule where the work happens: anything a later session needs lives under
+`.itd-memory/`, and `/handoff` plus `/session-save` refuse to reference a scratchpad path.
+
+**Effort** S. **Risk** none identified.
+
+### P7 (single, harness says it every session) - the memory index is twice its limit
+
+**Signal.** Every session start prints `MEMORY.md is 45.7 KB (limit 24.4 KB) - index entries are
+too long. Only part of it was loaded.` The index is therefore partially invisible to the loader
+it exists for.
+
+**Proposal.** Run the consolidation through the approval-diff gate: propose merges and deletions
+read-only, show the before/after, and only write after an explicit go.
+
+**Effort** S. **Risk** losing a fact in the merge - which is exactly why the diff is approved
+before it is applied, never a blind rewrite.
+
+## Step 3 — decision stays with the owner
+
+Recommended into the next release scope: **P4** and **P2** (both S, both remove a measured
+recurring cost), then **P1** as its own unit because it changes gate semantics. **P3** is worth
+holding until `BROKER-ISOLATION` lands, since that unit may change how the isolated candidate
+behaves anyway. **P6** and **P7** are cheap and can ride along with any release. **P5** is real
+but is a mining exercise, not a release.
+
+Not proposed on purpose: nothing that would raise VCR, `meta_review` pass rate or any other
+in-house number as its own justification. The five ledger abstentions stay abstained - no
+external safe-use signal appeared.


### PR DESCRIPTION
Records the 2026-09-10 retro and accepts its two cheapest proposals into the backlog. Documentation and backlog only - no skill, hook, test or script changes.

## The retro ran on the scan, not on memory

`docs/retros/RETRO-2026-09-10.md` quotes the output of `itd_retro_scan.py .` verbatim, and every one of its seven proposals carries a number or a line taken from it. The five ledger abstentions (F-14, F-15, F-17, F-19, F-20) were re-reviewed and all five stay abstained - no external safe-use signal appeared for any of them.

## Its live incident

One unobtainable adjudicated receipt froze four independent gates at once:

| gate | refusal |
| --- | --- |
| unit transition | `UNVERIFIED REL-1.104.0 - full checker receipt is missing` |
| review cache | `plain review verdict is not trusted without an adjudicated receipt` |
| commit gate | `[REVIEW GATE] Коммит заблокирован ... нет успешного /review` |
| registry profile | `{"reason": "local-review profile evidence is invalid", "status": "UNVERIFIED"}` |

Six producer attempts, all red on one leg, while the unit's own sealed command was green on the host.

## What is accepted

Two entries land in `BACKLOG.md` as **P1 2026-09-10**, both effort S, both sourced from measurement:

**The installed runtime poisons its own inventory.** The oracle replays through it, Python writes `__pycache__` beside the modules it imports there, and the next `validate_runtime` calls that inventory drift. Three hits in one session on both hosts; currently worked around by hand inside the mint runner, which is the sign it belongs in the product.

**VCR counts an owner-route close as machine-verified.** The scan reports 12 of 12 while the event ledger holds eleven `harness` and one `human-owner`. The headline number cannot see the one distinction this goal exists to measure.

The second deliberately lowers our own metric. That is the point: four owner-route closes have accumulated in this series, and a number that hides them is worse than a smaller honest one.

## Not proposed on purpose

Nothing whose only justification would be raising VCR, the `meta_review` pass rate or any other in-house figure. The retro itself changed no methodology - `/retro` never does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
